### PR TITLE
Fix crash when sorting partial semantic versions

### DIFF
--- a/src/hcli/lib/ida/plugin/__init__.py
+++ b/src/hcli/lib/ida/plugin/__init__.py
@@ -143,13 +143,13 @@ def parse_plugin_version(version: str) -> semantic_version.Version:
 
     # Parse as partial first
     parsed = semantic_version.Version(version, partial=True)
-    
+
     # Normalize to full version to ensure sortability
     # None components become 0
     major = parsed.major if parsed.major is not None else 0
     minor = parsed.minor if parsed.minor is not None else 0
     patch = parsed.patch if parsed.patch is not None else 0
-    
+
     return semantic_version.Version(f"{major}.{minor}.{patch}")
 
 


### PR DESCRIPTION
The sync crashes when plugins use partial versions (`1` or `1.0`) instead of the required `x.y.z` format:

TypeError: '<' not supported between instances of 'NoneType' and 'int'

This happens because `semantic_version.Version(partial=True)` produces non-comparable values when mixed with complete versions.

**Fix:** Normalize all versions to full `x.y.z` by replacing missing components with `0`:
- `1` → `1.0.0`  
- `1.0` → `1.0.0`
