### PR TITLE
lints, fixes, and more

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,8 +92,7 @@ jobs:
 
       - name: Install IDA ${{ matrix.os_ida.ida_version }}
         run: |
-          # TODO: add --set-default after v0.8.1-dev.3
-          uv run hcli ida install --download-id ${{ matrix.os_ida.slug }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir $RUNNER_TEMP/app/ida/
+          uv run hcli ida install --download-id ${{ matrix.os_ida.slug }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir $RUNNER_TEMP/app/ida/ --set-default
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,8 +97,11 @@ jobs:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
 
+      # TODO: this won't work on windows due to bash-isms
       - name: Run idat
-        run: ${{ runner.temp }}/app/ida/${{ matrix.os_ida.idat_path }} -a -A -c -t -L${{ runner.temp }}/ida.log
+        run: |
+          ${{ runner.temp }}/app/ida/${{ matrix.os_ida.idat_path }} -a -A -c -t -L"${{ runner.temp }}/ida.log" -S"${{ github.workspace }}/tests/scripts/hi.py" || echo "ida: $?"
+          cat "${{ runner.temp }}/ida.log"
 
       - name: Run tests
         run: uv run pytest -v tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,13 @@ jobs:
             os: macos-latest
             ida_version: "9.1"
             slug: "release/9.1/ida-essential/ida-essential_91_x64mac.app.zip"
-            idat_path: "/Content/MacOS/idat"
+            idat_path: "/Contents/MacOS/idat"
 
           - name: IDA 9.1 on macOS (ARM)
             os: macos-latest
             ida_version: "9.1"
             slug: "release/9.1/ida-essential/ida-essential_91_armmac.app.zip"
-            idat_path: "/Content/MacOS/idat"
+            idat_path: "/Contents/MacOS/idat"
 
           - name: IDA 9.0 on Linux
             os: ubuntu-latest
@@ -65,13 +65,13 @@ jobs:
             os: macos-latest
             ida_version: "9.0"
             slug: "release/9.0/ida-essential/ida-essential_90_x64mac.app.zip"
-            idat_path: "/Content/MacOS/idat"
+            idat_path: "/Contents/MacOS/idat"
 
           - name: IDA 9.0 on macOS (ARM)
             os: macos-latest
             ida_version: "9.0"
             slug: "release/9.0/ida-essential/ida-essential_90_armmac.app.zip"
-            idat_path: "/Content/MacOS/idat"
+            idat_path: "/Contents/MacOS/idat"
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ build-backend = "setuptools.build_meta"
 [dependency-groups]
 dev = [
     "types-pexpect>=4.9.0.20250809",
+    "types-requests>=2.32.4.20250809",
 ]
 
 [project.optional-dependencies]

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -446,8 +446,6 @@ class IDAConfigJson(BaseModel):
 
 def get_ida_config_path() -> Path:
     idausr = get_ida_user_dir()
-    if not idausr:
-        raise ValueError("$IDAUSR doesn't exist")
 
     return Path(idausr) / "ida-config.json"
 

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -554,7 +554,7 @@ elif system == "Darwin":
     else:
         raise ValueError(f"Unsupported macOS version: {version}")
 else:
-    raise ValueError(f"Unsupported OS: {os_}")
+    raise ValueError(f"Unsupported OS: {system}")
 print("__hcli__:" + json.dumps(plat))
 sys.exit()
 """

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -85,6 +85,9 @@ def is_installable(download: DownloadResource) -> bool:
 
 def get_ida_user_dir() -> Optional[str]:
     """Get the IDA Pro user directory."""
+    if "HCLI_IDAUSR" in os.environ:
+        return os.environ["HCLI_IDAUSR"]
+
     if get_os() == "windows":
         appdata = os.environ.get("APPDATA")
         if appdata:

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -441,7 +441,7 @@ class IDAConfigJson(BaseModel):
     """IDA configuration $IDAUSR/ida-config.json"""
 
     # like: "/Applications/IDA Professional 9.1.app/Contents/MacOS"
-    installation_directory: Path = Field(validation_alias=AliasPath("Paths", "ida-install-dir"))
+    installation_directory: Path = Field(validation_alias=AliasPath("Paths", "ida-install-dir"), min_length=1)
 
 
 def get_ida_config_path() -> Path:

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -53,7 +53,7 @@ class IdaVersion:
             suffix = suffix_match if suffix_match else None
             return cls(major, minor, suffix)
 
-        raise ValueError("Unrecognized format")
+        raise ValueError(f"Unrecognized format: {basename}")
 
     def __str__(self):
         base = f"{self.major}.{self.minor}"

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -1,0 +1,120 @@
+# see also hcli.lib.util.python
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from hcli.lib.ida import run_py_in_current_idapython
+
+logger = logging.getLogger(__name__)
+
+
+FIND_PYTHON_PY = """
+# output like:
+#
+#     __hcli__:"/Users/user/code/hex-rays/ida-hcli/.venv/bin/python3"
+import shutil
+import sys
+import json
+print("__hcli__:" + json.dumps(shutil.which("python")))
+sys.exit()
+"""
+
+
+def find_current_python_executable() -> Path:
+    """find the python executable associated with the current IDA installation"""
+    if "HCLI_CURRENT_IDA_PYTHON_EXE" in os.environ:
+        return Path(os.environ["HCLI_CURRENT_IDA_PYTHON_EXE"])
+
+    return Path(run_py_in_current_idapython(FIND_PYTHON_PY))
+
+
+def does_current_ida_have_pip(python_exe: Path) -> bool:
+    """Check if pip is available in the given Python executable."""
+    try:
+        process = subprocess.run(
+            [str(python_exe), "-m", "pip", "help"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=1.0
+        )
+        return process.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+class CantInstallPackagesError(ValueError): ...
+
+
+def verify_pip_can_install_packages(python_exe: Path, packages: list[str]):
+    """Check if the given Python packages (e.g., "foo>=v1.0,<3") can be installed.
+
+    This allows pip to determine if there are any version conflicts
+    """
+    process = subprocess.run(
+        [str(python_exe), "-m", "pip", "install", "--dry-run"] + packages,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, stderr = process.stdout, process.stderr
+    if process.returncode != 0:
+        # error output might look like:
+        #
+        #     ❯ pip install --dry-run flare-capa==v1.0.0 flare-capa==v1.0.1
+        #    Collecting flare-capa==v1.0.0
+        #      Using cached flare-capa-1.0.0.tar.gz (62 kB)
+        #      Installing build dependencies ... done
+        #      Getting requirements to build wheel ... done
+        #      Preparing metadata (pyproject.toml) ... done
+        #    ERROR: Cannot install flare-capa==v1.0.0 and flare-capa==v1.0.1 because these package versions have conflicting dependencies.
+        #
+        #    The conflict is caused by:
+        #        The user requested flare-capa==v1.0.0
+        #        The user requested flare-capa==v1.0.1
+        #
+        #    To fix this you could try to:
+        #    1. loosen the range of package versions you've specified
+        #    2. remove package versions to allow pip to attempt to solve the dependency conflict
+        #
+        #    ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
+        logger.debug("can't install packages")
+        logger.debug(stdout.decode())
+        logger.debug(stderr.decode())
+        raise CantInstallPackagesError(stdout.decode())
+
+
+def pip_install_packages(python_exe: Path, packages: list[str]):
+    """Install the given Python packages (e.g., "foo>=v1.0,<3")."""
+    process = subprocess.run(
+        [str(python_exe), "-m", "pip", "install"] + packages, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    stdout, stderr = process.stdout, process.stderr
+    if process.returncode != 0:
+        # error output might look like:
+        #
+        #     ❯ pip install --dry-run flare-capa==v1.0.0 flare-capa==v1.0.1
+        #    Collecting flare-capa==v1.0.0
+        #      Using cached flare-capa-1.0.0.tar.gz (62 kB)
+        #      Installing build dependencies ... done
+        #      Getting requirements to build wheel ... done
+        #      Preparing metadata (pyproject.toml) ... done
+        #    ERROR: Cannot install flare-capa==v1.0.0 and flare-capa==v1.0.1 because these package versions have conflicting dependencies.
+        #
+        #    The conflict is caused by:
+        #        The user requested flare-capa==v1.0.0
+        #        The user requested flare-capa==v1.0.1
+        #
+        #    To fix this you could try to:
+        #    1. loosen the range of package versions you've specified
+        #    2. remove package versions to allow pip to attempt to solve the dependency conflict
+        #
+        #    ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
+        logger.debug("can't install packages")
+        logger.debug(stdout.decode())
+        logger.debug(stderr.decode())
+        raise CantInstallPackagesError(stdout.decode())
+
+
+def pip_freeze(python_exe: Path):
+    process = subprocess.run([str(python_exe), "-m", "pip", "freeze"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, _ = process.stdout, process.stderr
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(process.returncode, [str(python_exe), "-m", "pip", "freeze"])
+    return stdout.decode()

--- a/src/hcli/lib/util/python.py
+++ b/src/hcli/lib/util/python.py
@@ -1,6 +1,7 @@
 """Python detection and utility functions."""
 
 import asyncio
+import asyncio.subprocess
 import tempfile
 from pathlib import Path
 from typing import Optional

--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -1,0 +1,44 @@
+import platform
+from pathlib import Path
+
+import pytest
+
+from hcli.lib.ida import (
+    find_current_ida_install_directory,
+    find_current_idat_executable,
+    get_ida_config,
+    get_ida_config_path,
+)
+
+
+# may fail if dev environment is not configured with IDA
+def test_get_ida_config_path():
+    result = get_ida_config_path()
+    assert isinstance(result, Path)
+    assert result.name == "ida-config.json"
+
+
+# may fail if dev environment is not configured with IDA
+def test_get_ida_config():
+    result = get_ida_config()
+    assert result is not None
+    assert hasattr(result, "installation_directory")
+
+
+# may fail if dev environment is not configured with IDA
+def test_find_current_ida_install_directory():
+    result = find_current_ida_install_directory()
+    assert isinstance(result, Path)
+    assert result.exists()
+    assert result.is_dir()
+
+
+# may fail if dev environment is not configured with IDA
+def test_find_current_idat_executable():
+    result = find_current_idat_executable()
+    assert isinstance(result, Path)
+    assert result.exists()
+    assert result.is_file()
+    assert "idat" in result.name.lower()
+
+

--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -5,6 +5,8 @@ import pytest
 
 from hcli.lib.ida import (
     find_current_ida_install_directory,
+    find_current_ida_platform,
+    find_current_ida_version,
     find_current_idat_executable,
     get_ida_config,
     get_ida_config_path,
@@ -42,3 +44,34 @@ def test_find_current_idat_executable():
     assert "idat" in result.name.lower()
 
 
+# Platform-specific tests for find_current_ida_platform()
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
+def test_find_current_ida_platform_windows():
+    """Test find_current_ida_platform() on Windows."""
+    result = find_current_ida_platform()
+    assert isinstance(result, str)
+    assert result == "windows-x86_64"
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Linux-specific test")
+def test_find_current_ida_platform_linux():
+    """Test find_current_ida_platform() on Linux."""
+    result = find_current_ida_platform()
+    assert isinstance(result, str)
+    assert result == "linux-x86_64"
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-specific test")
+def test_find_current_ida_platform_macos():
+    """Test find_current_ida_platform() on macOS."""
+    result = find_current_ida_platform()
+    assert isinstance(result, str)
+    assert result in ["macos-x86_64", "macos-aarch64"]
+
+
+# may fail if dev environment is not configured with IDA
+def test_find_current_ida_version():
+    """Test find_current_ida_version() returns expected version."""
+    result = find_current_ida_version()
+    assert isinstance(result, str)
+    assert result in ["9.1", "9.2"]

--- a/tests/scripts/hi.py
+++ b/tests/scripts/hi.py
@@ -1,0 +1,5 @@
+import sys
+
+print("hi")
+
+sys.exit(0)

--- a/uv.lock
+++ b/uv.lock
@@ -831,6 +831,7 @@ test = [
 [package.dev-dependencies]
 dev = [
     { name = "types-pexpect" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -870,7 +871,10 @@ requires-dist = [
 provides-extras = ["dev", "test", "docs"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "types-pexpect", specifier = ">=4.9.0.20250809" }]
+dev = [
+    { name = "types-pexpect", specifier = ">=4.9.0.20250809" },
+    { name = "types-requests", specifier = ">=2.32.4.20250809" },
+]
 
 [[package]]
 name = "idapro"
@@ -2405,6 +2409,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7f/a2/29564e69dee62f0f887ba7bfffa82fa4975504952e6199b218d3b403becd/types_pexpect-4.9.0.20250809.tar.gz", hash = "sha256:17a53c785b847c90d0be9149b00b0254e6e92c21cd856e853dac810ddb20101f", size = 13240, upload-time = "2025-08-09T03:15:04.554Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/1b/4d557287e6672feb749cf0d8ef5eb19189aff043e73e509e3775febc1cf1/types_pexpect-4.9.0.20250809-py3-none-any.whl", hash = "sha256:d19d206b8a7c282dac9376f26f072e036d22e9cf3e7d8eba3f477500b1f39101", size = 17039, upload-time = "2025-08-09T03:15:03.528Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20250809"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/b0/9355adb86ec84d057fea765e4c49cce592aaf3d5117ce5609a95a7fc3dac/types_requests-2.32.4.20250809.tar.gz", hash = "sha256:d8060de1c8ee599311f56ff58010fb4902f462a1470802cf9f6ed27bc46c4df3", size = 23027, upload-time = "2025-08-09T03:17:10.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/6f/ec0012be842b1d888d46884ac5558fd62aeae1f0ec4f7a581433d890d4b5/types_requests-2.32.4.20250809-py3-none-any.whl", hash = "sha256:f73d1832fb519ece02c85b1f09d5f0dd3108938e7d47e7f94bbfa18a6782b163", size = 20644, upload-time = "2025-08-09T03:17:09.716Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
adds:
  - parsing of `ida-config.json` with Pedantic validation
  - fetching current IDA installation directory (via `ida-config.json`)
  - but prefer IDA_USR when present
  - routines to run IDAPython scripts via idat
    - discover current version, current platform
    - discover current python.exe path
    - invoke pip in current Python environment
  - `--set-default` to `hcli ida install` to update `ida-config.json`
  - testing of idat during CI

changes:
  - use `pathlib.Path` instead of strings
  - better discovery of existing IDA installations
  - raise exceptions instead of returning `None`

fixes:
  - linter warnings #10


closes #10