### PR TITLE
fix: use license_key instead of pubhash for downloads

### DIFF
--- a/src/hcli/commands/license/common.py
+++ b/src/hcli/commands/license/common.py
@@ -149,10 +149,10 @@ async def download_license_asset(
         Downloaded file path or None if failed
     """
     try:
-        if not lic.pubhash:
-            console.print(f"[red]License has no ID for asset {asset_type}[/red]")
+        if not lic.license_key:
+            console.print(f"[red]License has no key for asset {asset_type}[/red]")
             return None
-        filename = await license.download_license(customer_id, lic.pubhash, asset_type, target_dir)
+        filename = await license.download_license(customer_id, lic.license_key, asset_type, target_dir)
         if filename:
             console.print(f"[green]License {asset_type} for {lic.pubhash} downloaded as: {filename}[/green]")
             return filename


### PR DESCRIPTION
## Summary
- License downloads were failing with 404 for renewed licenses
- The download API queries by `license_key` (unique internal ID), but hcli was sending `pubhash` (stable customer-facing ID)
- After renewal, the new license keeps the same `pubhash` but gets a new `license_key`, so downloading by `pubhash` matched the old revoked license → 404
- Fix: use `lic.license_key` for the download API call, keep `lic.pubhash` for display

## Test plan
- [ ] Find a customer with a renewed license
- [ ] Run `hcli license list` — should show the license with its `pubhash`
- [ ] Run `hcli license get` and download the license — should succeed (no more 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)