### PR TITLE
feat: add ida tool install/search/list/remove commands

### DIFF
--- a/src/hcli/commands/ida/__init__.py
+++ b/src/hcli/commands/ida/__init__.py
@@ -18,6 +18,7 @@ from .remove import remove
 from .set_default import set_default_ida
 from .source import source
 from .switch import switch
+from .tool import tool
 
 ida.add_command(accept_eula_command)
 ida.add_command(add)
@@ -29,3 +30,4 @@ ida.add_command(remove)
 ida.add_command(set_default_ida)
 ida.add_command(source)
 ida.add_command(switch)
+ida.add_command(tool)

--- a/src/hcli/commands/ida/tool/__init__.py
+++ b/src/hcli/commands/ida/tool/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import rich_click as click
+
+
+@click.group()
+def tool() -> None:
+    """Manage IDA-related utility tools."""
+
+
+from .install import install_tool
+from .list import list_tools
+from .remove import remove_tool
+from .search import search_tools
+
+tool.add_command(install_tool, name="install")
+tool.add_command(list_tools, name="list")
+tool.add_command(remove_tool, name="remove")
+tool.add_command(search_tools, name="search")

--- a/src/hcli/commands/ida/tool/common.py
+++ b/src/hcli/commands/ida/tool/common.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import re
+
+from hcli.lib.api.asset import asset as asset_api
+
+KNOWN_TOOLS = {"vault2git", "git-ida"}
+
+# Matches release/<version>/sdk-and-utilities/<tool_name>
+_TOOL_PATH_RE = re.compile(r"^release/([^/]+)/sdk-and-utilities/([^/]+)$")
+
+
+async def fetch_tool_assets() -> list[tuple[str, str, str]]:
+    """Fetch all tool assets from the installers bucket.
+
+    Returns a list of (asset_key, tool_name, version) tuples,
+    filtered to known tools under release/*/sdk-and-utilities/*.
+    """
+    paged = await asset_api.get_files("installers")
+    results: list[tuple[str, str, str]] = []
+    for item in paged.items:
+        m = _TOOL_PATH_RE.match(item.key)
+        if not m:
+            continue
+        version, tool_name = m.group(1), m.group(2)
+        if tool_name.lower() in {t.lower() for t in KNOWN_TOOLS}:
+            results.append((item.key, tool_name, version))
+    return results

--- a/src/hcli/commands/ida/tool/install.py
+++ b/src/hcli/commands/ida/tool/install.py
@@ -117,7 +117,9 @@ async def install_tool(download_id: str, install_dir: str | None, force: bool) -
             console.print(f"[red]Failed to get download URL for {asset_key}[/red]")
             return
 
-        downloaded_path = await client.download_file(asset.url, target_dir=tmp_dir, force=True, auth=True, asset_key=asset_key)
+        downloaded_path = await client.download_file(
+            asset.url, target_dir=tmp_dir, force=True, auth=True, asset_key=asset_key
+        )
 
         # Determine target filename
         binary_name = tool_name

--- a/src/hcli/commands/ida/tool/install.py
+++ b/src/hcli/commands/ida/tool/install.py
@@ -82,12 +82,12 @@ async def install_tool(download_id: str, install_dir: str | None, force: bool) -
     """
     # Parse name[:version]
     if ":" in download_id:
-        name, version = download_id.split(":", 1)
-        version = None if version == "latest" else version
+        name, ver = download_id.split(":", 1)
+        requested_version: str | None = None if ver == "latest" else ver
     else:
-        name, version = download_id, None
+        name, requested_version = download_id, None
 
-    result = await _resolve_tool(name, version)
+    result = await _resolve_tool(name, requested_version)
     if not result:
         return
     asset_key, tool_name, version = result

--- a/src/hcli/commands/ida/tool/install.py
+++ b/src/hcli/commands/ida/tool/install.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import stat
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import rich_click as click
+
+from hcli.lib.api.asset import asset as asset_api
+from hcli.lib.api.common import get_api_client
+from hcli.lib.commands import async_command, auth_command
+from hcli.lib.config import config_store
+from hcli.lib.console import console
+
+from .common import KNOWN_TOOLS, fetch_tool_assets
+
+
+def _get_default_tool_install_dir() -> Path:
+    """Return the default directory for installing tools."""
+    if platform.system() == "Windows":
+        local_app_data = os.environ.get("LOCALAPPDATA", "")
+        return Path(local_app_data) / "hex-rays" / "hcli" / "tools"
+    return Path.home() / ".local" / "bin"
+
+
+async def _resolve_tool(name: str, version: str | None) -> tuple[str, str, str] | None:
+    """Resolve a tool name (and optional version) to an asset key.
+
+    Returns (asset_key, tool_name, resolved_version) or None on failure.
+    """
+    # Validate name against known tools (case-insensitive)
+    matched_known = None
+    for known in KNOWN_TOOLS:
+        if known.lower() == name.lower():
+            matched_known = known
+            break
+
+    if not matched_known:
+        console.print(f"[red]Unknown tool: '{name}'[/red]")
+        console.print("[yellow]Known tools:[/yellow]")
+        for t in sorted(KNOWN_TOOLS):
+            console.print(f"  - {t}")
+        return None
+
+    assets = await fetch_tool_assets()
+
+    # Filter to matching tool name
+    matches = [(k, n, v) for k, n, v in assets if n.lower() == matched_known.lower()]
+
+    if not matches:
+        console.print(f"[red]No assets found for tool '{matched_known}'[/red]")
+        return None
+
+    if version:
+        # Match specific version
+        for asset_key, tool_name, ver in matches:
+            if ver == version:
+                return (asset_key, tool_name, ver)
+        available = sorted({v for _, _, v in matches}, reverse=True)
+        console.print(f"[red]Version '{version}' not found for '{matched_known}'[/red]")
+        console.print(f"[yellow]Available versions: {', '.join(available)}[/yellow]")
+        return None
+
+    # No version specified: pick the highest (lexicographic sort)
+    matches.sort(key=lambda x: x[2], reverse=True)
+    return matches[0]
+
+
+@auth_command()
+@click.argument("download_id")
+@click.option("--install-dir", type=click.Path(), default=None, help="Custom install directory")
+@click.option("--force", is_flag=True, help="Reinstall even if already installed")
+@async_command
+async def install_tool(download_id: str, install_dir: str | None, force: bool) -> None:
+    """Install an IDA-related utility tool.
+
+    DOWNLOAD_ID: Tool name (e.g., 'vault2git') or name:version (e.g., 'vault2git:9.4')
+    """
+    # Parse name[:version]
+    if ":" in download_id:
+        name, version = download_id.split(":", 1)
+        version = None if version == "latest" else version
+    else:
+        name, version = download_id, None
+
+    result = await _resolve_tool(name, version)
+    if not result:
+        return
+    asset_key, tool_name, version = result
+
+    console.print(f"[green]Resolved: {tool_name} v{version} → {asset_key}[/green]")
+
+    # Check if already installed
+    installed: dict = config_store.get_object("tools.installed", {}) or {}
+    if tool_name in installed and not force:
+        existing = installed[tool_name]
+        console.print(
+            f"[yellow]{tool_name} is already installed (version: {existing.get('version', 'unknown')})[/yellow]"
+        )
+        console.print("[yellow]Use --force to reinstall[/yellow]")
+        return
+
+    # Determine install directory
+    target_dir = Path(install_dir) if install_dir else _get_default_tool_install_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    # Download to temp dir
+    console.print(f"[yellow]Downloading {tool_name}...[/yellow]")
+    with tempfile.TemporaryDirectory(prefix="hcli_tool_") as tmp_dir:
+        client = await get_api_client()
+        asset = await asset_api.get_file("installers", asset_key)
+        if not asset or not asset.url:
+            console.print(f"[red]Failed to get download URL for {asset_key}[/red]")
+            return
+
+        downloaded_path = await client.download_file(asset.url, target_dir=tmp_dir, force=True, auth=True, asset_key=asset_key)
+
+        # Determine target filename
+        binary_name = tool_name
+        if platform.system() == "Windows":
+            binary_name += ".exe"
+
+        target_path = target_dir / binary_name
+
+        # Move downloaded file to install dir
+        shutil.move(str(downloaded_path), str(target_path))
+
+        # Make executable on Unix
+        if platform.system() != "Windows":
+            current_stat = os.stat(target_path)
+            os.chmod(target_path, current_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    # Update config
+    installed[tool_name] = {
+        "version": version,
+        "key": asset_key,
+        "path": str(target_path),
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    config_store.set_object("tools.installed", installed)
+
+    console.print(f"[green]Successfully installed {tool_name} to {target_path}[/green]")
+
+    # Check PATH
+    if not shutil.which(binary_name):
+        console.print(f"[yellow]Warning: {target_dir} is not in your PATH[/yellow]")
+        console.print(f"[yellow]Add it to your PATH to use '{binary_name}' directly[/yellow]")

--- a/src/hcli/commands/ida/tool/list.py
+++ b/src/hcli/commands/ida/tool/list.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import rich_click as click
+from rich.table import Table
+
+from hcli.lib.commands import async_command
+from hcli.lib.config import config_store
+from hcli.lib.console import console
+
+
+@click.command()
+@async_command
+async def list_tools() -> None:
+    """List installed IDA-related utility tools."""
+    installed: dict = config_store.get_object("tools.installed", {}) or {}
+
+    if not installed:
+        console.print("[yellow]No tools installed.[/yellow]")
+        console.print("[blue]Use 'hcli ida tool search' to find available tools.[/blue]")
+        return
+
+    table = Table(title="Installed Tools")
+    table.add_column("Name", style="cyan")
+    table.add_column("Version", style="green")
+    table.add_column("Path", style="blue")
+    table.add_column("Status", style="bold")
+
+    for name, info in installed.items():
+        path = info.get("path", "")
+        exists = Path(path).exists() if path else False
+        status = "[green]OK[/green]" if exists else "[red]Missing[/red]"
+        table.add_row(name, info.get("version", "unknown"), path, status)
+
+    console.print(table)

--- a/src/hcli/commands/ida/tool/remove.py
+++ b/src/hcli/commands/ida/tool/remove.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import rich_click as click
+
+from hcli.lib.commands import async_command
+from hcli.lib.config import config_store
+from hcli.lib.console import console
+
+
+@click.command()
+@click.argument("name")
+@click.option("--keep-binary", is_flag=True, help="Remove from config but keep the binary file")
+@async_command
+async def remove_tool(name: str, keep_binary: bool) -> None:
+    """Remove an installed IDA-related utility tool.
+
+    NAME: The name of the tool to remove (e.g., 'vault2git')
+    """
+    installed: dict = config_store.get_object("tools.installed", {}) or {}
+
+    if name not in installed:
+        console.print(f"[red]Tool '{name}' is not installed.[/red]")
+        if installed:
+            console.print("[yellow]Installed tools:[/yellow]")
+            for tool_name in installed:
+                console.print(f"  - {tool_name}")
+        return
+
+    tool_info = installed[name]
+    tool_path = tool_info.get("path", "")
+
+    # Delete binary unless --keep-binary
+    if not keep_binary and tool_path:
+        Path(tool_path).unlink(missing_ok=True)
+        console.print(f"[green]Removed binary: {tool_path}[/green]")
+
+    # Remove from config
+    del installed[name]
+    config_store.set_object("tools.installed", installed)
+
+    console.print(f"[green]Successfully removed {name}[/green]")

--- a/src/hcli/commands/ida/tool/search.py
+++ b/src/hcli/commands/ida/tool/search.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import rich_click as click
+from rich.table import Table
+
+from hcli.lib.commands import async_command, auth_command
+from hcli.lib.console import console
+
+from .common import fetch_tool_assets
+
+
+@auth_command()
+@click.argument("pattern", required=False, default=None)
+@click.option("--all-versions", is_flag=True, help="Show all versions (default: latest only)")
+@async_command
+async def search_tools(pattern: str | None, all_versions: bool) -> None:
+    """Search for available IDA tools."""
+    assets = await fetch_tool_assets()
+
+    if not assets:
+        console.print("[yellow]No tools found.[/yellow]")
+        return
+
+    # Filter by pattern if provided
+    if pattern:
+        pattern_lower = pattern.lower()
+        assets = [(k, name, ver) for k, name, ver in assets if pattern_lower in name.lower()]
+
+    if not assets:
+        console.print(f"[yellow]No tools matching '{pattern}'.[/yellow]")
+        return
+
+    # Group by tool name
+    by_name: dict[str, list[tuple[str, str, str]]] = {}
+    for asset_key, tool_name, version in assets:
+        by_name.setdefault(tool_name, []).append((asset_key, tool_name, version))
+
+    # Sort versions descending within each tool
+    for entries in by_name.values():
+        entries.sort(key=lambda x: x[2], reverse=True)
+
+    table = Table(title="Available Tools")
+    table.add_column("Name", style="cyan")
+    table.add_column("Version", style="green")
+    table.add_column("Install Command", style="blue")
+
+    for tool_name in sorted(by_name):
+        entries = by_name[tool_name]
+        if all_versions:
+            for asset_key, name, version in entries:
+                table.add_row(name, version, f"hcli ida tool install {name}:{version}")
+        else:
+            # Latest only
+            asset_key, name, version = entries[0]
+            table.add_row(name, version, f"hcli ida tool install {name}:{version}")
+
+    console.print(table)


### PR DESCRIPTION
## Summary
- Add `ida tool` subcommand group for managing IDA-related utility tools
- `ida tool search` — browse available tools from the installers bucket, with optional pattern filtering and `--all-versions`
- `ida tool install` — download and install a tool by name (optionally pinned to a version via `name:version`), with smart resolution against known tools
- `ida tool list` — show installed tools with path and status
- `ida tool remove` — uninstall a tool (binary + config), with `--keep-binary` option

**Note:** The set of known tools (`vault2git`, `git-ida`) is currently hardcoded in `common.py`. This acts as an allowlist to filter assets from the `sdk-and-utilities` bucket path. As new tools are added, this list will need to be updated manually. A future improvement could fetch the known tools list dynamically from the API or a config file.

## Test plan
- [ ] Run `hcli ida tool search` and verify it lists available tools
- [ ] Run `hcli ida tool install vault2git` and verify download + PATH warning
- [ ] Run `hcli ida tool list` and verify installed tool appears
- [ ] Run `hcli ida tool remove vault2git` and verify cleanup
- [ ] Test `--force` reinstall and `name:version` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)