### PR TITLE
ci: disable major release option in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ on:
           - dev
           - release-patch
           - release-minor
-          - release-major
+          # Disabled: Major releases require careful coordination and are difficult to unpublish
+          # - release-major
         default: 'dev'
 
 permissions:


### PR DESCRIPTION
Comment out the release-major option from the release workflow dropdown
to prevent accidental major version bumps that would be difficult to
unpublish across PyPI, GitHub releases, and related artifacts.