### PR TITLE
feat: add tag shortcuts for download and install commands

### DIFF
--- a/src/hcli/lib/util/io.py
+++ b/src/hcli/lib/util/io.py
@@ -198,15 +198,41 @@ def get_os() -> str:
 
 def get_arch() -> str:
     """Get the system architecture."""
-    system = platform.system()
-    if system == "Windows":
+    machine = platform.machine().lower()
+    # Normalize common architecture names
+    if machine in ("x86_64", "amd64"):
         return "x86_64"
-    elif system == "Linux":
-        return platform.machine()
-    elif system == "Darwin":
+    elif machine in ("arm64", "aarch64", "arm"):
         return "arm64"
     else:
         return platform.machine()
+
+
+def get_tag_os() -> str:
+    """Get the current OS in the format used by asset tags.
+
+    Returns OS identifier in format: {arch}{os}
+    Examples: x64win, x64linux, x64mac, armmac, armwin, armlinux
+    """
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    # Determine architecture
+    is_arm = machine in ("arm64", "aarch64", "arm")
+    arch_prefix = "arm" if is_arm else "x64"
+
+    # Determine OS
+    if system == "darwin":
+        os_suffix = "mac"
+    elif system == "linux":
+        os_suffix = "linux"
+    elif system == "windows":
+        os_suffix = "win"
+    else:
+        # Default to linux if unknown
+        os_suffix = "linux"
+
+    return f"{arch_prefix}{os_suffix}"
 
 
 def get_file_size(path: str) -> int:


### PR DESCRIPTION
## Summary

Implements tag shortcuts for version specification in download and install commands, allowing users to use simple tags like `ida-pro:latest` or `ida:9.2` instead of full asset paths.

Closes #111

## Changes

### API Integration
- Added `Tag` model with all fields from `/api/assets/tags` endpoint
- Added `get_tags()` method to `AssetAPI` class to fetch available tags

### Platform Detection
- Enhanced `get_arch()` for better architecture detection
- Added `get_tag_os()` function to return OS in tag format (e.g., `armmac`, `x64win`, `x64linux`)

### Download Command
- Implemented tag resolution with automatic OS detection
- Support for two tag formats:
  - `category:version` - OS is auto-detected based on current platform
  - `category:version:os` - explicit OS specification
- Added `--list-tags` option to display all available tags in a formatted table
- Shows helpful error messages with available tags when tag not found

### Install Command
- Updated `ida install` command to support tags via `--download-id` option
- Automatically finds downloaded installer after tag resolution
- Updated help text to document tag support

## Examples

```bash
# Download with auto-detected OS
hcli download ida-pro:latest
hcli download ida-essential:9.2

# Download with explicit OS
hcli download ida-pro:latest:x64linux

# List all available tags
hcli download --list-tags

# Install with auto-detected OS
hcli ida install --download-id ida-pro:latest

# Install with explicit OS
hcli ida install --download-id ida-essential:9.2:armmac
```

## Testing

- All code passes `mypy` type checking
- Tested tag resolution with both auto-detected and explicit OS
- Tested `--list-tags` output formatting
- Tested integration with `ida install` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)