### PR TITLE
github: fix empty repo detection during sync

### DIFF
--- a/src/hcli/lib/ida/plugin/repo/github.py
+++ b/src/hcli/lib/ida/plugin/repo/github.py
@@ -474,7 +474,7 @@ class GitHubGraphQLClient:
         for i, (owner, repo) in enumerate(repos):
             repo_data = data.get(f"repo{i}")
 
-            if not repo_data:
+            if not repo_data or not repo_data.get("defaultBranchRef"):
                 logger.warning(f"Repository {owner}/{repo} not found")
                 continue
 


### PR DESCRIPTION
Sync in [plugin-repository](https://github.com/HexRaysSA/plugin-repository) was broken by empty repo `0Eniltilps/foo` (HexRaysSA/plugin-repository#19).

Empty repos have `repo_data` but `defaultBranchRef` is null, causing sync to fail. 
This PR added check for `defaultBranchRef` existence before processing.
