### PR TITLE
Fix pagination bug in GitHub code search

### DIFF
--- a/src/hcli/lib/ida/plugin/repo/github.py
+++ b/src/hcli/lib/ida/plugin/repo/github.py
@@ -740,7 +740,7 @@ def find_github_repos_with_plugins(token: str) -> list[str]:
                         )
                     )
 
-                if len(items) < 100:
+                if len(items) < 25:
                     break
 
                 page += 1


### PR DESCRIPTION
The search only ever fetches the first 25 repositories, even there are hundreds exist. This causes the `plugin‑repository` to fail to index new plugins.