### PR TITLE
remove idat invocations for version and platform detection

### DIFF
--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -1,16 +1,21 @@
 import os
 import platform
+import struct
+import tempfile
 from pathlib import Path
 
 import pytest
 
 from hcli.lib.ida import (
+    detect_binary_arch,
     find_current_ida_install_directory,
     find_current_ida_platform,
     find_current_ida_version,
     find_current_idat_executable,
     get_ida_config,
     get_ida_config_path,
+    parse_version_from_dir_name,
+    parse_version_from_ida_pro_py,
 )
 
 
@@ -55,7 +60,6 @@ def test_find_current_idat_executable():
 
 # Platform-specific tests for find_current_ida_platform()
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
-@pytest.mark.skipif(not has_idat(), reason="Skip when idat not present (Free/Home)")
 def test_find_current_ida_platform_windows():
     """Test find_current_ida_platform() on Windows."""
     result = find_current_ida_platform()
@@ -64,7 +68,6 @@ def test_find_current_ida_platform_windows():
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Linux-specific test")
-@pytest.mark.skipif(not has_idat(), reason="Skip when idat not present (Free/Home)")
 def test_find_current_ida_platform_linux():
     """Test find_current_ida_platform() on Linux."""
     result = find_current_ida_platform()
@@ -73,7 +76,6 @@ def test_find_current_ida_platform_linux():
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-specific test")
-@pytest.mark.skipif(not has_idat(), reason="Skip when idat not present (Free/Home)")
 def test_find_current_ida_platform_macos():
     """Test find_current_ida_platform() on macOS."""
     result = find_current_ida_platform()
@@ -81,9 +83,94 @@ def test_find_current_ida_platform_macos():
     assert result in ["macos-x86_64", "macos-aarch64"]
 
 
-@pytest.mark.skipif(not has_idat(), reason="Skip when idat not present (Free/Home)")
 def test_find_current_ida_version():
     """Test find_current_ida_version() returns expected version."""
     result = find_current_ida_version()
     assert isinstance(result, str)
     assert result in ["9.0", "9.1", "9.2"]
+
+
+def test_parse_version_from_ida_pro_py():
+    """Test parsing IDA version from python/ida_pro.py."""
+    ida_dir = find_current_ida_install_directory()
+    result = parse_version_from_ida_pro_py(ida_dir)
+    assert result is not None
+    assert result in ["9.0", "9.1", "9.2"]
+
+
+def test_parse_version_from_ida_pro_py_missing():
+    """Test that missing ida_pro.py returns None."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = parse_version_from_ida_pro_py(Path(tmpdir))
+        assert result is None
+
+
+def test_parse_version_from_dir_name():
+    """Test parsing IDA version from directory names."""
+    assert parse_version_from_dir_name(Path("/opt/IDA Professional 9.2")) == "9.2"
+    assert parse_version_from_dir_name(Path("/opt/IDA-Professional-9.2")) == "9.2"
+    assert parse_version_from_dir_name(Path("/opt/IDA Professional 9.1sp1")) == "9.1"
+    assert parse_version_from_dir_name(Path("/Applications/IDA Professional 9.2.app")) == "9.2"
+    assert parse_version_from_dir_name(Path("/opt/my-ida")) is None
+
+
+def test_detect_binary_arch_elf_x86_64():
+    """Test detecting x86_64 ELF binary."""
+    # Minimal ELF header: magic + class(64) + data(LE) + ... + e_machine=0x3E
+    header = bytearray(20)
+    header[0:4] = b"\x7fELF"
+    header[4] = 2  # 64-bit
+    header[5] = 1  # little-endian
+    struct.pack_into("<H", header, 18, 0x3E)  # EM_X86_64
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(header)
+        f.flush()
+        assert detect_binary_arch(Path(f.name)) == "x86_64"
+    os.unlink(f.name)
+
+
+def test_detect_binary_arch_elf_aarch64():
+    """Test detecting aarch64 ELF binary."""
+    header = bytearray(20)
+    header[0:4] = b"\x7fELF"
+    header[4] = 2
+    header[5] = 1
+    struct.pack_into("<H", header, 18, 0xB7)  # EM_AARCH64
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(header)
+        f.flush()
+        assert detect_binary_arch(Path(f.name)) == "aarch64"
+    os.unlink(f.name)
+
+
+def test_detect_binary_arch_macho_x86_64():
+    """Test detecting x86_64 Mach-O binary."""
+    header = bytearray(20)
+    struct.pack_into("<I", header, 0, 0xFEEDFACF)  # MH_MAGIC_64
+    struct.pack_into("<I", header, 4, 0x01000007)  # CPU_TYPE_X86_64
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(header)
+        f.flush()
+        assert detect_binary_arch(Path(f.name)) == "x86_64"
+    os.unlink(f.name)
+
+
+def test_detect_binary_arch_macho_aarch64():
+    """Test detecting aarch64 Mach-O binary."""
+    header = bytearray(20)
+    struct.pack_into("<I", header, 0, 0xFEEDFACF)  # MH_MAGIC_64
+    struct.pack_into("<I", header, 4, 0x0100000C)  # CPU_TYPE_ARM64
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(header)
+        f.flush()
+        assert detect_binary_arch(Path(f.name)) == "aarch64"
+    os.unlink(f.name)
+
+
+def test_detect_binary_arch_unknown():
+    """Test that unrecognized binary returns None."""
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(b"not a binary format at all!")
+        f.flush()
+        assert detect_binary_arch(Path(f.name)) is None
+    os.unlink(f.name)


### PR DESCRIPTION
Replace the three idat-based detection mechanisms with static alternatives:

- Version: parse python/ida_pro.py for "IDA SDK v{major}.{minor}" docstring,
  falling back to regex on the installation directory name. Confirmed working
  across IDA 9.0, 9.1, and 9.2. The ida_pro.py file is present in all IDA
  editions that include IDAPython (Pro, Essential, Home, Classroom).

- Platform: on macOS, read the idat binary's ELF/Mach-O header to determine
  x86_64 vs aarch64. This correctly identifies the binary's architecture even
  under Rosetta, without spawning any subprocess. Windows and Linux remain
  hardcoded as before.

- Python exe: deduplicate discovery in the plugin install pipeline.
  validate_can_install_plugin now returns the discovered python_exe so
  _install_plugin_archive can reuse it instead of invoking idat a second time.

Also removes the version and platform disk caches (no longer needed since
detection is now instantaneous) and the FIND_VERSION_PY / FIND_PLATFORM_PY
IDAPython scripts.

idat is still used for Python interpreter discovery (via FIND_PYTHON_PY in
python.py), but only when a plugin has pip dependencies that need installing.

https://claude.ai/code/session_01HVoZkptmgKmAHSZhk6KmKm