### PR TITLE
fix: plugin search and install broken for all plugins

### DIFF
--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -90,8 +90,7 @@ def install_plugin(ctx, plugin: str, config: tuple[str, ...]) -> None:
                 parsed_value = parse_setting_value(descr, value_str)
                 descr.validate_value(parsed_value)
 
-        with rich.status.Status("installing plugin", console=stderr_console):
-            install_plugin_archive(buf, plugin_name)
+        install_plugin_archive(buf, plugin_name)
 
         try:
             if metadata.plugin.settings:

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -110,7 +110,7 @@ def handle_plugin_name_query(plugins: list[Plugin], query: str, current_version:
     plugin = get_plugin_by_name(plugins, query)
     latest_metadata = get_latest_plugin_metadata(plugin)
 
-    metadata_dict = latest_metadata.plugin.model_dump()
+    metadata_dict = latest_metadata.plugin.model_dump(by_alias=True)
     del metadata_dict["platforms"]
     metadata_dict["idaVersions"] = render_ida_versions(metadata_dict["idaVersions"])
 
@@ -187,7 +187,7 @@ def handle_plugin_spec_query(plugins: list[Plugin], query: str, current_version:
     locations = plugin.versions[version]
     metadata = locations[0].metadata
 
-    metadata_dict = metadata.plugin.model_dump()
+    metadata_dict = metadata.plugin.model_dump(by_alias=True)
     del metadata_dict["platforms"]
     metadata_dict["idaVersions"] = render_ida_versions(metadata_dict["idaVersions"])
 


### PR DESCRIPTION
## Summary
- Fix plugin search failing with `Error: 'idaVersions'` for all plugins
- Fix plugin install failing with `Error: Only one live display may be active at once`

## Root Cause

### Search Bug
Commit c857eb4 introduced code that accesses `metadata_dict["idaVersions"]`, but `model_dump()` returns Python attribute names (`ida_versions`), not JSON aliases.

### Install Bug  
Nested Rich Status displays: the command's `Status("installing plugin")` wrapper conflicts with `Status("finding IDA installation")` inside `install_plugin_archive()`.

## Fix
1. **search.py**: Use `model_dump(by_alias=True)` to get JSON-style keys
2. **install.py**: Remove redundant outer Status wrapper

## Test plan
- [x] `hcli plugin search qscripts` - works
- [x] `hcli plugin search capa` - works
- [x] `hcli plugin install qscripts` - works
- [x] `hcli plugin install bindiff` - works
- [x] Full cycle: search → install → search → uninstall