### PR TITLE
feat: add GitHub URL support for plugin install

### DIFF
--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -63,7 +63,9 @@ def install_plugin(ctx, plugin: str, config: tuple[str, ...]) -> None:
             try:
                 owner, repo, tag = parse_github_url(plugin_spec)
                 tag_info = f"@{tag}" if tag else " (latest release)"
-                with rich.status.Status(f"fetching plugin from GitHub: {owner}/{repo}{tag_info}", console=stderr_console):
+                with rich.status.Status(
+                    f"fetching plugin from GitHub: {owner}/{repo}{tag_info}", console=stderr_console
+                ):
                     buf = fetch_github_release_zip_asset(owner, repo, tag)
             except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
                 console.print("[red]Cannot connect to GitHub - network unavailable.[/red]")

--- a/src/hcli/lib/ida/plugin/repo/github.py
+++ b/src/hcli/lib/ida/plugin/repo/github.py
@@ -49,7 +49,9 @@ def parse_github_url(url: str) -> tuple[str, str, str | None]:
         # Handle git@ prefix separately
         if url.startswith("git@"):
             # git@github.com:owner/repo.git@tag
-            parts = url.split("@", 2)  # ['git', 'github.com:owner/repo.git', 'tag'] or ['git', 'github.com:owner/repo.git']
+            parts = url.split(
+                "@", 2
+            )  # ['git', 'github.com:owner/repo.git', 'tag'] or ['git', 'github.com:owner/repo.git']
             if len(parts) == 3:
                 tag = parts[2]
                 url = f"git@{parts[1]}"
@@ -116,7 +118,9 @@ def fetch_github_release_zip_asset(owner: str, repo: str, tag: str | None = None
 
     if len(zip_assets) > 1:
         asset_names = [a["name"] for a in zip_assets]
-        raise ValueError(f"Multiple .zip assets found in release: {', '.join(asset_names)}. Cannot determine which to install.")
+        raise ValueError(
+            f"Multiple .zip assets found in release: {', '.join(asset_names)}. Cannot determine which to install."
+        )
 
     asset = zip_assets[0]
     asset_name = asset["name"]
@@ -124,7 +128,9 @@ def fetch_github_release_zip_asset(owner: str, repo: str, tag: str | None = None
     download_url = asset["browser_download_url"]
 
     if asset_size > MAX_DOWNLOAD_SIZE:
-        raise ValueError(f"Asset {asset_name} ({asset_size} bytes) exceeds maximum size limit ({MAX_DOWNLOAD_SIZE} bytes)")
+        raise ValueError(
+            f"Asset {asset_name} ({asset_size} bytes) exceeds maximum size limit ({MAX_DOWNLOAD_SIZE} bytes)"
+        )
 
     logger.info(f"downloading asset: {asset_name} ({asset_size} bytes) from {download_url}")
     response = requests.get(download_url, timeout=60.0)


### PR DESCRIPTION
## Summary

- Add support for installing plugins directly from GitHub repositories using release assets
- Supports multiple URL formats: HTTPS, HTTPS with `.git`, SSH, and all with optional `@tag` suffix
- When no tag is specified, fetches the latest release
- Downloads the `.zip` asset from the release (errors if no `.zip` or multiple `.zip` assets)

## Usage

```bash
# Install from latest release
hcli plugin install https://github.com/HexRaysSA/ida-chat-plugin

# Install specific version
hcli plugin install https://github.com/HexRaysSA/ida-chat-plugin@0.1.0

# SSH format also works
hcli plugin install git@github.com:HexRaysSA/ida-chat-plugin.git
```

## Test plan

- [x] Test URL parsing for all supported formats
- [x] Test fetching release assets from GitHub API
- [x] Test full install flow with `https://github.com/HexRaysSA/ida-chat-plugin`
- [x] Test install with specific tag `@0.1.0`
- [x] Test install with SSH URL format

🤖 Generated with [Claude Code](https://claude.com/claude-code)