### PR TITLE
disambiguate colliding plugin names via repository URLs

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -308,6 +308,8 @@ $ hcli plugin search ipython
  ipyida  2.3  installed
 ```
 
+If two repository plugins share the same bare name, HCLI will ask you to qualify the reference with the plugin's repository URL, for example `hcli plugin install ida-chat@https://github.com/HexRaysSA/ida-chat-plugin` or `hcli plugin install ida-chat==1.0.0@https://github.com/HexRaysSA/ida-chat-plugin`. See [Plugin Manager](../user-guide/plugin-manager.md) for details.
+
 ```bash
 $ hcli plugin install ipyida
 Installed plugin: ipyida==2.3

--- a/docs/reference/plugin-repository-architecture.md
+++ b/docs/reference/plugin-repository-architecture.md
@@ -54,7 +54,12 @@ $IDAUSR/plugins/oplog/
 
 The directory name matches the plugin name from `ida-plugin.json`.
 This is why the contents of `name` are fairly restrictive. They should also be globally unique.
-We'll address collisions in plugin names by taking into account the code repository, too.
 
 During upgrades, the existing directory is replaced with the new version.
 Uninstallation is as easy as deleting the directory.
+
+### Plugin identity and name collisions
+
+In the repository index, a plugin is identified by the pair `(name, repository URL)`. Two plugins with the same bare name from different repositories are distinct entries, and the repository URL is normalized (lowercased scheme/host/path, trailing slash stripped) before comparison so that cosmetic URL differences do not split a single plugin into two.
+
+On disk, however, plugins still install as `$IDAUSR/plugins/<name>`. Name is therefore the installed-layout identity, and only one plugin with a given bare name can be installed at a time. When the repository contains multiple plugins with the same name, HCLI requires a qualified reference of the form `name@repository-url` (optionally with a version spec, e.g. `name==1.2.3@repository-url`). An installed plugin's local metadata records its source repository, so status and upgrade operations anchor their repository lookups on the installed plugin's host and stay consistent even when the bare name is ambiguous in the repository.

--- a/docs/user-guide/plugin-manager.md
+++ b/docs/user-guide/plugin-manager.md
@@ -71,6 +71,27 @@ You can discover interesting plugins via:
 
 HCLI supports installing plugins to be loaded by IDA 9.0 and newer.
 
+### Disambiguating plugin names
+
+When two plugins share the same bare name in the repository (for example, different forks of the same project), HCLI cannot tell which one you mean from the name alone. The `search`, `install`, and `upgrade` commands will print the ambiguous candidates and ask you to qualify the reference with the plugin's repository URL:
+
+```console
+❯ hcli plugin install ida-chat
+Error: plugin name 'ida-chat' is ambiguous
+Choose one of:
+  ida-chat@https://github.com/HexRaysSA/ida-chat-plugin
+  ida-chat@https://github.com/tanu360/ida-chat-plugin
+```
+
+You can pin the reference with `name@repository-url`, and optionally include a version spec:
+
+```console
+❯ hcli plugin install ida-chat@https://github.com/HexRaysSA/ida-chat-plugin
+❯ hcli plugin install ida-chat==1.0.0@https://github.com/HexRaysSA/ida-chat-plugin
+```
+
+Because plugins install into `$IDAUSR/plugins/<name>`, only one plugin with a given bare name can be installed at a time. If you need to switch to a different same-named plugin from another repository, uninstall the current one first. Similarly, `upgrade` will not change the source repository: once a plugin is installed, its repository is recorded in the local metadata and upgrades are anchored to it.
+
 
 ## As a plugin author...
 

--- a/src/hcli/commands/plugin/config.py
+++ b/src/hcli/commands/plugin/config.py
@@ -11,7 +11,7 @@ import rich_click as click
 
 from hcli.lib.console import console
 from hcli.lib.ida import get_ida_config
-from hcli.lib.ida.plugin.install import get_metadata_from_plugin_directory, get_plugin_directory
+from hcli.lib.ida.plugin.install import get_metadata_from_plugin_directory, resolve_installed_plugin_directory
 from hcli.lib.ida.plugin.settings import del_plugin_setting, get_plugin_setting, parse_setting_value, set_plugin_setting
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ def set(ctx, key: str, value: str) -> None:
     """Set a plugin configuration setting."""
     plugin_name = ctx.obj["config_plugin_name"]
     try:
-        plugin_path = get_plugin_directory(plugin_name)
+        plugin_path = resolve_installed_plugin_directory(plugin_name)
         metadata = get_metadata_from_plugin_directory(plugin_path)
         descr = metadata.plugin.get_setting(key)
         parsed_value = parse_setting_value(descr, value)
@@ -91,7 +91,7 @@ def list(ctx) -> None:
     """List all configuration settings for a plugin."""
     plugin_name = ctx.obj["config_plugin_name"]
     try:
-        plugin_path = get_plugin_directory(plugin_name)
+        plugin_path = resolve_installed_plugin_directory(plugin_name)
         metadata = get_metadata_from_plugin_directory(plugin_path)
 
         if not metadata.plugin.settings:

--- a/src/hcli/commands/plugin/config.py
+++ b/src/hcli/commands/plugin/config.py
@@ -11,10 +11,18 @@ import rich_click as click
 
 from hcli.lib.console import console
 from hcli.lib.ida import get_ida_config
-from hcli.lib.ida.plugin.install import get_metadata_from_plugin_directory, resolve_installed_plugin_directory
+from hcli.lib.ida.plugin.install import (
+    find_installed_plugin,
+    get_metadata_from_plugin_directory,
+    resolve_installed_plugin_directory,
+)
 from hcli.lib.ida.plugin.settings import del_plugin_setting, get_plugin_setting, parse_setting_value, set_plugin_setting
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_config_plugin_name(plugin_name: str) -> str:
+    return find_installed_plugin(plugin_name).name
 
 
 @click.group()
@@ -137,6 +145,7 @@ def export(ctx) -> None:
     """Export plugin configuration settings as JSON."""
     plugin_name = ctx.obj["config_plugin_name"]
     try:
+        plugin_name = resolve_config_plugin_name(plugin_name)
         config = get_ida_config()
         if plugin_name not in config.plugins:
             console.print("{}")
@@ -158,6 +167,7 @@ def import_(ctx, json_input: str | None) -> None:
     """Import plugin configuration settings from JSON."""
     plugin_name = ctx.obj["config_plugin_name"]
     try:
+        plugin_name = resolve_config_plugin_name(plugin_name)
         if json_input:
             data = json.loads(json_input)
         else:

--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -80,12 +80,11 @@ def install_plugin(ctx, plugin: str, config: tuple[str, ...], no_build_isolation
         elif is_github_repository_url(plugin_spec):
             logger.info("installing from GitHub repository")
             try:
-                owner, repo, tag = parse_github_url(plugin_spec)
-                tag_info = f"@{tag}" if tag else " (latest release)"
+                owner, repo = parse_github_url(plugin_spec)
                 with rich.status.Status(
-                    f"fetching plugin from GitHub: {owner}/{repo}{tag_info}", console=stderr_console
+                    f"fetching plugin from GitHub: {owner}/{repo} (latest release)", console=stderr_console
                 ):
-                    buf = fetch_github_release_zip_asset(owner, repo, tag)
+                    buf = fetch_github_release_zip_asset(owner, repo)
             except (httpx.ConnectError, httpx.TimeoutException):
                 console.print("[red]Cannot connect to GitHub - network unavailable.[/red]")
                 console.print("Please check your internet connection.")

--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -23,9 +23,20 @@ from hcli.lib.ida.plugin import (
     get_metadata_from_plugin_archive,
     get_metadatas_with_paths_from_plugin_archive,
 )
-from hcli.lib.ida.plugin.install import install_plugin_archive, uninstall_plugin
+from hcli.lib.ida.plugin.exceptions import (
+    AmbiguousPluginReferenceError,
+    InstalledPluginNameConflictError,
+    PluginNotInstalledError,
+)
+from hcli.lib.ida.plugin.install import find_installed_plugin, install_plugin_archive, uninstall_plugin
+from hcli.lib.ida.plugin.reference import (
+    format_qualified_plugin_reference,
+    is_github_repository_url,
+    normalize_plugin_host,
+    parse_plugin_reference,
+)
 from hcli.lib.ida.plugin.repo import BasePluginRepo, fetch_plugin_archive
-from hcli.lib.ida.plugin.repo.github import fetch_github_release_zip_asset, is_github_url, parse_github_url
+from hcli.lib.ida.plugin.repo.github import fetch_github_release_zip_asset, parse_github_url
 from hcli.lib.ida.plugin.settings import has_plugin_setting, parse_setting_value, set_plugin_setting
 
 logger = logging.getLogger(__name__)
@@ -66,7 +77,7 @@ def install_plugin(ctx, plugin: str, config: tuple[str, ...], no_build_isolation
                 raise ValueError("plugin archive must contain a single plugin for local file system installation")
             plugin_name = items[0][1].plugin.name
 
-        elif is_github_url(plugin_spec):
+        elif is_github_repository_url(plugin_spec):
             logger.info("installing from GitHub repository")
             try:
                 owner, repo, tag = parse_github_url(plugin_spec)
@@ -101,12 +112,49 @@ def install_plugin(ctx, plugin: str, config: tuple[str, ...], no_build_isolation
         else:
             logger.info("finding plugin in repository")
             plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
-            with rich.status.Status("fetching plugin", console=stderr_console):
-                plugin_name, buf = plugin_repo.fetch_compatible_plugin_from_spec(
-                    plugin_spec, current_ida_platform, current_ida_version
-                )
+            try:
+                ref = parse_plugin_reference(plugin_spec)
+            except ValueError as e:
+                raise click.BadParameter(f"invalid plugin reference: {plugin_spec!r}: {e}")
+
+            # reconstruct the plugin_spec for repo lookup without the @host suffix
+            bare_spec = ref.name + ref.version_spec
+            try:
+                with rich.status.Status("fetching plugin", console=stderr_console):
+                    plugin_name, buf = plugin_repo.fetch_compatible_plugin_from_spec(
+                        bare_spec, current_ida_platform, current_ida_version, host=ref.host
+                    )
+            except AmbiguousPluginReferenceError as e:
+                console.print(f"[red]Error[/red]: plugin name '{e.name}' is ambiguous")
+                console.print("Choose one of:")
+                for candidate_name, candidate_host in e.candidates:
+                    console.print(
+                        f"  {format_qualified_plugin_reference((candidate_name, ref.version_spec, candidate_host))}"
+                    )
+                raise click.Abort()
 
         _, metadata = get_metadata_from_plugin_archive(buf, plugin_name)
+
+        # Same-name install conflict: another plugin with the same bare name is already
+        # installed from a different repository. The install layout is
+        # $IDAUSR/plugins/<name>, so only one same-name plugin can be installed at a time.
+        # Use the archive metadata host (not the download URL) as the long-term identity
+        # because GitHub redirects can cause the fetch URL and the metadata host to differ.
+        try:
+            installed = find_installed_plugin(plugin_name)
+        except PluginNotInstalledError:
+            installed = None
+
+        if installed is not None and normalize_plugin_host(installed.host) != normalize_plugin_host(
+            metadata.plugin.host
+        ):
+            raise InstalledPluginNameConflictError(
+                requested_name=plugin_name,
+                requested_host=metadata.plugin.host,
+                installed_name=installed.name,
+                installed_host=installed.host,
+                installed_path=installed.path,
+            )
 
         if metadata.plugin.settings:
             for config_item in config:
@@ -221,6 +269,16 @@ def install_plugin(ctx, plugin: str, config: tuple[str, ...], no_build_isolation
 
     except FailedToDetectIDAVersion:
         explain_failed_to_detect_ida_version(console)
+        raise click.Abort()
+
+    except InstalledPluginNameConflictError as e:
+        console.print(
+            f"[red]Error[/red]: cannot install plugin "
+            f"'{e.requested_name}@{e.requested_host}' because "
+            f"'{e.installed_name}@{e.installed_host}' is already installed at {e.installed_path}"
+        )
+        console.print(f"Only one plugin with the bare name '{e.requested_name}' can be installed at a time.")
+        console.print("Uninstall the existing plugin first, then install the other qualified plugin.")
         raise click.Abort()
 
     except Exception as e:

--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -124,12 +124,12 @@ def install_plugin(ctx, plugin: str, config: tuple[str, ...], no_build_isolation
                         bare_spec, current_ida_platform, current_ida_version, host=ref.host
                     )
             except AmbiguousPluginReferenceError as e:
+                if ref.version_spec and not e.version_spec:
+                    e = AmbiguousPluginReferenceError(e.name, e.candidates, ref.version_spec)
                 console.print(f"[red]Error[/red]: plugin name '{e.name}' is ambiguous")
                 console.print("Choose one of:")
-                for candidate_name, candidate_host in e.candidates:
-                    console.print(
-                        f"  {format_qualified_plugin_reference((candidate_name, ref.version_spec, candidate_host))}"
-                    )
+                for candidate_ref in e.candidate_refs:
+                    console.print(f"  {format_qualified_plugin_reference(candidate_ref)}")
                 raise click.Abort()
 
         _, metadata = get_metadata_from_plugin_archive(buf, plugin_name)

--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -31,7 +31,7 @@ from hcli.lib.ida.plugin.exceptions import (
 from hcli.lib.ida.plugin.install import find_installed_plugin, install_plugin_archive, uninstall_plugin
 from hcli.lib.ida.plugin.reference import (
     format_qualified_plugin_reference,
-    is_github_repository_url,
+    is_github_direct_install_url,
     normalize_plugin_host,
     parse_plugin_reference,
 )
@@ -77,14 +77,15 @@ def install_plugin(ctx, plugin: str, config: tuple[str, ...], no_build_isolation
                 raise ValueError("plugin archive must contain a single plugin for local file system installation")
             plugin_name = items[0][1].plugin.name
 
-        elif is_github_repository_url(plugin_spec):
+        elif is_github_direct_install_url(plugin_spec):
             logger.info("installing from GitHub repository")
             try:
-                owner, repo = parse_github_url(plugin_spec)
+                owner, repo, tag = parse_github_url(plugin_spec)
+                tag_info = f"@{tag}" if tag else " (latest release)"
                 with rich.status.Status(
-                    f"fetching plugin from GitHub: {owner}/{repo} (latest release)", console=stderr_console
+                    f"fetching plugin from GitHub: {owner}/{repo}{tag_info}", console=stderr_console
                 ):
-                    buf = fetch_github_release_zip_asset(owner, repo)
+                    buf = fetch_github_release_zip_asset(owner, repo, tag)
             except (httpx.ConnectError, httpx.TimeoutException):
                 console.print("[red]Cannot connect to GitHub - network unavailable.[/red]")
                 console.print("Please check your internet connection.")

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -223,11 +223,13 @@ def handle_keyword_query(plugins: list[Plugin], query: str, current_version: str
     table.add_column("version", style="default")
     table.add_column("status")
     table.add_column("repo", style="grey69")
+    has_matches = False
 
     for plugin in sorted(plugins, key=lambda p: p.name.lower()):
         if not does_plugin_match_query(query or "", plugin):
             continue
 
+        has_matches = True
         latest_metadata = get_latest_plugin_metadata(plugin)
 
         if not is_compatible_plugin(plugin, current_platform, current_version):
@@ -266,9 +268,9 @@ def handle_keyword_query(plugins: list[Plugin], query: str, current_version: str
                 latest_metadata.plugin.urls.repository,
             )
 
-    console.print(table)
-
-    if not plugins:
+    if has_matches:
+        console.print(table)
+    else:
         console.print("[grey69]No plugins found[/grey69]")
 
 

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 
 import rich.table
 import rich_click as click
+import semantic_version
 
 from hcli.lib.console import console
 from hcli.lib.ida import (
@@ -110,11 +111,8 @@ def render_ambiguity_error(err: AmbiguousPluginReferenceError) -> None:
         console.print(f"  {format_qualified_plugin_reference((candidate_name, err.version_spec, candidate_host))}")
 
 
-def handle_plugin_name_query(plugins: list[Plugin], ref: PluginReference, current_version: str, current_platform: str):
-    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
-    latest_metadata = get_latest_plugin_metadata(plugin)
-
-    metadata_dict = latest_metadata.plugin.model_dump()
+def output_plugin_metadata(metadata) -> None:
+    metadata_dict = metadata.plugin.model_dump()
     del metadata_dict["platforms"]
     metadata_dict["idaVersions"] = render_ida_versions(metadata_dict["idaVersions"])
 
@@ -122,8 +120,14 @@ def handle_plugin_name_query(plugins: list[Plugin], ref: PluginReference, curren
         console.print(f"{key}: {value}")
     console.print()
 
-    # i had hoped to use markdown/syntax, but it always has a background color, and we dont know light/dark theme state.
 
+def output_plugin_versions_table(
+    plugin: Plugin,
+    versions: Sequence[str],
+    current_version: str,
+    current_platform: str,
+    title: str,
+) -> None:
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("version", style="default")
     table.add_column("status")
@@ -133,9 +137,9 @@ def handle_plugin_name_query(plugins: list[Plugin], ref: PluginReference, curren
     if installed_record is not None:
         existing_version = parse_plugin_version(installed_record.version)
 
-    for version, locations in sorted(plugin.versions.items(), key=lambda p: parse_plugin_version(p[0]), reverse=True):
+    for version in versions:
+        locations = plugin.versions[version]
         metadata = locations[0].metadata
-
         is_compatible = is_compatible_plugin_version(plugin, version, locations, current_platform, current_version)
 
         status = ""
@@ -146,17 +150,37 @@ def handle_plugin_name_query(plugins: list[Plugin], ref: PluginReference, curren
             if parse_plugin_version(metadata.plugin.version) > existing_version and is_compatible:
                 status = f"[yellow]upgradable[/yellow] from {existing_version}"
 
-        else:
-            if not is_compatible:
-                status = "[grey69]incompatible[/grey69]"
+        elif not is_compatible:
+            status = "[grey69]incompatible[/grey69]"
 
-        table.add_row(
-            version,
-            status,
-        )
+        table.add_row(version, status)
 
-    console.print("available versions:")
+    console.print(title)
     console.print(table)
+
+
+def get_matching_versions(plugin: Plugin, version_spec: str) -> list[str]:
+    wanted_spec = semantic_version.SimpleSpec(version_spec)
+    return [
+        version
+        for version, _ in sorted(plugin.versions.items(), key=lambda p: parse_plugin_version(p[0]), reverse=True)
+        if parse_plugin_version(version) in wanted_spec
+    ]
+
+
+def handle_plugin_name_query(plugins: list[Plugin], ref: PluginReference, current_version: str, current_platform: str):
+    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
+    output_plugin_metadata(get_latest_plugin_metadata(plugin))
+    output_plugin_versions_table(
+        plugin,
+        [
+            version
+            for version, _ in sorted(plugin.versions.items(), key=lambda p: parse_plugin_version(p[0]), reverse=True)
+        ],
+        current_version,
+        current_platform,
+        "available versions:",
+    )
 
 
 def render_ida_versions(versions: Sequence[IdaVersion]) -> str:
@@ -179,27 +203,13 @@ def render_platforms(platforms: Sequence[Platform]) -> str:
     return ", ".join(sorted(platforms))
 
 
-def handle_plugin_spec_query(plugins: list[Plugin], ref: PluginReference, current_version: str, current_platform: str):
-    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
-
-    # version_spec is like "==1.2.3"; strip the leading operator
-    version = ref.version_spec[2:] if ref.version_spec.startswith("==") else ref.version_spec.lstrip("=><!~")
-    if not version:
-        raise ValueError(f"invalid plugin version: {ref.version_spec!r}")
-
+def handle_plugin_exact_version_query(plugin: Plugin, version: str):
     if version not in plugin.versions:
-        raise KeyError(f"version {version} not found for plugin {ref.name}")
+        raise KeyError(f"version {version} not found for plugin {plugin.name}")
 
     locations = plugin.versions[version]
     metadata = locations[0].metadata
-
-    metadata_dict = metadata.plugin.model_dump()
-    del metadata_dict["platforms"]
-    metadata_dict["idaVersions"] = render_ida_versions(metadata_dict["idaVersions"])
-
-    for key, value in sorted(metadata_dict.items()):
-        console.print(f"{key}: {value}")
-    console.print()
+    output_plugin_metadata(metadata)
 
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("IDA version spec", style="default")
@@ -215,6 +225,33 @@ def handle_plugin_spec_query(plugins: list[Plugin], ref: PluginReference, curren
 
     console.print("download locations:")
     console.print(table)
+
+
+def handle_plugin_version_range_query(
+    plugin: Plugin,
+    ref: PluginReference,
+    current_version: str,
+    current_platform: str,
+):
+    matching_versions = get_matching_versions(plugin, ref.version_spec)
+    if not matching_versions:
+        raise KeyError(f"no versions matching {ref.version_spec!r} found for plugin {plugin.name!r}")
+
+    output_plugin_metadata(plugin.versions[matching_versions[0]][0].metadata)
+    output_plugin_versions_table(plugin, matching_versions, current_version, current_platform, "matching versions:")
+
+
+def handle_plugin_spec_query(plugins: list[Plugin], ref: PluginReference, current_version: str, current_platform: str):
+    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
+
+    if ref.version_spec.startswith("=="):
+        version = ref.version_spec[2:]
+        if not version:
+            raise ValueError(f"invalid plugin version: {ref.version_spec!r}")
+        handle_plugin_exact_version_query(plugin, version)
+        return
+
+    handle_plugin_version_range_query(plugin, ref, current_version, current_platform)
 
 
 def handle_keyword_query(plugins: list[Plugin], query: str, current_version: str, current_platform: str):

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -26,11 +26,8 @@ from hcli.lib.ida.plugin import (
     parse_ida_version,
     parse_plugin_version,
 )
-from hcli.lib.ida.plugin.exceptions import (
-    AmbiguousPluginReferenceError,
-    PluginNotInstalledError,
-)
-from hcli.lib.ida.plugin.install import find_installed_plugin
+from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError
+from hcli.lib.ida.plugin.install import InstalledPluginRecord, find_installed_plugin_in, get_installed_plugin_records
 from hcli.lib.ida.plugin.reference import (
     PluginReference,
     format_qualified_plugin_reference,
@@ -89,18 +86,16 @@ def does_plugin_match_query(query: str, plugin: Plugin) -> bool:
     return False
 
 
-def find_installed_matching(plugin: Plugin):
+def find_installed_matching(
+    plugin: Plugin,
+    installed_records: list[InstalledPluginRecord],
+) -> InstalledPluginRecord | None:
     """Look up the installed record for this *specific* repository plugin.
 
     Matches on both bare name and normalized host so a same-name plugin from a
     different repository does not register as installed.
-
-    Returns the record or ``None`` when no matching plugin is installed.
     """
-    try:
-        return find_installed_plugin(plugin.name, host=plugin.host)
-    except PluginNotInstalledError:
-        return None
+    return find_installed_plugin_in(installed_records, plugin.name, host=plugin.host)
 
 
 def render_ambiguity_error(err: AmbiguousPluginReferenceError) -> None:
@@ -127,12 +122,13 @@ def output_plugin_versions_table(
     current_version: str,
     current_platform: str,
     title: str,
+    installed_records: list[InstalledPluginRecord],
 ) -> None:
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("version", style="default")
     table.add_column("status")
 
-    installed_record = find_installed_matching(plugin)
+    installed_record = find_installed_matching(plugin, installed_records)
     existing_version = None
     if installed_record is not None:
         existing_version = parse_plugin_version(installed_record.version)
@@ -168,7 +164,13 @@ def get_matching_versions(plugin: Plugin, version_spec: str) -> list[str]:
     ]
 
 
-def handle_plugin_name_query(plugins: list[Plugin], ref: PluginReference, current_version: str, current_platform: str):
+def handle_plugin_name_query(
+    plugins: list[Plugin],
+    ref: PluginReference,
+    current_version: str,
+    current_platform: str,
+    installed_records: list[InstalledPluginRecord],
+):
     plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
     output_plugin_metadata(get_latest_plugin_metadata(plugin))
     output_plugin_versions_table(
@@ -180,6 +182,7 @@ def handle_plugin_name_query(plugins: list[Plugin], ref: PluginReference, curren
         current_version,
         current_platform,
         "available versions:",
+        installed_records,
     )
 
 
@@ -232,16 +235,25 @@ def handle_plugin_version_range_query(
     ref: PluginReference,
     current_version: str,
     current_platform: str,
+    installed_records: list[InstalledPluginRecord],
 ):
     matching_versions = get_matching_versions(plugin, ref.version_spec)
     if not matching_versions:
         raise KeyError(f"no versions matching {ref.version_spec!r} found for plugin {plugin.name!r}")
 
     output_plugin_metadata(plugin.versions[matching_versions[0]][0].metadata)
-    output_plugin_versions_table(plugin, matching_versions, current_version, current_platform, "matching versions:")
+    output_plugin_versions_table(
+        plugin, matching_versions, current_version, current_platform, "matching versions:", installed_records
+    )
 
 
-def handle_plugin_spec_query(plugins: list[Plugin], ref: PluginReference, current_version: str, current_platform: str):
+def handle_plugin_spec_query(
+    plugins: list[Plugin],
+    ref: PluginReference,
+    current_version: str,
+    current_platform: str,
+    installed_records: list[InstalledPluginRecord],
+):
     plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
 
     if ref.version_spec.startswith("=="):
@@ -251,10 +263,16 @@ def handle_plugin_spec_query(plugins: list[Plugin], ref: PluginReference, curren
         handle_plugin_exact_version_query(plugin, version)
         return
 
-    handle_plugin_version_range_query(plugin, ref, current_version, current_platform)
+    handle_plugin_version_range_query(plugin, ref, current_version, current_platform, installed_records)
 
 
-def handle_keyword_query(plugins: list[Plugin], query: str, current_version: str, current_platform: str):
+def handle_keyword_query(
+    plugins: list[Plugin],
+    query: str,
+    current_version: str,
+    current_platform: str,
+    installed_records: list[InstalledPluginRecord],
+):
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("name", style="blue")
     table.add_column("version", style="default")
@@ -282,7 +300,7 @@ def handle_keyword_query(plugins: list[Plugin], query: str, current_version: str
                 plugin, current_platform, current_version
             )
 
-            installed_record = find_installed_matching(plugin)
+            installed_record = find_installed_matching(plugin, installed_records)
             is_upgradable = False
             existing_version: str | None = None
             if installed_record is not None:
@@ -331,9 +349,10 @@ def search_plugins(ctx, query: str | None = None) -> None:
 
         plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
         plugins: list[Plugin] = plugin_repo.get_plugins()
+        installed_records = get_installed_plugin_records()
 
         if not query:
-            handle_keyword_query(plugins, "", current_version, current_platform)
+            handle_keyword_query(plugins, "", current_version, current_platform, installed_records)
             return
 
         # Try to parse the query as a qualified reference. If parsing fails
@@ -342,7 +361,7 @@ def search_plugins(ctx, query: str | None = None) -> None:
         try:
             ref = parse_plugin_reference(query)
         except ValueError:
-            handle_keyword_query(plugins, query, current_version, current_platform)
+            handle_keyword_query(plugins, query, current_version, current_platform, installed_records)
             return
 
         # A qualified query (with a host) is always an exact plugin query.
@@ -350,14 +369,14 @@ def search_plugins(ctx, query: str | None = None) -> None:
         # matches a known bare name case-insensitively; otherwise fall back
         # to keyword/substring search.
         if ref.host is None and not _has_exact_name_match(plugins, ref.name):
-            handle_keyword_query(plugins, query, current_version, current_platform)
+            handle_keyword_query(plugins, query, current_version, current_platform, installed_records)
             return
 
         try:
             if ref.version_spec:
-                handle_plugin_spec_query(plugins, ref, current_version, current_platform)
+                handle_plugin_spec_query(plugins, ref, current_version, current_platform, installed_records)
             else:
-                handle_plugin_name_query(plugins, ref, current_version, current_platform)
+                handle_plugin_name_query(plugins, ref, current_version, current_platform, installed_records)
         except AmbiguousPluginReferenceError as e:
             # ``get_plugin_by_name`` does not know the user's version spec;
             # attach it here so candidate suggestions render ``name==1.2.3@repo``.

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -24,9 +24,17 @@ from hcli.lib.ida.plugin import (
     Platform,
     parse_ida_version,
     parse_plugin_version,
-    split_plugin_version_spec,
 )
-from hcli.lib.ida.plugin.install import get_metadata_from_plugin_directory, get_plugin_directory, is_plugin_installed
+from hcli.lib.ida.plugin.exceptions import (
+    AmbiguousPluginReferenceError,
+    PluginNotInstalledError,
+)
+from hcli.lib.ida.plugin.install import find_installed_plugin
+from hcli.lib.ida.plugin.reference import (
+    PluginReference,
+    format_qualified_plugin_reference,
+    parse_plugin_reference,
+)
 from hcli.lib.ida.plugin.repo import (
     BasePluginRepo,
     Plugin,
@@ -80,32 +88,30 @@ def does_plugin_match_query(query: str, plugin: Plugin) -> bool:
     return False
 
 
-def is_plugin_name_query(plugins: list[Plugin], query: str):
-    """like 'plugin1' exact matches a known plugin"""
-    if not query:
-        return False
+def find_installed_matching(plugin: Plugin):
+    """Look up the installed record for this *specific* repository plugin.
 
-    query = query.lower()
+    Matches on both bare name and normalized host so a same-name plugin from a
+    different repository does not register as installed.
 
+    Returns the record or ``None`` when no matching plugin is installed.
+    """
     try:
-        _ = get_plugin_by_name(plugins, query)
-        return True
-    except KeyError:
-        return False
+        return find_installed_plugin(plugin.name, host=plugin.host)
+    except PluginNotInstalledError:
+        return None
 
 
-def is_plugin_spec_query(plugins: list[Plugin], query: str):
-    """like 'plugin1==1.0.0' exact matches a known plugin name, with version"""
-    try:
-        plugin_name, _ = split_plugin_version_spec(query)
-    except ValueError:
-        return False
-
-    return bool(plugin_name != query and is_plugin_name_query(plugins, plugin_name))
+def render_ambiguity_error(err: AmbiguousPluginReferenceError) -> None:
+    """Render the user-facing message for an ambiguous bare-name query."""
+    console.print(f"[red]Error[/red]: plugin name '{err.name}' is ambiguous")
+    console.print("Choose one of:")
+    for candidate_name, candidate_host in err.candidates:
+        console.print(f"  {format_qualified_plugin_reference((candidate_name, err.version_spec, candidate_host))}")
 
 
-def handle_plugin_name_query(plugins: list[Plugin], query: str, current_version: str, current_platform: str):
-    plugin = get_plugin_by_name(plugins, query)
+def handle_plugin_name_query(plugins: list[Plugin], ref: PluginReference, current_version: str, current_platform: str):
+    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
     latest_metadata = get_latest_plugin_metadata(plugin)
 
     metadata_dict = latest_metadata.plugin.model_dump()
@@ -122,12 +128,10 @@ def handle_plugin_name_query(plugins: list[Plugin], query: str, current_version:
     table.add_column("version", style="default")
     table.add_column("status")
 
-    is_installed = is_plugin_installed(plugin.name)
+    installed_record = find_installed_matching(plugin)
     existing_version = None
-    if is_installed:
-        existing_plugin_path = get_plugin_directory(plugin.name)
-        existing_metadata = get_metadata_from_plugin_directory(existing_plugin_path)
-        existing_version = parse_plugin_version(existing_metadata.plugin.version)
+    if installed_record is not None:
+        existing_version = parse_plugin_version(installed_record.version)
 
     for version, locations in sorted(plugin.versions.items(), key=lambda p: parse_plugin_version(p[0]), reverse=True):
         metadata = locations[0].metadata
@@ -135,11 +139,11 @@ def handle_plugin_name_query(plugins: list[Plugin], query: str, current_version:
         is_compatible = is_compatible_plugin_version(plugin, version, locations, current_platform, current_version)
 
         status = ""
-        if is_installed:
-            if is_installed and parse_plugin_version(metadata.plugin.version) == existing_version:
+        if installed_record is not None and existing_version is not None:
+            if parse_plugin_version(metadata.plugin.version) == existing_version:
                 status = "[green]currently installed[/green]"
 
-            if is_installed and parse_plugin_version(metadata.plugin.version) > existing_version and is_compatible:
+            if parse_plugin_version(metadata.plugin.version) > existing_version and is_compatible:
                 status = f"[yellow]upgradable[/yellow] from {existing_version}"
 
         else:
@@ -175,12 +179,16 @@ def render_platforms(platforms: Sequence[Platform]) -> str:
     return ", ".join(sorted(platforms))
 
 
-def handle_plugin_spec_query(plugins: list[Plugin], query: str, current_version: str, current_platform: str):
-    name, version = split_plugin_version_spec(query)
-    if not version:
-        raise ValueError(f"invalid plugin version: {query}")
+def handle_plugin_spec_query(plugins: list[Plugin], ref: PluginReference, current_version: str, current_platform: str):
+    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
 
-    plugin = get_plugin_by_name(plugins, name)
+    # version_spec is like "==1.2.3"; strip the leading operator
+    version = ref.version_spec[2:] if ref.version_spec.startswith("==") else ref.version_spec.lstrip("=><!~")
+    if not version:
+        raise ValueError(f"invalid plugin version: {ref.version_spec!r}")
+
+    if version not in plugin.versions:
+        raise KeyError(f"version {version} not found for plugin {ref.name}")
 
     locations = plugin.versions[version]
     metadata = locations[0].metadata
@@ -235,13 +243,11 @@ def handle_keyword_query(plugins: list[Plugin], query: str, current_version: str
                 plugin, current_platform, current_version
             )
 
-            is_installed = is_plugin_installed(plugin.name)
+            installed_record = find_installed_matching(plugin)
             is_upgradable = False
-            existing_version = None
-            if is_installed:
-                existing_plugin_path = get_plugin_directory(plugin.name)
-                existing_metadata = get_metadata_from_plugin_directory(existing_plugin_path)
-                existing_version = existing_metadata.plugin.version
+            existing_version: str | None = None
+            if installed_record is not None:
+                existing_version = installed_record.version
                 if parse_plugin_version(latest_compatible_metadata.plugin.version) > parse_plugin_version(
                     existing_version
                 ):
@@ -250,7 +256,7 @@ def handle_keyword_query(plugins: list[Plugin], query: str, current_version: str
             status = ""
             if is_upgradable:
                 status = f"[yellow]upgradable[/yellow] from {existing_version}"
-            elif is_installed:
+            elif installed_record is not None:
                 status = "installed"
 
             table.add_row(
@@ -264,6 +270,11 @@ def handle_keyword_query(plugins: list[Plugin], query: str, current_version: str
 
     if not plugins:
         console.print("[grey69]No plugins found[/grey69]")
+
+
+def _has_exact_name_match(plugins: list[Plugin], name: str) -> bool:
+    wanted = name.lower()
+    return any(p.name.lower() == wanted for p in plugins)
 
 
 @click.command()
@@ -282,13 +293,39 @@ def search_plugins(ctx, query: str | None = None) -> None:
         plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
         plugins: list[Plugin] = plugin_repo.get_plugins()
 
-        if is_plugin_name_query(plugins, query or ""):
-            handle_plugin_name_query(plugins, query or "", current_version, current_platform)
+        if not query:
+            handle_keyword_query(plugins, "", current_version, current_platform)
+            return
 
-        elif is_plugin_spec_query(plugins, query or ""):
-            handle_plugin_spec_query(plugins, query or "", current_version, current_platform)
-        else:
-            handle_keyword_query(plugins, query or "", current_version, current_platform)
+        # Try to parse the query as a qualified reference. If parsing fails
+        # (malformed version spec, etc.) fall back to keyword search so the
+        # substring path continues to work for unusual user input.
+        try:
+            ref = parse_plugin_reference(query)
+        except ValueError:
+            handle_keyword_query(plugins, query, current_version, current_platform)
+            return
+
+        # A qualified query (with a host) is always an exact plugin query.
+        # An unqualified query is only an exact plugin query if it exactly
+        # matches a known bare name case-insensitively; otherwise fall back
+        # to keyword/substring search.
+        if ref.host is None and not _has_exact_name_match(plugins, ref.name):
+            handle_keyword_query(plugins, query, current_version, current_platform)
+            return
+
+        try:
+            if ref.version_spec:
+                handle_plugin_spec_query(plugins, ref, current_version, current_platform)
+            else:
+                handle_plugin_name_query(plugins, ref, current_version, current_platform)
+        except AmbiguousPluginReferenceError as e:
+            # ``get_plugin_by_name`` does not know the user's version spec;
+            # attach it here so candidate suggestions render ``name==1.2.3@repo``.
+            if ref.version_spec and not e.version_spec:
+                e = AmbiguousPluginReferenceError(e.name, e.candidates, ref.version_spec)
+            render_ambiguity_error(e)
+            raise click.Abort()
 
     except MissingCurrentInstallationDirectory:
         explain_missing_current_installation_directory(console)
@@ -297,6 +334,9 @@ def search_plugins(ctx, query: str | None = None) -> None:
     except FailedToDetectIDAVersion:
         explain_failed_to_detect_ida_version(console)
         raise click.Abort()
+
+    except click.Abort:
+        raise
 
     except Exception as e:
         logger.debug("error: %s", e, exc_info=True)

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -107,8 +107,8 @@ def render_ambiguity_error(err: AmbiguousPluginReferenceError) -> None:
     """Render the user-facing message for an ambiguous bare-name query."""
     console.print(f"[red]Error[/red]: plugin name '{err.name}' is ambiguous")
     console.print("Choose one of:")
-    for candidate_name, candidate_host in err.candidates:
-        console.print(f"  {format_qualified_plugin_reference((candidate_name, err.version_spec, candidate_host))}")
+    for ref in err.candidate_refs:
+        console.print(f"  {format_qualified_plugin_reference(ref)}")
 
 
 def output_plugin_metadata(metadata) -> None:

--- a/src/hcli/commands/plugin/status.py
+++ b/src/hcli/commands/plugin/status.py
@@ -17,10 +17,11 @@ from hcli.lib.ida import (
     find_current_ida_version,
 )
 from hcli.lib.ida.plugin import parse_plugin_version
+from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError
 from hcli.lib.ida.plugin.install import (
     get_installed_legacy_plugins,
     get_installed_minimal_plugins,
-    get_installed_plugins,
+    get_installed_plugin_records,
     get_plugins_directory,
 )
 from hcli.lib.ida.plugin.repo import BasePluginRepo
@@ -42,16 +43,26 @@ def get_plugin_status(ctx) -> None:
         table.add_column("version", style="default")
         table.add_column("status")
 
-        for name, version in get_installed_plugins():
+        for record in get_installed_plugin_records():
             status = ""
             try:
-                location = plugin_repo.find_compatible_plugin_from_spec(name, current_platform, current_ida_version)
-                if parse_plugin_version(location.metadata.plugin.version) > parse_plugin_version(version):
+                # Anchor the repository lookup on the installed plugin's host so a
+                # colliding plugin name in the repository does not raise ambiguity
+                # or pick the wrong variant.
+                location = plugin_repo.find_compatible_plugin_from_spec(
+                    record.name, current_platform, current_ida_version, host=record.host
+                )
+                if parse_plugin_version(location.metadata.plugin.version) > parse_plugin_version(record.version):
                     status = f"upgradable to [yellow]{location.metadata.plugin.version}[/yellow]"
-            except (ValueError, KeyError):
+            except (ValueError, KeyError, AmbiguousPluginReferenceError):
+                # AmbiguousPluginReferenceError should not escape this command.
+                # The installed plugin's own metadata carries its host, so
+                # anchoring on that host above should normally resolve the
+                # collision; if it does not, treat the plugin as absent from
+                # the repository rather than crashing status.
                 status = "[yellow]not found in repository[/yellow]"
 
-            table.add_row(name, version, status)
+            table.add_row(record.name, record.version, status)
 
         has_incompatible_plugins = False
         plugin_directory = get_plugins_directory()

--- a/src/hcli/commands/plugin/upgrade.py
+++ b/src/hcli/commands/plugin/upgrade.py
@@ -16,7 +16,9 @@ from hcli.lib.ida import (
     find_current_ida_version,
 )
 from hcli.lib.ida.plugin import get_metadata_from_plugin_archive
-from hcli.lib.ida.plugin.install import upgrade_plugin_archive
+from hcli.lib.ida.plugin.exceptions import PluginNotInstalledError
+from hcli.lib.ida.plugin.install import find_installed_plugin, upgrade_plugin_archive
+from hcli.lib.ida.plugin.reference import normalize_plugin_host, parse_plugin_reference
 from hcli.lib.ida.plugin.repo import BasePluginRepo
 
 logger = logging.getLogger(__name__)
@@ -47,11 +49,39 @@ def upgrade_plugin(ctx, plugin: str, no_build_isolation: bool) -> None:
         if plugin_spec.startswith("https://"):
             raise ValueError("cannot upgrade using URL; uninstall/reinstall instead")
 
+        try:
+            ref = parse_plugin_reference(plugin_spec)
+        except ValueError as e:
+            raise click.BadParameter(f"invalid plugin reference: {plugin_spec!r}: {e}")
+
+        # Resolve the installed plugin first so we can anchor the upgrade to
+        # the repository the user currently has installed. This avoids
+        # switching repositories implicitly and also resolves the host for
+        # bare-name upgrades even when the repository has a colliding name.
+        try:
+            installed = find_installed_plugin(ref.name)
+        except PluginNotInstalledError:
+            console.print(f"[red]Error[/red]: plugin '{ref.name}' is not installed")
+            raise click.Abort()
+
+        if ref.host is not None and normalize_plugin_host(installed.host) != normalize_plugin_host(ref.host):
+            console.print(
+                f"[red]Error[/red]: installed plugin '{installed.name}' comes from {installed.host}, not {ref.host}"
+            )
+            console.print(
+                "Upgrade cannot switch repositories. Uninstall first, then install the other qualified plugin."
+            )
+            raise click.Abort()
+
+        # Anchor the lookup to the installed host regardless of whether the
+        # user supplied it. This is what makes bare-name upgrades work even
+        # when the repository has a colliding name.
+        bare_spec = ref.name + ref.version_spec
         logger.info("finding plugin in repository")
         plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
         try:
             plugin_name, buf = plugin_repo.fetch_compatible_plugin_from_spec(
-                plugin_spec, current_ida_platform, current_ida_version
+                bare_spec, current_ida_platform, current_ida_version, host=installed.host
             )
         except (httpx.ConnectError, httpx.TimeoutException):
             console.print("[red]Cannot connect to plugin repository - network unavailable.[/red]")
@@ -70,6 +100,9 @@ def upgrade_plugin(ctx, plugin: str, no_build_isolation: bool) -> None:
     except FailedToDetectIDAVersion:
         explain_failed_to_detect_ida_version(console)
         raise click.Abort()
+
+    except click.Abort:
+        raise
 
     except Exception as e:
         logger.debug("error: %s", e, exc_info=True)

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -554,6 +554,9 @@ class IDAConfigJson(BaseModel):
     paths: PathsConfig = Field(alias="Paths", default_factory=lambda: PathsConfig())
     settings: SettingsConfig = Field(alias="Settings", default_factory=lambda: SettingsConfig())
     # from plugin name to config.
+    # NOTE: keyed by bare plugin name for now. Two plugins with the same bare
+    # name but different repository URLs will share the same settings entry;
+    # revisiting this is out of scope for the initial collision fix.
     plugins: dict[str, PluginConfig] = Field(alias="Plugins", default_factory=dict)
 
 

--- a/src/hcli/lib/ida/plugin/exceptions.py
+++ b/src/hcli/lib/ida/plugin/exceptions.py
@@ -120,11 +120,15 @@ class AmbiguousPluginReferenceError(Exception):
         candidates: Sequence[tuple[str, str]],
         version_spec: str = "",
     ):
+        from hcli.lib.ida.plugin.reference import PluginReference
+
         self.name = name
-        # ``candidates`` holds (name, host) pairs; using plain tuples keeps this
-        # module free of the ``Plugin`` import (which would cause a circular import).
         self.candidates = list(candidates)
         self.version_spec = version_spec
+        self.candidate_refs: list[PluginReference] = [
+            PluginReference(name=cname, version_spec=version_spec, host=chost)
+            for cname, chost in candidates
+        ]
         super().__init__(f"ambiguous plugin reference: {name!r} matches {len(self.candidates)} plugins")
 
 

--- a/src/hcli/lib/ida/plugin/exceptions.py
+++ b/src/hcli/lib/ida/plugin/exceptions.py
@@ -126,8 +126,7 @@ class AmbiguousPluginReferenceError(Exception):
         self.candidates = list(candidates)
         self.version_spec = version_spec
         self.candidate_refs: list[PluginReference] = [
-            PluginReference(name=cname, version_spec=version_spec, host=chost)
-            for cname, chost in candidates
+            PluginReference(name=cname, version_spec=version_spec, host=chost) for cname, chost in candidates
         ]
         super().__init__(f"ambiguous plugin reference: {name!r} matches {len(self.candidates)} plugins")
 

--- a/src/hcli/lib/ida/plugin/exceptions.py
+++ b/src/hcli/lib/ida/plugin/exceptions.py
@@ -105,3 +105,51 @@ class PluginVersionDowngradeError(PluginUpgradeError):
             f"Cannot upgrade plugin '{name}': new version {new_version} "
             f"is not greater than current version {current_version}"
         )
+
+
+class AmbiguousPluginReferenceError(Exception):
+    """A bare plugin reference matches multiple repository plugins.
+
+    Commands should render this to the user along with the qualified
+    ``name@repo`` form of each candidate so the user can rerun unambiguously.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        candidates: Sequence[tuple[str, str]],
+        version_spec: str = "",
+    ):
+        self.name = name
+        # ``candidates`` holds (name, host) pairs; using plain tuples keeps this
+        # module free of the ``Plugin`` import (which would cause a circular import).
+        self.candidates = list(candidates)
+        self.version_spec = version_spec
+        super().__init__(f"ambiguous plugin reference: {name!r} matches {len(self.candidates)} plugins")
+
+
+class InstalledPluginNameConflictError(PluginInstallationError):
+    """Installing a plugin would collide with another already-installed same-name plugin.
+
+    Raised when the user asks to install ``foo@repo-a`` but ``foo@repo-b`` is
+    already installed. The install layout is ``$IDAUSR/plugins/<name>``, so
+    only one plugin with a given bare name can be installed at a time.
+    """
+
+    def __init__(
+        self,
+        requested_name: str,
+        requested_host: str,
+        installed_name: str,
+        installed_host: str,
+        installed_path: Path,
+    ):
+        self.requested_name = requested_name
+        self.requested_host = requested_host
+        self.installed_name = installed_name
+        self.installed_host = installed_host
+        self.installed_path = installed_path
+        super().__init__(
+            f"cannot install plugin '{requested_name}@{requested_host}' because "
+            f"'{installed_name}@{installed_host}' is already installed at {installed_path}"
+        )

--- a/src/hcli/lib/ida/plugin/install.py
+++ b/src/hcli/lib/ida/plugin/install.py
@@ -209,6 +209,28 @@ def get_installed_plugin_records() -> list[InstalledPluginRecord]:
     return records
 
 
+def find_installed_plugin_in(
+    records: list[InstalledPluginRecord],
+    name: str,
+    host: str | None = None,
+) -> InstalledPluginRecord | None:
+    """Search *pre-fetched* records for a plugin by name and optional host.
+
+    Returns ``None`` when no match is found (does not raise).
+    """
+    wanted_name = name.lower()
+    wanted_host = normalize_plugin_host(host) if host else None
+
+    for record in records:
+        if record.name.lower() != wanted_name:
+            continue
+        if wanted_host is not None and normalize_plugin_host(record.host) != wanted_host:
+            continue
+        return record
+
+    return None
+
+
 def find_installed_plugin(name: str, host: str | None = None) -> InstalledPluginRecord:
     """Find an installed plugin by name, optionally qualified by host.
 
@@ -219,17 +241,10 @@ def find_installed_plugin(name: str, host: str | None = None) -> InstalledPlugin
     Raises:
         PluginNotInstalledError: when no matching installed plugin exists.
     """
-    wanted_name = name.lower()
-    wanted_host = normalize_plugin_host(host) if host else None
-
-    for record in get_installed_plugin_records():
-        if record.name.lower() != wanted_name:
-            continue
-        if wanted_host is not None and normalize_plugin_host(record.host) != wanted_host:
-            continue
-        return record
-
-    raise PluginNotInstalledError(name)
+    record = find_installed_plugin_in(get_installed_plugin_records(), name, host)
+    if record is None:
+        raise PluginNotInstalledError(name)
+    return record
 
 
 def resolve_installed_plugin_directory(name: str) -> Path:

--- a/src/hcli/lib/ida/plugin/install.py
+++ b/src/hcli/lib/ida/plugin/install.py
@@ -5,6 +5,7 @@ import pathlib
 import shutil
 import tempfile
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
 
 import rich.status
@@ -39,6 +40,7 @@ from hcli.lib.ida.plugin.exceptions import (
     PluginNotInstalledError,
     PluginVersionDowngradeError,
 )
+from hcli.lib.ida.plugin.reference import normalize_plugin_host
 from hcli.lib.ida.python import (
     CantInstallPackagesError,
     does_current_ida_have_pip,
@@ -144,12 +146,39 @@ def validate_metadata_in_plugin_directory(plugin_path: Path):
             raise ValueError(f"Logo file not found in directory: '{metadata.plugin.logo_path}'")
 
 
-def get_installed_plugin_paths() -> list[Path]:
+@dataclass(frozen=True)
+class InstalledPluginRecord:
+    """An installed plugin and its on-disk metadata."""
+
+    path: Path
+    metadata: IDAMetadataDescriptor
+
+    @property
+    def name(self) -> str:
+        return self.metadata.plugin.name
+
+    @property
+    def version(self) -> str:
+        return self.metadata.plugin.version
+
+    @property
+    def host(self) -> str:
+        return self.metadata.plugin.host
+
+
+def get_installed_plugin_records() -> list[InstalledPluginRecord]:
+    """Enumerate installed plugins with their on-disk metadata.
+
+    This is the canonical source of truth for "what is installed". Other
+    helpers (``get_installed_plugins``, ``is_plugin_installed``, etc.) are
+    implemented on top of this list so they agree on what counts as
+    installed.
+    """
     plugins_dir = get_plugins_directory()
-    installed_paths: list[Path] = []
+    records: list[InstalledPluginRecord] = []
 
     if not plugins_dir.exists():
-        return installed_paths
+        return records
 
     for plugin_path in plugins_dir.iterdir():
         if not plugin_path.is_dir():
@@ -165,29 +194,63 @@ def get_installed_plugin_paths() -> list[Path]:
             logger.debug(f"Invalid plugin metadata in {plugin_path}: {e}")
             continue
 
-        metadata = get_metadata_from_plugin_directory(plugin_path)
-        if metadata.plugin.name != plugin_path.name:
-            logger.debug("plugin name and path mismatch")
-            continue
-
-        installed_paths.append(plugin_path)
-
-    return installed_paths
-
-
-def get_installed_plugins() -> list[tuple[str, str]]:
-    """fetch (name, version) pairs for currently installed plugins"""
-    installed_plugins: list[tuple[str, str]] = []
-
-    for plugin_path in get_installed_plugin_paths():
         try:
             metadata = get_metadata_from_plugin_directory(plugin_path)
-            installed_plugins.append((metadata.plugin.name, metadata.plugin.version))
         except ValueError as e:
             logger.warning(f"Failed to read metadata from {plugin_path}: {e}")
             continue
 
-    return installed_plugins
+        if metadata.plugin.name != plugin_path.name:
+            logger.debug("plugin name and path mismatch")
+            continue
+
+        records.append(InstalledPluginRecord(path=plugin_path, metadata=metadata))
+
+    return records
+
+
+def find_installed_plugin(name: str, host: str | None = None) -> InstalledPluginRecord:
+    """Find an installed plugin by name, optionally qualified by host.
+
+    Name matching is case-insensitive because the user may type a different
+    case than the on-disk directory. Host matching, when supplied, is done
+    after normalization.
+
+    Raises:
+        PluginNotInstalledError: when no matching installed plugin exists.
+    """
+    wanted_name = name.lower()
+    wanted_host = normalize_plugin_host(host) if host else None
+
+    for record in get_installed_plugin_records():
+        if record.name.lower() != wanted_name:
+            continue
+        if wanted_host is not None and normalize_plugin_host(record.host) != wanted_host:
+            continue
+        return record
+
+    raise PluginNotInstalledError(name)
+
+
+def resolve_installed_plugin_directory(name: str) -> Path:
+    """Resolve the on-disk directory for an installed plugin by name.
+
+    Case-insensitive. Used by local commands (uninstall, config) so typing
+    ``PLUGIN1`` finds ``$IDAUSR/plugins/plugin1``.
+
+    Raises:
+        PluginNotInstalledError: when no matching installed plugin exists.
+    """
+    return find_installed_plugin(name).path
+
+
+def get_installed_plugin_paths() -> list[Path]:
+    return [r.path for r in get_installed_plugin_records()]
+
+
+def get_installed_plugins() -> list[tuple[str, str]]:
+    """fetch (name, version) pairs for currently installed plugins"""
+    return [(r.name, r.version) for r in get_installed_plugin_records()]
 
 
 def get_installed_minimal_plugins() -> list[tuple[Path, MinimalIDAPluginMetadata]]:
@@ -523,32 +586,31 @@ def validate_can_uninstall_plugin(name: str) -> None:
     Raises:
         PluginNotInstalledError: If plugin is not installed
     """
-    if name not in [name for (name, _version) in get_installed_plugins()]:
-        logger.warning(f"Plugin directory not installed: {name}")
-        raise PluginNotInstalledError(name)
+    # find_installed_plugin raises PluginNotInstalledError when no match; name
+    # matching is case-insensitive.
+    find_installed_plugin(name)
 
 
 def uninstall_plugin(name: str):
     # NOTE: keep this in sync with upgrade (checkpoint/rollback) which has an inlined copy.
 
-    validate_can_uninstall_plugin(name)
-
-    plugin_path = get_plugin_directory(name)
-    metadata = get_metadata_from_plugin_directory(plugin_path)
-    logger.info("uninstalling plugin: %s (%s)", name, metadata.plugin.version)
+    record = find_installed_plugin(name)
+    logger.info("uninstalling plugin: %s (%s)", record.name, record.version)
 
     # note that the pythonDependencies of the plugin aren't pruned.
     # we could re-collect all the deps requested by other plugins
     # but we shouldn't do a sync, since there might be other utils installed by the user.
     # so I think its better to just leave the orphans around.
 
-    shutil.rmtree(plugin_path)
+    shutil.rmtree(record.path)
 
 
 def is_plugin_installed(name: str) -> bool:
-    installed_plugins = [name for (name, _version) in get_installed_plugins()]
-    logger.debug("installed plugins: %s", installed_plugins)
-    return name in installed_plugins
+    try:
+        find_installed_plugin(name)
+    except PluginNotInstalledError:
+        return False
+    return True
 
 
 def validate_can_upgrade_plugin(

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -50,10 +50,11 @@ class PluginReference:
 def is_github_repository_url(value: str) -> bool:
     """Return True if ``value`` is a whole-string GitHub repository URL.
 
-    This differs from ``repo/github.py:is_github_url`` which only checks
-    whether ``github.com/`` appears somewhere in the string. A qualified
-    plugin reference like ``foo@https://github.com/org/repo`` must parse as
-    a reference, not a raw URL, so we use a strict whole-string match here.
+    This is stricter than ``is_github_direct_install_url``: it only accepts
+    plain repository URLs and rejects direct-install variants such as
+    ``.git`` suffixes or ``@tag`` qualifiers. A qualified plugin reference
+    like ``foo@https://github.com/org/repo`` must parse as a reference, not
+    a raw URL, so we use a strict whole-string match here.
     """
     return bool(_GITHUB_REPO_RE.match(value))
 

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -50,11 +50,10 @@ class PluginReference:
 def is_github_repository_url(value: str) -> bool:
     """Return True if ``value`` is a whole-string GitHub repository URL.
 
-    This is stricter than ``is_github_direct_install_url``: it only accepts
-    plain repository URLs and rejects direct-install variants such as
-    ``.git`` suffixes or ``@tag`` qualifiers. A qualified plugin reference
-    like ``foo@https://github.com/org/repo`` must parse as a reference, not
-    a raw URL, so we use a strict whole-string match here.
+    This differs from ``repo/github.py:is_github_url`` which only checks
+    whether ``github.com/`` appears somewhere in the string. A qualified
+    plugin reference like ``foo@https://github.com/org/repo`` must parse as
+    a reference, not a raw URL, so we use a strict whole-string match here.
     """
     return bool(_GITHUB_REPO_RE.match(value))
 
@@ -163,9 +162,15 @@ def parse_plugin_reference(value: str) -> PluginReference:
     remaining = value
     if "@" in value:
         left, _, right = value.rpartition("@")
-        if is_github_repository_url(right):
-            host = normalize_plugin_host(right)
-            remaining = left
+        if not is_github_repository_url(right):
+            raise ValueError(
+                f"plugin reference has an '@' but the suffix is not a valid GitHub repository URL: {value!r}"
+            )
+        host = normalize_plugin_host(right)
+        remaining = left
+
+    if "@" in remaining:
+        raise ValueError(f"plugin reference name/version must not contain '@': {value!r}")
 
     name, version_spec = _split_name_and_version(remaining)
     if not name:

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -23,6 +23,14 @@ from urllib.parse import urlparse
 # ``src/hcli/lib/ida/plugin/__init__.py``). Trailing slash optional.
 _GITHUB_REPO_RE = re.compile(r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/?$", re.IGNORECASE)
 
+# broader match that also accepts ``.git`` suffix and ``@tag`` for direct
+# installs (e.g. ``https://github.com/org/repo.git@v1.0``).
+_GITHUB_DIRECT_INSTALL_RE = re.compile(
+    r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+"
+    r"(?:\.git)?(?:@[a-zA-Z0-9._/+-]+)?/?$",
+    re.IGNORECASE,
+)
+
 
 @dataclass(frozen=True)
 class PluginReference:
@@ -48,6 +56,23 @@ def is_github_repository_url(value: str) -> bool:
     a reference, not a raw URL, so we use a strict whole-string match here.
     """
     return bool(_GITHUB_REPO_RE.match(value))
+
+
+def is_github_direct_install_url(value: str) -> bool:
+    """Return True if ``value`` is a GitHub URL suitable for direct installation.
+
+    Accepts the same shapes as ``is_github_repository_url`` plus ``.git``
+    suffix and ``@tag`` for tagged releases::
+
+        https://github.com/org/repo
+        https://github.com/org/repo.git
+        https://github.com/org/repo@v1.0
+        https://github.com/org/repo.git@v1.0
+
+    Does NOT match qualified plugin references (``name@https://...``)
+    because those don't start with ``https://``.
+    """
+    return bool(_GITHUB_DIRECT_INSTALL_RE.match(value))
 
 
 def normalize_plugin_host(host: str) -> str:
@@ -130,9 +155,8 @@ def parse_plugin_reference(value: str) -> PluginReference:
     if not value:
         raise ValueError("plugin reference is empty")
 
-    if is_github_repository_url(value):
-        # the whole string is a raw GitHub URL, not a plugin reference
-        raise ValueError(f"value is a raw GitHub URL, not a plugin reference: {value!r}")
+    if is_github_direct_install_url(value):
+        raise ValueError(f"value is a GitHub URL, not a plugin reference: {value!r}")
 
     host: str | None = None
     remaining = value

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -1,0 +1,176 @@
+"""Parsing and normalization helpers for plugin references.
+
+A plugin reference is a user-supplied string that names a plugin and may
+optionally qualify it with a version spec and/or a repository URL (host).
+
+Accepted forms:
+    name
+    name==1.2.3
+    name@https://github.com/org/repo
+    name==1.2.3@https://github.com/org/repo
+
+The module is intentionally free of Click/Rich so it can be unit tested easily.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+# whole-string match for a GitHub repository URL in the shape allowed by
+# ``ida-plugin.json`` (see ``URLs.validate_github_url`` in
+# ``src/hcli/lib/ida/plugin/__init__.py``). Trailing slash optional.
+_GITHUB_REPO_RE = re.compile(r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/?$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class PluginReference:
+    """A parsed plugin reference.
+
+    Attributes:
+        name: bare plugin name.
+        version_spec: version specifier with operator (``"==1.2.3"``), or ``""`` when absent.
+        host: normalized repository URL, or ``None`` when unqualified.
+    """
+
+    name: str
+    version_spec: str
+    host: str | None
+
+
+def is_github_repository_url(value: str) -> bool:
+    """Return True if ``value`` is a whole-string GitHub repository URL.
+
+    This differs from ``repo/github.py:is_github_url`` which only checks
+    whether ``github.com/`` appears somewhere in the string. A qualified
+    plugin reference like ``foo@https://github.com/org/repo`` must parse as
+    a reference, not a raw URL, so we use a strict whole-string match here.
+    """
+    return bool(_GITHUB_REPO_RE.match(value))
+
+
+def normalize_plugin_host(host: str) -> str:
+    """Normalize a plugin repository URL for comparison.
+
+    The normalization:
+    - lowercases scheme, netloc, and path;
+    - strips exactly one trailing slash from the path.
+
+    Args:
+        host: repository URL string, for example ``https://GitHub.com/Org/Repo/``.
+
+    Returns:
+        normalized URL string, for example ``https://github.com/org/repo``.
+
+    Raises:
+        ValueError: when ``host`` cannot be parsed as an absolute URL with scheme and netloc.
+    """
+    parsed = urlparse(host)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"invalid plugin host URL: {host!r}")
+
+    scheme = parsed.scheme.lower()
+    netloc = parsed.netloc.lower()
+    path = parsed.path.lower()
+    path = path.removesuffix("/")
+
+    return f"{scheme}://{netloc}{path}"
+
+
+def _split_name_and_version(value: str) -> tuple[str, str]:
+    """Split ``name[op version]`` into ``(name, version_spec)``.
+
+    Returns ``(value, "")`` when there's no version spec. The version spec is
+    returned including the operator (``"==1.2.3"``) so callers can round-trip
+    the original syntax.
+
+    Raises:
+        ValueError: when the operator looks malformed (e.g. trailing ``=``
+            without another character).
+    """
+    # look for the first operator char
+    match = re.search(r"[=><!~]", value)
+    if not match:
+        return value, ""
+
+    op_start = match.start()
+    name = value[:op_start]
+    op_chars = value[op_start : op_start + 2]
+    if len(op_chars) < 2 or op_chars[1] != "=":
+        raise ValueError(f"invalid plugin version spec: {value!r}")
+
+    # operator + remaining characters (the version string)
+    version_spec = value[op_start:]
+    return name, version_spec
+
+
+def parse_plugin_reference(value: str) -> PluginReference:
+    """Parse a plugin reference string.
+
+    Supported forms:
+        name
+        name==1.2.3
+        name@https://github.com/org/repo
+        name==1.2.3@https://github.com/org/repo
+
+    The version operator, when present, appears before the ``@repo`` suffix.
+    The repository suffix is detected by splitting on the last ``@`` and
+    checking whether the suffix is a whole-string GitHub repository URL.
+    A string that is itself a raw GitHub repository URL is NOT treated as a
+    plugin reference and raises ``ValueError``.
+
+    Returns:
+        a ``PluginReference`` with ``host`` normalized when present.
+
+    Raises:
+        ValueError: when the string cannot be parsed (empty name, malformed
+            operator, etc.).
+    """
+    if not value:
+        raise ValueError("plugin reference is empty")
+
+    if is_github_repository_url(value):
+        # the whole string is a raw GitHub URL, not a plugin reference
+        raise ValueError(f"value is a raw GitHub URL, not a plugin reference: {value!r}")
+
+    host: str | None = None
+    remaining = value
+    if "@" in value:
+        left, _, right = value.rpartition("@")
+        if is_github_repository_url(right):
+            host = normalize_plugin_host(right)
+            remaining = left
+
+    name, version_spec = _split_name_and_version(remaining)
+    if not name:
+        raise ValueError(f"plugin reference has empty name: {value!r}")
+
+    return PluginReference(name=name, version_spec=version_spec, host=host)
+
+
+def format_qualified_plugin_reference(
+    ref: PluginReference | tuple[str, str, str | None],
+) -> str:
+    """Render a plugin reference in its canonical user-facing string form.
+
+    Formats:
+        name@repo
+        name==1.2.3@repo
+
+    The ``host`` must be provided for the output to be useful; callers that
+    only have a bare name/version don't need this helper.
+    """
+    if isinstance(ref, PluginReference):
+        name, version_spec, host = ref.name, ref.version_spec, ref.host
+    else:
+        name, version_spec, host = ref
+
+    if not host:
+        if version_spec:
+            return f"{name}{version_spec}"
+        return name
+
+    if version_spec:
+        return f"{name}{version_spec}@{host}"
+    return f"{name}@{host}"

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -149,28 +149,18 @@ def parse_plugin_reference(value: str) -> PluginReference:
     return PluginReference(name=name, version_spec=version_spec, host=host)
 
 
-def format_qualified_plugin_reference(
-    ref: PluginReference | tuple[str, str, str | None],
-) -> str:
+def format_qualified_plugin_reference(ref: PluginReference) -> str:
     """Render a plugin reference in its canonical user-facing string form.
 
     Formats:
         name@repo
         name==1.2.3@repo
-
-    The ``host`` must be provided for the output to be useful; callers that
-    only have a bare name/version don't need this helper.
     """
-    if isinstance(ref, PluginReference):
-        name, version_spec, host = ref.name, ref.version_spec, ref.host
-    else:
-        name, version_spec, host = ref
+    if not ref.host:
+        if ref.version_spec:
+            return f"{ref.name}{ref.version_spec}"
+        return ref.name
 
-    if not host:
-        if version_spec:
-            return f"{name}{version_spec}"
-        return name
-
-    if version_spec:
-        return f"{name}{version_spec}@{host}"
-    return f"{name}@{host}"
+    if ref.version_spec:
+        return f"{ref.name}{ref.version_spec}@{ref.host}"
+    return f"{ref.name}@{ref.host}"

--- a/src/hcli/lib/ida/plugin/repo/__init__.py
+++ b/src/hcli/lib/ida/plugin/repo/__init__.py
@@ -20,6 +20,8 @@ from hcli.lib.ida.plugin import (
     split_plugin_version_spec,
     validate_metadata_in_plugin_archive,
 )
+from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError
+from hcli.lib.ida.plugin.reference import normalize_plugin_host
 from hcli.lib.util.logging import m
 
 logger = logging.getLogger(__name__)
@@ -104,27 +106,40 @@ def get_latest_compatible_plugin_metadata(
 
 
 def get_plugin_by_name(plugins: list[Plugin], name: str, host: str | None = None) -> Plugin:
+    """Find a plugin by name and, optionally, host.
+
+    Name matching is case-insensitive. Host matching, when supplied, uses
+    normalized URL comparison so trailing-slash and casing differences do
+    not prevent a match.
+
+    Raises:
+        KeyError: when no matching plugin exists.
+        AmbiguousPluginReferenceError: when the bare name matches multiple
+            plugins and no host was provided to disambiguate.
+    """
+    wanted_name = name.lower()
     if host:
-        plugins = [
-            plugin for plugin in plugins if plugin.name.lower() == name.lower() and plugin.host.lower() == host.lower()
+        normalized_host = normalize_plugin_host(host)
+        matches = [
+            plugin
+            for plugin in plugins
+            if plugin.name.lower() == wanted_name and normalize_plugin_host(plugin.host) == normalized_host
         ]
     else:
-        plugins = [plugin for plugin in plugins if plugin.name.lower() == name.lower()]
+        matches = [plugin for plugin in plugins if plugin.name.lower() == wanted_name]
 
-    if not plugins:
+    if not matches:
         raise KeyError(f"plugin not found: {name}")
 
-    if len(plugins) > 1:
-        logger.debug("found plugin:")
-        for plugin in plugins:
+    if len(matches) > 1:
+        logger.debug("ambiguous plugin reference, found matches:")
+        for plugin in matches:
             logger.debug("  - %s (%s)", plugin.name, plugin.host)
 
-        # this needs to be implemented.
-        # callers should handle this nicely and then provide host.
-        # but nobody does this today.
-        raise NotImplementedError(f"colliding plugin name: {name}")
+        candidates = [(plugin.name, plugin.host) for plugin in matches]
+        raise AmbiguousPluginReferenceError(name, candidates)
 
-    return plugins[0]
+    return matches[0]
 
 
 class BasePluginRepo(ABC):
@@ -172,7 +187,7 @@ class BasePluginRepo(ABC):
         raise KeyError(f"plugin not found: {plugin_spec}")
 
     def fetch_compatible_plugin_from_spec(
-        self, plugin_spec: str, current_platform: str, current_version: str
+        self, plugin_spec: str, current_platform: str, current_version: str, host: str | None = None
     ) -> tuple[str, bytes]:
         """Fetch compatible plugin from spec with SHA256 verification.
 
@@ -180,12 +195,13 @@ class BasePluginRepo(ABC):
             plugin_spec: Plugin specification (e.g., "plugin1", "plugin1==1.0.0")
             current_platform: Current IDA platform (e.g., "macos-aarch64")
             current_version: Current IDA version (e.g., "9.1")
+            host: optional repository URL to disambiguate colliding plugin names.
 
         Returns:
             Tuple of (actual_plugin_name, plugin_archive_bytes).
             The plugin name returned uses the correct casing from the metadata.
         """
-        location = self.find_compatible_plugin_from_spec(plugin_spec, current_platform, current_version)
+        location = self.find_compatible_plugin_from_spec(plugin_spec, current_platform, current_version, host=host)
         plugin_name = location.metadata.plugin.name
         logger.debug("plugin name: %s", plugin_name)
         buf = fetch_plugin_archive(location.url)
@@ -260,7 +276,7 @@ class PluginArchiveIndex:
             platforms = frozenset(metadata.plugin.platforms)
             spec = (ida_versions, platforms)
 
-            if expected_host and expected_host.lower() != host.lower():
+            if expected_host and normalize_plugin_host(expected_host) != normalize_plugin_host(host):
                 logger.debug(m("host mismatch: %s: %s versus expected %s", name, host, expected_host, **context))
                 continue
 

--- a/src/hcli/lib/ida/plugin/repo/__init__.py
+++ b/src/hcli/lib/ida/plugin/repo/__init__.py
@@ -271,12 +271,13 @@ class PluginArchiveIndex:
 
             name = metadata.plugin.name
             host = metadata.plugin.host
+            normalized_host = normalize_plugin_host(host)
             version = metadata.plugin.version
             ida_versions = frozenset(metadata.plugin.ida_versions)
             platforms = frozenset(metadata.plugin.platforms)
             spec = (ida_versions, platforms)
 
-            if expected_host and normalize_plugin_host(expected_host) != normalize_plugin_host(host):
+            if expected_host and normalize_plugin_host(expected_host) != normalized_host:
                 logger.debug(m("host mismatch: %s: %s versus expected %s", name, host, expected_host, **context))
                 continue
 
@@ -293,7 +294,7 @@ class PluginArchiveIndex:
                 )
             )
 
-            versions = self.index[(name.lower(), host.lower())]
+            versions = self.index[(name.lower(), normalized_host)]
             specs = versions[version]
             specs[spec].append((url, sha256, metadata))
 
@@ -322,7 +323,6 @@ class PluginArchiveIndex:
                         )
                         locations_by_version[version].append(location)
                         display_name = metadata.plugin.name
-                        display_host = metadata.plugin.host
 
             plugin = Plugin(name=display_name, host=display_host, versions=locations_by_version)
             ret.append(plugin)

--- a/src/hcli/lib/ida/plugin/repo/github.py
+++ b/src/hcli/lib/ida/plugin/repo/github.py
@@ -27,21 +27,34 @@ MAX_DOWNLOAD_SIZE = 100 * 1024 * 1024
 GITHUB_API_URL = "https://api.github.com"
 
 
-def parse_github_url(url: str) -> tuple[str, str]:
-    """Parse a direct-install GitHub repository URL into ``(owner, repo)``.
+def parse_github_url(url: str) -> tuple[str, str, str | None]:
+    """Parse a direct-install GitHub URL into ``(owner, repo, tag)``.
+
+    Supports::
+
+        https://github.com/owner/repo
+        https://github.com/owner/repo/
+        https://github.com/owner/repo.git
+        https://github.com/owner/repo@tag
+        https://github.com/owner/repo.git@tag
 
     Raises:
-        ValueError: when ``url`` is not an ``https://github.com/owner/repo`` URL.
+        ValueError: when ``url`` is not an HTTPS GitHub repository URL.
     """
+    tag: str | None = None
+    if "@" in url:
+        url, tag = url.rsplit("@", 1)
+
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
         raise ValueError(f"Invalid GitHub URL: {url}")
 
-    parts = [part for part in parsed.path.split("/") if part]
+    path = parsed.path.lstrip("/").removesuffix(".git")
+    parts = [part for part in path.split("/") if part]
     if len(parts) != 2:
         raise ValueError(f"Invalid GitHub URL: {url}")
 
-    return parts[0], parts[1]
+    return parts[0], parts[1], tag
 
 
 def fetch_github_release_zip_asset(owner: str, repo: str, tag: str | None = None) -> bytes:

--- a/src/hcli/lib/ida/plugin/repo/github.py
+++ b/src/hcli/lib/ida/plugin/repo/github.py
@@ -43,7 +43,11 @@ def parse_github_url(url: str) -> tuple[str, str, str | None]:
     """
     tag: str | None = None
     if "@" in url:
-        url, tag = url.rsplit("@", 1)
+        url, raw_tag = url.rsplit("@", 1)
+        raw_tag = raw_tag.rstrip("/")
+        if not raw_tag:
+            raise ValueError(f"Invalid GitHub URL: empty tag after '@': {url}")
+        tag = raw_tag
 
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":

--- a/src/hcli/lib/ida/plugin/repo/github.py
+++ b/src/hcli/lib/ida/plugin/repo/github.py
@@ -1,7 +1,6 @@
 import functools
 import json
 import logging
-import re
 import time
 import urllib.error
 import urllib.parse
@@ -28,55 +27,21 @@ MAX_DOWNLOAD_SIZE = 100 * 1024 * 1024
 GITHUB_API_URL = "https://api.github.com"
 
 
-def is_github_url(url: str) -> bool:
-    """Check if URL is a GitHub repository URL."""
-    return "github.com/" in url or url.startswith("git@github.com:")
+def parse_github_url(url: str) -> tuple[str, str]:
+    """Parse a direct-install GitHub repository URL into ``(owner, repo)``.
 
-
-def parse_github_url(url: str) -> tuple[str, str, str | None]:
-    """Parse GitHub URL into (owner, repo, tag).
-
-    Supports:
-    - https://github.com/owner/repo
-    - https://github.com/owner/repo.git
-    - https://github.com/owner/repo@tag
-    - git@github.com:owner/repo.git
-    - git@github.com:owner/repo.git@tag
+    Raises:
+        ValueError: when ``url`` is not an ``https://github.com/owner/repo`` URL.
     """
-    # Extract optional @tag suffix
-    tag: str | None = None
-    if "@" in url:
-        # Handle git@ prefix separately
-        if url.startswith("git@"):
-            # git@github.com:owner/repo.git@tag
-            parts = url.split(
-                "@", 2
-            )  # ['git', 'github.com:owner/repo.git', 'tag'] or ['git', 'github.com:owner/repo.git']
-            if len(parts) == 3:
-                tag = parts[2]
-                url = f"git@{parts[1]}"
-        else:
-            # https://github.com/owner/repo@tag
-            url, tag = url.rsplit("@", 1)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
+        raise ValueError(f"Invalid GitHub URL: {url}")
 
-    # Parse the URL to get owner/repo
-    if url.startswith("git@"):
-        # git@github.com:owner/repo.git
-        match = re.match(r"git@github\.com:([^/]+)/(.+?)(?:\.git)?$", url)
-        if not match:
-            raise ValueError(f"Invalid GitHub SSH URL: {url}")
-        owner, repo = match.groups()
-    else:
-        # https://github.com/owner/repo(.git)
-        parsed = urllib.parse.urlparse(url)
-        path = parsed.path.lstrip("/")
-        path = path.removesuffix(".git")
-        parts = path.split("/")
-        if len(parts) < 2:
-            raise ValueError(f"Invalid GitHub URL: {url}")
-        owner, repo = parts[0], parts[1]
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) != 2:
+        raise ValueError(f"Invalid GitHub URL: {url}")
 
-    return owner, repo, tag
+    return parts[0], parts[1]
 
 
 def fetch_github_release_zip_asset(owner: str, repo: str, tag: str | None = None) -> bytes:

--- a/src/hcli/lib/ida/plugin/settings.py
+++ b/src/hcli/lib/ida/plugin/settings.py
@@ -4,9 +4,26 @@ from pathlib import Path
 
 from hcli.lib.ida import PluginConfig, get_ida_config, set_ida_config
 from hcli.lib.ida.plugin import ChoiceValueError, PluginSettingDescriptor
-from hcli.lib.ida.plugin.install import get_metadata_from_plugin_directory, get_plugin_directory, get_plugins_directory
+from hcli.lib.ida.plugin.install import (
+    find_installed_plugin,
+    get_metadata_from_plugin_directory,
+    get_plugin_directory,
+    get_plugins_directory,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_installed_plugin_name(plugin_name: str) -> str:
+    """Return the canonical name of the installed plugin matching ``plugin_name``.
+
+    Settings are keyed by bare plugin name in ida-config.json, so we standardize
+    on the canonical casing from the installed plugin's metadata.
+
+    Raises:
+        PluginNotInstalledError: when no matching installed plugin exists.
+    """
+    return find_installed_plugin(plugin_name).name
 
 
 def parse_setting_value(descriptor: PluginSettingDescriptor, string_value: str) -> str | bool:
@@ -33,6 +50,7 @@ def parse_setting_value(descriptor: PluginSettingDescriptor, string_value: str) 
 
 
 def set_plugin_setting(plugin_name: str, key: str, value: str | bool):
+    plugin_name = _resolve_installed_plugin_name(plugin_name)
     plugin_path = get_plugin_directory(plugin_name)
     metadata = get_metadata_from_plugin_directory(plugin_path)
     descr = metadata.plugin.get_setting(key)
@@ -66,6 +84,7 @@ def set_plugin_setting(plugin_name: str, key: str, value: str | bool):
 
 
 def get_plugin_setting(plugin_name: str, key: str) -> str | bool:
+    plugin_name = _resolve_installed_plugin_name(plugin_name)
     plugin_path = get_plugin_directory(plugin_name)
     metadata = get_metadata_from_plugin_directory(plugin_path)
     descr = metadata.plugin.get_setting(key)
@@ -99,6 +118,7 @@ def get_plugin_setting(plugin_name: str, key: str) -> str | bool:
 
 
 def del_plugin_setting(plugin_name: str, key: str):
+    plugin_name = _resolve_installed_plugin_name(plugin_name)
     plugin_path = get_plugin_directory(plugin_name)
     metadata = get_metadata_from_plugin_directory(plugin_path)
     descr = metadata.plugin.get_setting(key)
@@ -129,6 +149,7 @@ def has_plugin_setting(plugin_name: str, key: str) -> bool:
 
     Returns: True if the setting is explicitly set, False otherwise
     """
+    plugin_name = _resolve_installed_plugin_name(plugin_name)
     plugin_path = get_plugin_directory(plugin_name)
     metadata = get_metadata_from_plugin_directory(plugin_path)
     metadata.plugin.get_setting(key)

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -250,6 +250,87 @@ def test_install_qualified_name_succeeds(tmp_path, virtual_ida_environment):
     assert is_plugin_installed("shared")
 
 
+def _build_colliding_repo_dir_with_v2(tmp_path: Path) -> Path:
+    """Colliding repo where org-a also publishes a newer version available to upgrade to."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    src = PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip"
+    # two versions of shared@org-a: v1.0.0 (installable first) and v3.0.0 (upgrade target)
+    make_plugin_zip(
+        src,
+        repo_dir / "shared-a-v1.zip",
+        new_name="shared",
+        new_version="1.0.0",
+        new_repository="https://github.com/org-a/shared",
+    )
+    make_plugin_zip(
+        src,
+        repo_dir / "shared-a-v3.zip",
+        new_name="shared",
+        new_version="3.0.0",
+        new_repository="https://github.com/org-a/shared",
+    )
+    # and one version of shared@org-b to force name-only ambiguity in the repo
+    make_plugin_zip(
+        src,
+        repo_dir / "shared-b-v1.zip",
+        new_name="shared",
+        new_version="2.0.0",
+        new_repository="https://github.com/org-b/shared",
+    )
+    return repo_dir
+
+
+def test_upgrade_bare_name_uses_installed_host(tmp_path, virtual_ida_environment):
+    """`plugin upgrade <bare-name>` anchors on the installed plugin's host."""
+    repo_dir = _build_colliding_repo_dir_with_v2(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+
+    # install v1.0.0 of shared@org-a
+    result = runner.invoke(
+        plugin_group,
+        ["--repo", str(repo_dir), "install", "shared==1.0.0@https://github.com/org-a/shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    # now upgrade by bare name — should pick v3.0.0 from org-a, not the v2.0.0 from org-b
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "upgrade", "shared"])
+    assert result.exit_code == 0, result.output
+    assert "3.0.0" in result.output
+
+
+def test_upgrade_host_mismatch_fails(tmp_path, virtual_ida_environment):
+    """Upgrade must not switch an installed plugin from one repository to another."""
+    repo_dir = _build_colliding_repo_dir_with_v2(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+
+    # install shared@org-a v1.0.0
+    result = runner.invoke(
+        plugin_group,
+        ["--repo", str(repo_dir), "install", "shared==1.0.0@https://github.com/org-a/shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    # try to "upgrade" by pointing at org-b — should fail with a repo-switch error
+    result = runner.invoke(
+        plugin_group,
+        ["--repo", str(repo_dir), "upgrade", "shared@https://github.com/org-b/shared"],
+    )
+    assert result.exit_code != 0
+    assert "comes from https://github.com/org-a/shared" in result.output
+    assert "Upgrade cannot switch repositories" in result.output
+
+
+def test_upgrade_not_installed_fails(tmp_path, virtual_ida_environment):
+    """Upgrade must fail cleanly when the plugin is not installed."""
+    repo_dir = _build_colliding_repo_dir_with_v2(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "upgrade", "shared"])
+    assert result.exit_code != 0
+    assert "not installed" in result.output
+
+
 def test_install_same_name_conflict(tmp_path, virtual_ida_environment):
     """Installing a same-name plugin from another repository must fail with a conflict error."""
     repo_dir = _build_colliding_repo_dir(tmp_path)

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -6,8 +6,11 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
+from fixtures import *
 from fixtures import PLUGINS_DIR
 
+from hcli.commands.plugin import plugin as plugin_group
 from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError
 from hcli.lib.ida.plugin.repo import PluginArchiveIndex, get_plugin_by_name
 
@@ -134,3 +137,85 @@ def test_get_plugin_by_name_is_case_insensitive(tmp_path):
 
     plugin = get_plugin_by_name(index.get_plugins(), "foo")
     assert plugin.name == "Foo"
+
+
+def _build_colliding_repo_dir(tmp_path: Path) -> Path:
+    """Write two colliding-name plugin zips into a repo directory."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    src = PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip"
+    make_plugin_zip(
+        src,
+        repo_dir / "shared-a.zip",
+        new_name="shared",
+        new_version="1.0.0",
+        new_repository="https://github.com/org-a/shared",
+    )
+    make_plugin_zip(
+        src,
+        repo_dir / "shared-b.zip",
+        new_name="shared",
+        new_version="2.0.0",
+        new_repository="https://github.com/org-b/shared",
+    )
+    return repo_dir
+
+
+def test_search_ambiguous_exact_name_renders_candidates(tmp_path, virtual_ida_environment):
+    """`plugin search <bare-name>` on an ambiguous name prints candidates and aborts."""
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "search", "shared"])
+
+    assert result.exit_code != 0
+    assert "plugin name 'shared' is ambiguous" in result.output
+    assert "Choose one of:" in result.output
+    assert "shared@https://github.com/org-a/shared" in result.output
+    assert "shared@https://github.com/org-b/shared" in result.output
+
+
+def test_search_ambiguous_version_spec_preserves_version(tmp_path, virtual_ida_environment):
+    """Candidate suggestions must keep the requested version spec."""
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "search", "shared==1.0.0"])
+
+    assert result.exit_code != 0
+    assert "plugin name 'shared' is ambiguous" in result.output
+    assert "shared==1.0.0@https://github.com/org-a/shared" in result.output
+    assert "shared==1.0.0@https://github.com/org-b/shared" in result.output
+
+
+def test_search_qualified_exact_name_resolves(tmp_path, virtual_ida_environment):
+    """A qualified reference picks the right repository plugin."""
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        plugin_group,
+        ["--repo", str(repo_dir), "search", "shared@https://github.com/org-a/shared"],
+    )
+
+    assert result.exit_code == 0, result.output
+    # details output should include the plugin name
+    assert "shared" in result.output
+    # the org-a repo should be identified in metadata
+    assert "org-a" in result.output
+    # and the org-b version (2.0.0) should not appear in the listing
+    assert "2.0.0" not in result.output
+
+
+def test_search_keyword_matches_colliding_plugins(tmp_path, virtual_ida_environment):
+    """Keyword search includes both colliding plugins (substring match on name)."""
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+
+    runner = CliRunner(mix_stderr=False)
+    # "shar" is a substring of "shared" but not an exact name, so this is a keyword query
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "search", "shar"])
+
+    assert result.exit_code == 0, result.output
+    # both repo URLs should show up as separate rows
+    assert "org-a" in result.output
+    assert "org-b" in result.output

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -259,6 +259,57 @@ def test_search_keyword_no_matches_reports_empty_result(tmp_path, virtual_ida_en
     assert "No plugins found" in result.output
 
 
+def test_search_exact_version_spec_shows_download_locations(virtual_ida_environment):
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "search", "plugin1==2.0.0"])
+
+    assert result.exit_code == 0, result.output
+    assert "download locations:" in result.output
+    assert "matching versions:" not in result.output
+
+
+def test_search_version_range_filters_matching_versions(virtual_ida_environment):
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "search", "plugin1>=2.0.0"])
+
+    assert result.exit_code == 0, result.output
+    assert "matching versions:" in result.output
+    assert "download locations:" not in result.output
+    assert "5.0.0" in result.output
+    assert "2.0.0" in result.output
+    assert "1.0.0" not in result.output
+
+
+def test_search_exclusion_version_spec_does_not_show_excluded_version(virtual_ida_environment):
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "search", "plugin1!=1.0.0"])
+
+    assert result.exit_code == 0, result.output
+    assert "matching versions:" in result.output
+    assert "1.0.0" not in result.output
+    assert "2.0.0" in result.output
+
+
+def test_search_version_range_without_matches_reports_constraint(virtual_ida_environment):
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "search", "plugin1>=99.0.0"])
+
+    assert result.exit_code != 0
+    assert "no versions matching '>=99.0.0' found for plugin 'plugin1'" in result.output
+
+
+def test_search_ambiguous_non_exact_version_spec_preserves_version(tmp_path, virtual_ida_environment):
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "search", "shared>=1.0.0"])
+
+    assert result.exit_code != 0
+    assert "plugin name 'shared' is ambiguous" in result.output
+    assert "shared>=1.0.0@https://github.com/org-a/shared" in result.output
+    assert "shared>=1.0.0@https://github.com/org-b/shared" in result.output
+
+
 def test_install_ambiguous_bare_name_fails(tmp_path, virtual_ida_environment):
     """`plugin install <bare-name>` on an ambiguous name prints candidates and aborts."""
     repo_dir = _build_colliding_repo_dir(tmp_path)

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -321,6 +321,26 @@ def test_upgrade_host_mismatch_fails(tmp_path, virtual_ida_environment):
     assert "Upgrade cannot switch repositories" in result.output
 
 
+def test_status_does_not_crash_on_colliding_name(tmp_path, virtual_ida_environment):
+    """status must succeed even when the installed plugin's bare name collides in the repository."""
+    repo_dir = _build_colliding_repo_dir_with_v2(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+
+    # install shared@org-a v1.0.0
+    result = runner.invoke(
+        plugin_group,
+        ["--repo", str(repo_dir), "install", "shared==1.0.0@https://github.com/org-a/shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    # status should not fail because of the repo-side name collision
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "status"])
+    assert result.exit_code == 0, result.output
+    assert "shared" in result.output
+    # should detect the v3.0.0 upgrade from org-a, not v2.0.0 from org-b
+    assert "3.0.0" in result.output
+
+
 def test_upgrade_not_installed_fails(tmp_path, virtual_ida_environment):
     """Upgrade must fail cleanly when the plugin is not installed."""
     repo_dir = _build_colliding_repo_dir_with_v2(tmp_path)

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -1,0 +1,136 @@
+"""Tests for repository-level plugin name collisions and host-aware resolution."""
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from fixtures import PLUGINS_DIR
+
+from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError
+from hcli.lib.ida.plugin.repo import PluginArchiveIndex, get_plugin_by_name
+
+
+def make_plugin_zip(
+    source_zip: Path,
+    dest_path: Path,
+    new_name: str | None = None,
+    new_version: str | None = None,
+    new_repository: str | None = None,
+) -> Path:
+    """Derive a plugin zip from a fixture by rewriting ida-plugin.json fields.
+
+    Used to synthesize two plugins with the same bare name but different
+    repository URLs so we can test collision handling without depending on
+    the public Hex-Rays plugin index.
+    """
+    with zipfile.ZipFile(source_zip, "r") as src, zipfile.ZipFile(dest_path, "w") as dst:
+        for item in src.infolist():
+            data = src.read(item.filename)
+            if item.filename.endswith("ida-plugin.json"):
+                metadata = json.loads(data)
+                if new_name is not None:
+                    metadata["plugin"]["name"] = new_name
+                if new_version is not None:
+                    metadata["plugin"]["version"] = new_version
+                if new_repository is not None:
+                    metadata["plugin"]["urls"]["repository"] = new_repository
+                data = json.dumps(metadata, indent=2).encode("utf-8")
+            dst.writestr(item, data)
+    return dest_path
+
+
+def build_index_with_colliding_plugins(tmp_path: Path) -> PluginArchiveIndex:
+    """Build a local index containing two 'shared' plugins from different repos."""
+    src = PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip"
+    # both plugins have identical bare names but different repository URLs
+    repo_a_zip = make_plugin_zip(
+        src,
+        tmp_path / "shared-a.zip",
+        new_name="shared",
+        new_version="1.0.0",
+        new_repository="https://github.com/org-a/shared",
+    )
+    repo_b_zip = make_plugin_zip(
+        src,
+        tmp_path / "shared-b.zip",
+        new_name="shared",
+        new_version="2.0.0",
+        new_repository="https://github.com/org-b/shared",
+    )
+
+    index = PluginArchiveIndex()
+    for zip_path in (repo_a_zip, repo_b_zip):
+        buf = zip_path.read_bytes()
+        # pass the expected host matching the one in ida-plugin.json so the
+        # index accepts the archive (GithubPluginRepo does the same).
+        metadata = json.loads(zipfile.ZipFile(io.BytesIO(buf)).read("src-v1/ida-plugin.json"))
+        host = metadata["plugin"]["urls"]["repository"]
+        index.index_plugin_archive(buf, zip_path.absolute().as_uri(), expected_host=host)
+    return index
+
+
+def test_get_plugin_by_name_unique(tmp_path):
+    # build an index with two distinct plugins (no collision)
+    src = PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip"
+    z = make_plugin_zip(src, tmp_path / "alpha.zip", new_name="alpha")
+    index = PluginArchiveIndex()
+    index.index_plugin_archive(z.read_bytes(), z.absolute().as_uri())
+
+    plugin = get_plugin_by_name(index.get_plugins(), "alpha")
+    assert plugin.name == "alpha"
+
+
+def test_get_plugin_by_name_ambiguous_raises(tmp_path):
+    index = build_index_with_colliding_plugins(tmp_path)
+
+    with pytest.raises(AmbiguousPluginReferenceError) as exc_info:
+        get_plugin_by_name(index.get_plugins(), "shared")
+
+    err = exc_info.value
+    assert err.name == "shared"
+    assert len(err.candidates) == 2
+    hosts = {host for _, host in err.candidates}
+    assert hosts == {
+        "https://github.com/org-a/shared",
+        "https://github.com/org-b/shared",
+    }
+
+
+def test_get_plugin_by_name_ambiguous_resolved_by_host(tmp_path):
+    index = build_index_with_colliding_plugins(tmp_path)
+    plugin = get_plugin_by_name(
+        index.get_plugins(),
+        "shared",
+        host="https://github.com/org-a/shared",
+    )
+    assert plugin.host == "https://github.com/org-a/shared"
+
+
+def test_get_plugin_by_name_host_normalized(tmp_path):
+    """Trailing slashes and casing differences should not prevent matching."""
+    index = build_index_with_colliding_plugins(tmp_path)
+    plugin = get_plugin_by_name(
+        index.get_plugins(),
+        "shared",
+        host="https://GitHub.com/Org-A/Shared/",
+    )
+    assert plugin.name == "shared"
+    assert plugin.host == "https://github.com/org-a/shared"
+
+
+def test_get_plugin_by_name_not_found(tmp_path):
+    index = build_index_with_colliding_plugins(tmp_path)
+    with pytest.raises(KeyError):
+        get_plugin_by_name(index.get_plugins(), "does-not-exist")
+
+
+def test_get_plugin_by_name_is_case_insensitive(tmp_path):
+    src = PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip"
+    z = make_plugin_zip(src, tmp_path / "Foo.zip", new_name="Foo")
+    index = PluginArchiveIndex()
+    index.index_plugin_archive(z.read_bytes(), z.absolute().as_uri())
+
+    plugin = get_plugin_by_name(index.get_plugins(), "foo")
+    assert plugin.name == "Foo"

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -321,6 +321,34 @@ def test_upgrade_host_mismatch_fails(tmp_path, virtual_ida_environment):
     assert "Upgrade cannot switch repositories" in result.output
 
 
+def test_uninstall_case_insensitive_cli(tmp_path, virtual_ida_environment):
+    """`plugin uninstall PLUGIN1` finds $IDAUSR/plugins/plugin1."""
+    from hcli.lib.ida.plugin.install import install_plugin_archive, is_plugin_installed
+
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+    assert is_plugin_installed("plugin1")
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["uninstall", "PLUGIN1"])
+    assert result.exit_code == 0, result.output
+    assert not is_plugin_installed("plugin1")
+
+
+def test_config_list_case_insensitive_cli(tmp_path, virtual_ida_environment):
+    """`plugin config PLUGIN1 list` resolves to the installed plugin's directory."""
+    from hcli.lib.ida.plugin.install import install_plugin_archive
+
+    # plugin1 has no settings defined, so `config list` should show the "No settings defined" line
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["config", "PLUGIN1", "list"])
+    assert result.exit_code == 0, result.output
+    assert "No settings defined" in result.output
+
+
 def test_status_does_not_crash_on_colliding_name(tmp_path, virtual_ida_environment):
     """status must succeed even when the installed plugin's bare name collides in the repository."""
     repo_dir = _build_colliding_repo_dir_with_v2(tmp_path)

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -123,6 +123,34 @@ def test_get_plugin_by_name_host_normalized(tmp_path):
     assert plugin.host == "https://github.com/org-a/shared"
 
 
+def test_index_normalizes_hosts_during_indexing(tmp_path):
+    src = PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip"
+    repo_a_zip = make_plugin_zip(
+        src,
+        tmp_path / "shared-a.zip",
+        new_name="shared",
+        new_version="1.0.0",
+        new_repository="https://github.com/Org-A/Shared",
+    )
+    repo_b_zip = make_plugin_zip(
+        src,
+        tmp_path / "shared-b.zip",
+        new_name="shared",
+        new_version="2.0.0",
+        new_repository="https://github.com/org-a/shared/",
+    )
+
+    index = PluginArchiveIndex()
+    index.index_plugin_archive(repo_a_zip.read_bytes(), repo_a_zip.absolute().as_uri())
+    index.index_plugin_archive(repo_b_zip.read_bytes(), repo_b_zip.absolute().as_uri())
+
+    plugins = index.get_plugins()
+    assert len(plugins) == 1
+    plugin = get_plugin_by_name(plugins, "shared", host="https://github.com/org-a/shared")
+    assert plugin.host == "https://github.com/org-a/shared"
+    assert set(plugin.versions) == {"1.0.0", "2.0.0"}
+
+
 def test_get_plugin_by_name_not_found(tmp_path):
     index = build_index_with_colliding_plugins(tmp_path)
     with pytest.raises(KeyError):
@@ -219,6 +247,16 @@ def test_search_keyword_matches_colliding_plugins(tmp_path, virtual_ida_environm
     # both repo URLs should show up as separate rows
     assert "org-a" in result.output
     assert "org-b" in result.output
+
+
+def test_search_keyword_no_matches_reports_empty_result(tmp_path, virtual_ida_environment):
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "search", "does-not-match-anything"])
+
+    assert result.exit_code == 0, result.output
+    assert "No plugins found" in result.output
 
 
 def test_install_ambiguous_bare_name_fails(tmp_path, virtual_ida_environment):
@@ -347,6 +385,35 @@ def test_config_list_case_insensitive_cli(tmp_path, virtual_ida_environment):
     result = runner.invoke(plugin_group, ["config", "PLUGIN1", "list"])
     assert result.exit_code == 0, result.output
     assert "No settings defined" in result.output
+
+
+def test_config_export_case_insensitive_cli(tmp_path, virtual_ida_environment):
+    from hcli.lib.ida.plugin.install import install_plugin_archive
+    from hcli.lib.ida.plugin.settings import set_plugin_setting
+
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v5.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+    set_plugin_setting("plugin1", "key1", "value")
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["config", "PLUGIN1", "export"])
+    assert result.exit_code == 0, result.output
+    assert '"key1": "value"' in result.output
+
+
+def test_config_export_requires_installed_plugin(tmp_path, virtual_ida_environment):
+    from hcli.lib.ida.plugin.install import install_plugin_archive, uninstall_plugin
+    from hcli.lib.ida.plugin.settings import set_plugin_setting
+
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v5.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+    set_plugin_setting("plugin1", "key1", "value")
+    uninstall_plugin("plugin1")
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["config", "plugin1", "export"])
+    assert result.exit_code != 0
+    assert "not installed" in result.output
 
 
 def test_status_does_not_crash_on_colliding_name(tmp_path, virtual_ida_environment):

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -219,3 +219,55 @@ def test_search_keyword_matches_colliding_plugins(tmp_path, virtual_ida_environm
     # both repo URLs should show up as separate rows
     assert "org-a" in result.output
     assert "org-b" in result.output
+
+
+def test_install_ambiguous_bare_name_fails(tmp_path, virtual_ida_environment):
+    """`plugin install <bare-name>` on an ambiguous name prints candidates and aborts."""
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "install", "shared"])
+
+    assert result.exit_code != 0
+    assert "plugin name 'shared' is ambiguous" in result.output
+    assert "shared@https://github.com/org-a/shared" in result.output
+    assert "shared@https://github.com/org-b/shared" in result.output
+
+
+def test_install_qualified_name_succeeds(tmp_path, virtual_ida_environment):
+    """`plugin install name@repo` installs the selected repository plugin."""
+    from hcli.lib.ida.plugin.install import is_plugin_installed
+
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        plugin_group,
+        ["--repo", str(repo_dir), "install", "shared@https://github.com/org-a/shared"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert is_plugin_installed("shared")
+
+
+def test_install_same_name_conflict(tmp_path, virtual_ida_environment):
+    """Installing a same-name plugin from another repository must fail with a conflict error."""
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        plugin_group,
+        ["--repo", str(repo_dir), "install", "shared@https://github.com/org-a/shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    # now try to install the other colliding plugin
+    result = runner.invoke(
+        plugin_group,
+        ["--repo", str(repo_dir), "install", "shared@https://github.com/org-b/shared"],
+    )
+    assert result.exit_code != 0
+    assert "cannot install plugin" in result.output
+    assert "https://github.com/org-a/shared" in result.output
+    assert "https://github.com/org-b/shared" in result.output
+    assert "Only one plugin with the bare name 'shared' can be installed at a time." in result.output

--- a/tests/lib/test_plugin_exceptions.py
+++ b/tests/lib/test_plugin_exceptions.py
@@ -4,6 +4,7 @@ from hcli.lib.ida.plugin.exceptions import (
     AmbiguousPluginReferenceError,
     InstalledPluginNameConflictError,
 )
+from hcli.lib.ida.plugin.reference import PluginReference
 
 
 class TestAmbiguousPluginReferenceError:
@@ -21,6 +22,24 @@ class TestAmbiguousPluginReferenceError:
         candidates = [("foo", "https://github.com/org-a/foo")]
         err = AmbiguousPluginReferenceError("foo", candidates, version_spec="==1.0.0")
         assert err.version_spec == "==1.0.0"
+
+    def test_candidate_refs(self):
+        candidates = [
+            ("foo", "https://github.com/org-a/foo"),
+            ("foo", "https://github.com/org-b/foo"),
+        ]
+        err = AmbiguousPluginReferenceError("foo", candidates, version_spec="==1.0.0")
+        assert err.candidate_refs == [
+            PluginReference(name="foo", version_spec="==1.0.0", host="https://github.com/org-a/foo"),
+            PluginReference(name="foo", version_spec="==1.0.0", host="https://github.com/org-b/foo"),
+        ]
+
+    def test_candidate_refs_no_version(self):
+        candidates = [("foo", "https://github.com/org-a/foo")]
+        err = AmbiguousPluginReferenceError("foo", candidates)
+        assert err.candidate_refs == [
+            PluginReference(name="foo", version_spec="", host="https://github.com/org-a/foo"),
+        ]
 
 
 class TestInstalledPluginNameConflictError:

--- a/tests/lib/test_plugin_exceptions.py
+++ b/tests/lib/test_plugin_exceptions.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from hcli.lib.ida.plugin.exceptions import (
+    AmbiguousPluginReferenceError,
+    InstalledPluginNameConflictError,
+)
+
+
+class TestAmbiguousPluginReferenceError:
+    def test_basic(self):
+        candidates = [
+            ("foo", "https://github.com/org-a/foo"),
+            ("foo", "https://github.com/org-b/foo"),
+        ]
+        err = AmbiguousPluginReferenceError("foo", candidates)
+        assert err.name == "foo"
+        assert err.version_spec == ""
+        assert err.candidates == candidates
+
+    def test_with_version_spec(self):
+        candidates = [("foo", "https://github.com/org-a/foo")]
+        err = AmbiguousPluginReferenceError("foo", candidates, version_spec="==1.0.0")
+        assert err.version_spec == "==1.0.0"
+
+
+class TestInstalledPluginNameConflictError:
+    def test_basic(self):
+        err = InstalledPluginNameConflictError(
+            requested_name="foo",
+            requested_host="https://github.com/org-b/foo",
+            installed_name="foo",
+            installed_host="https://github.com/org-a/foo",
+            installed_path=Path("/idausr/plugins/foo"),
+        )
+        assert err.requested_name == "foo"
+        assert err.installed_host == "https://github.com/org-a/foo"
+        assert "already installed" in str(err)

--- a/tests/lib/test_plugin_records.py
+++ b/tests/lib/test_plugin_records.py
@@ -1,0 +1,94 @@
+"""Tests for installed-plugin records and case-insensitive lookup."""
+
+import pytest
+from fixtures import *
+from fixtures import PLUGINS_DIR
+
+from hcli.lib.ida.plugin.exceptions import PluginNotInstalledError
+from hcli.lib.ida.plugin.install import (
+    find_installed_plugin,
+    get_installed_plugin_records,
+    install_plugin_archive,
+    is_plugin_installed,
+    resolve_installed_plugin_directory,
+    uninstall_plugin,
+)
+
+
+def test_installed_plugin_records(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    records = get_installed_plugin_records()
+    assert len(records) == 1
+    record = records[0]
+    assert record.name == "plugin1"
+    assert record.version == "1.0.0"
+    assert record.host == "https://github.com/HexRaysSA/ida-hcli"
+    assert record.path.name == "plugin1"
+
+
+def test_find_installed_plugin_case_insensitive(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    record_lower = find_installed_plugin("plugin1")
+    record_upper = find_installed_plugin("PLUGIN1")
+    record_mixed = find_installed_plugin("Plugin1")
+
+    assert record_lower.path == record_upper.path == record_mixed.path
+    assert record_lower.name == "plugin1"
+
+
+def test_find_installed_plugin_with_matching_host(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    # the host in the fixture metadata is https://github.com/HexRaysSA/ida-hcli
+    record = find_installed_plugin("plugin1", host="https://github.com/HexRaysSA/ida-hcli")
+    assert record.name == "plugin1"
+
+    # case-insensitive via normalization
+    record = find_installed_plugin("plugin1", host="https://github.com/hexrayssa/ida-hcli/")
+    assert record.name == "plugin1"
+
+
+def test_find_installed_plugin_host_mismatch(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    with pytest.raises(PluginNotInstalledError):
+        find_installed_plugin("plugin1", host="https://github.com/other-org/other-repo")
+
+
+def test_find_installed_plugin_not_installed(virtual_ida_environment):
+    with pytest.raises(PluginNotInstalledError):
+        find_installed_plugin("does-not-exist")
+
+
+def test_resolve_installed_plugin_directory_case_insensitive(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    path_lower = resolve_installed_plugin_directory("plugin1")
+    path_upper = resolve_installed_plugin_directory("PLUGIN1")
+    assert path_lower == path_upper
+
+
+def test_case_insensitive_uninstall(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+    assert is_plugin_installed("plugin1")
+
+    # uninstall with uppercase name should still work
+    uninstall_plugin("PLUGIN1")
+    assert not is_plugin_installed("plugin1")
+
+
+def test_is_plugin_installed_case_insensitive(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    assert is_plugin_installed("plugin1")
+    assert is_plugin_installed("PLUGIN1")
+    assert is_plugin_installed("Plugin1")

--- a/tests/lib/test_plugin_reference.py
+++ b/tests/lib/test_plugin_reference.py
@@ -144,6 +144,20 @@ def test_parse_plugin_reference_rejects_invalid_values(value: str):
         parse_plugin_reference(value)
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "plugin1@https://gitlab.com/org/repo",
+        "plugin1@not-a-url",
+        "plugin1@https://github.com/org/repo/blob/main",
+        "plugin1@@https://github.com/org/repo",
+    ],
+)
+def test_parse_plugin_reference_rejects_at_with_invalid_suffix(value: str):
+    with pytest.raises(ValueError):
+        parse_plugin_reference(value)
+
+
 def test_format_qualified_plugin_reference_name_only():
     ref = PluginReference(name="plugin1", version_spec="", host="https://github.com/org/repo")
     assert format_qualified_plugin_reference(ref) == "plugin1@https://github.com/org/repo"
@@ -192,3 +206,12 @@ def test_parse_github_url_rejects_non_https():
 def test_parse_github_url_rejects_non_github():
     with pytest.raises(ValueError):
         parse_github_url("https://gitlab.com/org/repo")
+
+
+def test_parse_github_url_strips_trailing_slash_after_tag():
+    assert parse_github_url("https://github.com/org/repo@v1.0/") == ("org", "repo", "v1.0")
+
+
+def test_parse_github_url_rejects_empty_tag():
+    with pytest.raises(ValueError):
+        parse_github_url("https://github.com/org/repo@/")

--- a/tests/lib/test_plugin_reference.py
+++ b/tests/lib/test_plugin_reference.py
@@ -9,111 +9,118 @@ from hcli.lib.ida.plugin.reference import (
 )
 
 
-class TestIsGithubRepositoryUrl:
-    def test_valid(self):
-        assert is_github_repository_url("https://github.com/org/repo")
-        assert is_github_repository_url("https://github.com/org/repo/")
-        assert is_github_repository_url("https://github.com/Hex-Rays/ida-hcli")
-
-    def test_rejects_subpaths(self):
-        # trailing segments beyond owner/repo are not valid repo URLs
-        assert not is_github_repository_url("https://github.com/org/repo/blob/main")
-
-    def test_rejects_loose_matches(self):
-        assert not is_github_repository_url("not a url")
-        assert not is_github_repository_url("github.com/org/repo")
-        assert not is_github_repository_url("http://github.com/org/repo")
-        # the old is_github_url() would accept substrings like these
-        assert not is_github_repository_url("foo@https://github.com/org/repo")
-        assert not is_github_repository_url("prefix https://github.com/org/repo")
+def test_is_github_repository_url_accepts_valid_repos():
+    assert is_github_repository_url("https://github.com/org/repo")
+    assert is_github_repository_url("https://github.com/org/repo/")
+    assert is_github_repository_url("https://github.com/Hex-Rays/ida-hcli")
 
 
-class TestNormalizePluginHost:
-    def test_lowercases_components(self):
-        assert normalize_plugin_host("HTTPS://GitHub.Com/Org/Repo") == "https://github.com/org/repo"
-
-    def test_strips_trailing_slash(self):
-        assert normalize_plugin_host("https://github.com/org/repo/") == "https://github.com/org/repo"
-
-    def test_preserves_no_trailing_slash(self):
-        assert normalize_plugin_host("https://github.com/org/repo") == "https://github.com/org/repo"
-
-    def test_rejects_invalid(self):
-        with pytest.raises(ValueError):
-            normalize_plugin_host("not a url")
-        with pytest.raises(ValueError):
-            normalize_plugin_host("")
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://github.com/org/repo/blob/main",
+        "not a url",
+        "github.com/org/repo",
+        "http://github.com/org/repo",
+        "foo@https://github.com/org/repo",
+        "prefix https://github.com/org/repo",
+    ],
+)
+def test_is_github_repository_url_rejects_invalid_shapes(value: str):
+    assert not is_github_repository_url(value)
 
 
-class TestParsePluginReference:
-    def test_bare_name(self):
-        ref = parse_plugin_reference("plugin1")
-        assert ref == PluginReference(name="plugin1", version_spec="", host=None)
-
-    def test_bare_version(self):
-        ref = parse_plugin_reference("plugin1==1.0.0")
-        assert ref == PluginReference(name="plugin1", version_spec="==1.0.0", host=None)
-
-    def test_various_operators(self):
-        for op in ("==", ">=", "<=", "!=", "~="):
-            ref = parse_plugin_reference(f"plugin1{op}1.0.0")
-            assert ref.name == "plugin1"
-            assert ref.version_spec == f"{op}1.0.0"
-
-    def test_qualified_name(self):
-        ref = parse_plugin_reference("plugin1@https://github.com/org/repo")
-        assert ref == PluginReference(
-            name="plugin1",
-            version_spec="",
-            host="https://github.com/org/repo",
-        )
-
-    def test_qualified_version(self):
-        ref = parse_plugin_reference("plugin1==1.0.0@https://github.com/org/repo")
-        assert ref == PluginReference(
-            name="plugin1",
-            version_spec="==1.0.0",
-            host="https://github.com/org/repo",
-        )
-
-    def test_qualified_trailing_slash_is_normalized(self):
-        ref = parse_plugin_reference("plugin1@https://github.com/org/repo/")
-        assert ref.host == "https://github.com/org/repo"
-
-    def test_qualified_case_insensitive(self):
-        ref = parse_plugin_reference("plugin1@https://GitHub.com/Org/Repo")
-        assert ref.host == "https://github.com/org/repo"
-
-    def test_raw_github_url_is_not_a_plugin_reference(self):
-        # distinct from qualified references; raw URLs are handled by install
-        # as "install from that repository", so parsing must reject them.
-        with pytest.raises(ValueError):
-            parse_plugin_reference("https://github.com/org/repo")
-
-    def test_empty(self):
-        with pytest.raises(ValueError):
-            parse_plugin_reference("")
-
-    def test_bad_operator(self):
-        with pytest.raises(ValueError):
-            parse_plugin_reference("plugin1=1.0.0")
+def test_normalize_plugin_host_lowercases_components():
+    assert normalize_plugin_host("HTTPS://GitHub.Com/Org/Repo") == "https://github.com/org/repo"
 
 
-class TestFormatQualifiedPluginReference:
-    def test_name_only(self):
-        ref = PluginReference(name="plugin1", version_spec="", host="https://github.com/org/repo")
-        assert format_qualified_plugin_reference(ref) == "plugin1@https://github.com/org/repo"
+def test_normalize_plugin_host_strips_trailing_slash():
+    assert normalize_plugin_host("https://github.com/org/repo/") == "https://github.com/org/repo"
 
-    def test_with_version(self):
-        ref = PluginReference(name="plugin1", version_spec="==1.0.0", host="https://github.com/org/repo")
-        assert format_qualified_plugin_reference(ref) == "plugin1==1.0.0@https://github.com/org/repo"
 
-    def test_without_host(self):
-        ref = PluginReference(name="plugin1", version_spec="==1.0.0", host=None)
-        assert format_qualified_plugin_reference(ref) == "plugin1==1.0.0"
+def test_normalize_plugin_host_preserves_no_trailing_slash():
+    assert normalize_plugin_host("https://github.com/org/repo") == "https://github.com/org/repo"
 
-    def test_tuple_input(self):
-        assert (
-            format_qualified_plugin_reference(("plugin1", "==1.0.0", "https://github.com/org/repo"))
-            == "plugin1==1.0.0@https://github.com/org/repo"
-        )
+
+@pytest.mark.parametrize("value", ["not a url", ""])
+def test_normalize_plugin_host_rejects_invalid_values(value: str):
+    with pytest.raises(ValueError):
+        normalize_plugin_host(value)
+
+
+def test_parse_plugin_reference_bare_name():
+    ref = parse_plugin_reference("plugin1")
+    assert ref == PluginReference(name="plugin1", version_spec="", host=None)
+
+
+def test_parse_plugin_reference_bare_version():
+    ref = parse_plugin_reference("plugin1==1.0.0")
+    assert ref == PluginReference(name="plugin1", version_spec="==1.0.0", host=None)
+
+
+@pytest.mark.parametrize("op", ["==", ">=", "<=", "!=", "~="])
+def test_parse_plugin_reference_various_operators(op: str):
+    ref = parse_plugin_reference(f"plugin1{op}1.0.0")
+    assert ref.name == "plugin1"
+    assert ref.version_spec == f"{op}1.0.0"
+
+
+def test_parse_plugin_reference_qualified_name():
+    ref = parse_plugin_reference("plugin1@https://github.com/org/repo")
+    assert ref == PluginReference(
+        name="plugin1",
+        version_spec="",
+        host="https://github.com/org/repo",
+    )
+
+
+def test_parse_plugin_reference_qualified_version():
+    ref = parse_plugin_reference("plugin1==1.0.0@https://github.com/org/repo")
+    assert ref == PluginReference(
+        name="plugin1",
+        version_spec="==1.0.0",
+        host="https://github.com/org/repo",
+    )
+
+
+def test_parse_plugin_reference_qualified_trailing_slash_is_normalized():
+    ref = parse_plugin_reference("plugin1@https://github.com/org/repo/")
+    assert ref.host == "https://github.com/org/repo"
+
+
+def test_parse_plugin_reference_qualified_case_insensitive():
+    ref = parse_plugin_reference("plugin1@https://GitHub.com/Org/Repo")
+    assert ref.host == "https://github.com/org/repo"
+
+
+def test_parse_plugin_reference_raw_github_url_is_not_a_plugin_reference():
+    with pytest.raises(ValueError):
+        parse_plugin_reference("https://github.com/org/repo")
+
+
+@pytest.mark.parametrize("value", ["", "plugin1=1.0.0"])
+def test_parse_plugin_reference_rejects_invalid_values(value: str):
+    with pytest.raises(ValueError):
+        parse_plugin_reference(value)
+
+
+def test_format_qualified_plugin_reference_name_only():
+    ref = PluginReference(name="plugin1", version_spec="", host="https://github.com/org/repo")
+    assert format_qualified_plugin_reference(ref) == "plugin1@https://github.com/org/repo"
+
+
+def test_format_qualified_plugin_reference_with_version():
+    ref = PluginReference(name="plugin1", version_spec="==1.0.0", host="https://github.com/org/repo")
+    assert format_qualified_plugin_reference(ref) == "plugin1==1.0.0@https://github.com/org/repo"
+
+
+def test_format_qualified_plugin_reference_without_host():
+    ref = PluginReference(name="plugin1", version_spec="==1.0.0", host=None)
+    assert format_qualified_plugin_reference(ref) == "plugin1==1.0.0"
+
+
+def test_format_qualified_plugin_reference_tuple_input():
+    assert (
+        format_qualified_plugin_reference(("plugin1", "==1.0.0", "https://github.com/org/repo"))
+        == "plugin1==1.0.0@https://github.com/org/repo"
+    )

--- a/tests/lib/test_plugin_reference.py
+++ b/tests/lib/test_plugin_reference.py
@@ -119,8 +119,6 @@ def test_format_qualified_plugin_reference_without_host():
     assert format_qualified_plugin_reference(ref) == "plugin1==1.0.0"
 
 
-def test_format_qualified_plugin_reference_tuple_input():
-    assert (
-        format_qualified_plugin_reference(("plugin1", "==1.0.0", "https://github.com/org/repo"))
-        == "plugin1==1.0.0@https://github.com/org/repo"
-    )
+def test_format_qualified_plugin_reference_bare_name():
+    ref = PluginReference(name="plugin1", version_spec="", host=None)
+    assert format_qualified_plugin_reference(ref) == "plugin1"

--- a/tests/lib/test_plugin_reference.py
+++ b/tests/lib/test_plugin_reference.py
@@ -3,10 +3,12 @@ import pytest
 from hcli.lib.ida.plugin.reference import (
     PluginReference,
     format_qualified_plugin_reference,
+    is_github_direct_install_url,
     is_github_repository_url,
     normalize_plugin_host,
     parse_plugin_reference,
 )
+from hcli.lib.ida.plugin.repo.github import parse_github_url
 
 
 def test_is_github_repository_url_accepts_valid_repos():
@@ -28,6 +30,35 @@ def test_is_github_repository_url_accepts_valid_repos():
 )
 def test_is_github_repository_url_rejects_invalid_shapes(value: str):
     assert not is_github_repository_url(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://github.com/org/repo",
+        "https://github.com/org/repo/",
+        "https://github.com/org/repo.git",
+        "https://github.com/org/repo@v1.0",
+        "https://github.com/org/repo.git@v1.0",
+        "https://github.com/org/repo@release/2.0",
+    ],
+)
+def test_is_github_direct_install_url_accepts(value: str):
+    assert is_github_direct_install_url(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not a url",
+        "github.com/org/repo",
+        "http://github.com/org/repo",
+        "foo@https://github.com/org/repo",
+        "git@github.com:org/repo.git",
+    ],
+)
+def test_is_github_direct_install_url_rejects(value: str):
+    assert not is_github_direct_install_url(value)
 
 
 def test_normalize_plugin_host_lowercases_components():
@@ -93,9 +124,18 @@ def test_parse_plugin_reference_qualified_case_insensitive():
     assert ref.host == "https://github.com/org/repo"
 
 
-def test_parse_plugin_reference_raw_github_url_is_not_a_plugin_reference():
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://github.com/org/repo",
+        "https://github.com/org/repo.git",
+        "https://github.com/org/repo@v1.0",
+        "https://github.com/org/repo.git@v1.0",
+    ],
+)
+def test_parse_plugin_reference_github_urls_are_not_plugin_references(value: str):
     with pytest.raises(ValueError):
-        parse_plugin_reference("https://github.com/org/repo")
+        parse_plugin_reference(value)
 
 
 @pytest.mark.parametrize("value", ["", "plugin1=1.0.0"])
@@ -122,3 +162,33 @@ def test_format_qualified_plugin_reference_without_host():
 def test_format_qualified_plugin_reference_bare_name():
     ref = PluginReference(name="plugin1", version_spec="", host=None)
     assert format_qualified_plugin_reference(ref) == "plugin1"
+
+
+def test_parse_github_url_basic():
+    assert parse_github_url("https://github.com/org/repo") == ("org", "repo", None)
+
+
+def test_parse_github_url_trailing_slash():
+    assert parse_github_url("https://github.com/org/repo/") == ("org", "repo", None)
+
+
+def test_parse_github_url_dot_git():
+    assert parse_github_url("https://github.com/org/repo.git") == ("org", "repo", None)
+
+
+def test_parse_github_url_with_tag():
+    assert parse_github_url("https://github.com/org/repo@v1.0") == ("org", "repo", "v1.0")
+
+
+def test_parse_github_url_dot_git_with_tag():
+    assert parse_github_url("https://github.com/org/repo.git@v1.0") == ("org", "repo", "v1.0")
+
+
+def test_parse_github_url_rejects_non_https():
+    with pytest.raises(ValueError):
+        parse_github_url("http://github.com/org/repo")
+
+
+def test_parse_github_url_rejects_non_github():
+    with pytest.raises(ValueError):
+        parse_github_url("https://gitlab.com/org/repo")

--- a/tests/lib/test_plugin_reference.py
+++ b/tests/lib/test_plugin_reference.py
@@ -1,0 +1,119 @@
+import pytest
+
+from hcli.lib.ida.plugin.reference import (
+    PluginReference,
+    format_qualified_plugin_reference,
+    is_github_repository_url,
+    normalize_plugin_host,
+    parse_plugin_reference,
+)
+
+
+class TestIsGithubRepositoryUrl:
+    def test_valid(self):
+        assert is_github_repository_url("https://github.com/org/repo")
+        assert is_github_repository_url("https://github.com/org/repo/")
+        assert is_github_repository_url("https://github.com/Hex-Rays/ida-hcli")
+
+    def test_rejects_subpaths(self):
+        # trailing segments beyond owner/repo are not valid repo URLs
+        assert not is_github_repository_url("https://github.com/org/repo/blob/main")
+
+    def test_rejects_loose_matches(self):
+        assert not is_github_repository_url("not a url")
+        assert not is_github_repository_url("github.com/org/repo")
+        assert not is_github_repository_url("http://github.com/org/repo")
+        # the old is_github_url() would accept substrings like these
+        assert not is_github_repository_url("foo@https://github.com/org/repo")
+        assert not is_github_repository_url("prefix https://github.com/org/repo")
+
+
+class TestNormalizePluginHost:
+    def test_lowercases_components(self):
+        assert normalize_plugin_host("HTTPS://GitHub.Com/Org/Repo") == "https://github.com/org/repo"
+
+    def test_strips_trailing_slash(self):
+        assert normalize_plugin_host("https://github.com/org/repo/") == "https://github.com/org/repo"
+
+    def test_preserves_no_trailing_slash(self):
+        assert normalize_plugin_host("https://github.com/org/repo") == "https://github.com/org/repo"
+
+    def test_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            normalize_plugin_host("not a url")
+        with pytest.raises(ValueError):
+            normalize_plugin_host("")
+
+
+class TestParsePluginReference:
+    def test_bare_name(self):
+        ref = parse_plugin_reference("plugin1")
+        assert ref == PluginReference(name="plugin1", version_spec="", host=None)
+
+    def test_bare_version(self):
+        ref = parse_plugin_reference("plugin1==1.0.0")
+        assert ref == PluginReference(name="plugin1", version_spec="==1.0.0", host=None)
+
+    def test_various_operators(self):
+        for op in ("==", ">=", "<=", "!=", "~="):
+            ref = parse_plugin_reference(f"plugin1{op}1.0.0")
+            assert ref.name == "plugin1"
+            assert ref.version_spec == f"{op}1.0.0"
+
+    def test_qualified_name(self):
+        ref = parse_plugin_reference("plugin1@https://github.com/org/repo")
+        assert ref == PluginReference(
+            name="plugin1",
+            version_spec="",
+            host="https://github.com/org/repo",
+        )
+
+    def test_qualified_version(self):
+        ref = parse_plugin_reference("plugin1==1.0.0@https://github.com/org/repo")
+        assert ref == PluginReference(
+            name="plugin1",
+            version_spec="==1.0.0",
+            host="https://github.com/org/repo",
+        )
+
+    def test_qualified_trailing_slash_is_normalized(self):
+        ref = parse_plugin_reference("plugin1@https://github.com/org/repo/")
+        assert ref.host == "https://github.com/org/repo"
+
+    def test_qualified_case_insensitive(self):
+        ref = parse_plugin_reference("plugin1@https://GitHub.com/Org/Repo")
+        assert ref.host == "https://github.com/org/repo"
+
+    def test_raw_github_url_is_not_a_plugin_reference(self):
+        # distinct from qualified references; raw URLs are handled by install
+        # as "install from that repository", so parsing must reject them.
+        with pytest.raises(ValueError):
+            parse_plugin_reference("https://github.com/org/repo")
+
+    def test_empty(self):
+        with pytest.raises(ValueError):
+            parse_plugin_reference("")
+
+    def test_bad_operator(self):
+        with pytest.raises(ValueError):
+            parse_plugin_reference("plugin1=1.0.0")
+
+
+class TestFormatQualifiedPluginReference:
+    def test_name_only(self):
+        ref = PluginReference(name="plugin1", version_spec="", host="https://github.com/org/repo")
+        assert format_qualified_plugin_reference(ref) == "plugin1@https://github.com/org/repo"
+
+    def test_with_version(self):
+        ref = PluginReference(name="plugin1", version_spec="==1.0.0", host="https://github.com/org/repo")
+        assert format_qualified_plugin_reference(ref) == "plugin1==1.0.0@https://github.com/org/repo"
+
+    def test_without_host(self):
+        ref = PluginReference(name="plugin1", version_spec="==1.0.0", host=None)
+        assert format_qualified_plugin_reference(ref) == "plugin1==1.0.0"
+
+    def test_tuple_input(self):
+        assert (
+            format_qualified_plugin_reference(("plugin1", "==1.0.0", "https://github.com/org/repo"))
+            == "plugin1==1.0.0@https://github.com/org/repo"
+        )


### PR DESCRIPTION
closes #168 

In summary: if two repository plugins share the same bare name, HCLI will ask you to qualify the reference with the plugin's repository URL, for example `hcli plugin install ida-chat@https://github.com/HexRaysSA/ida-chat-plugin` or `hcli plugin install ida-chat==1.0.0@https://github.com/HexRaysSA/ida-chat-plugin`.


1. Repository plugins are uniquely identified by the pair `(plugin.name, plugin.urls.repository)`.
2. Bare plugin names remain supported when they resolve to exactly one repository plugin.
3. When multiple repository plugins share the same bare name, HCLI must reject the ambiguous reference, list the colliding candidates, and
4. Installed plugins remain limited to one plugin per bare name because the install directory is `$IDAUSR/plugins/<name>`.

## Accepted reference syntax

1. HCLI continues to accept the existing unqualified forms:
   1a. `name`
   1b. `name==1.2.3`
   1c. any other version operator already supported today before the version, such as `>=`, `<=`, `!=`, and `~=`
2. HCLI adds qualified forms that include the repository URL:
   2a. `name@https://github.com/org/repo`
   2b. `name==1.2.3@https://github.com/org/repo`
   2c. the version operator, when present, appears before the `@repo` suffix
3. The repository URL used in a qualified reference must match the plugin's `ida-plugin.json` `urls.repository` value after normalization.
4. Repository URL normalization for matching is:
   4a. compare case-insensitively
   4b. ignore a single trailing slash
5. Raw GitHub repository URLs accepted by `hcli plugin install` continue to mean "install from that repository" and are not interpreted as qualified plugin references.

## Command behavior

1. `hcli plugin search`
   1a. keyword and substring searches continue to list all matching plugins, including colliding names from different repositories
   1b. exact bare-name and exact bare-version queries show plugin details only when the bare name is unique
   1c. when an exact bare-name or exact bare-version query is ambiguous, HCLI prints the colliding candidates and shows the qualified forms to use
   1d. qualified queries show details for the selected repository plugin
2. `hcli plugin install`
   2a. bare-name installs continue to work when the bare name is unique
   2b. ambiguous bare-name installs fail with an error that lists the colliding candidates and shows the qualified forms to use
   2c. qualified installs select the repository plugin explicitly
   2d. if another installed plugin already occupies `$IDAUSR/plugins/<name>`, HCLI fails with an error that explains only one plugin with that bare name can be installed at a time
3. `hcli plugin upgrade`
   3a. when the user provides a bare installed plugin name, HCLI resolves the installed plugin first and uses its repository URL for the upgrade lookup
   3b. qualified upgrades target the selected repository plugin explicitly
   3c. upgrade does not switch an installed plugin from one repository to another; switching repositories requires uninstalling and then installing the other qualified plugin
4. `hcli plugin status`
   4a. status uses the installed plugin's local metadata, including its repository URL, when checking for available upgrades
   4b. status must not fail because multiple repository plugins share the same bare name
5. Commands that target an already installed plugin by name resolve that installed plugin case-insensitively using local metadata.
6. Plugin settings remain keyed by bare plugin name in `ida-config.json` for now.

## Error reporting

1. Ambiguity errors must:
   1a. identify the ambiguous bare name
   1b. list the colliding candidates as `name@repo`
   1c. show the exact qualified syntax the user can rerun
2. Same-name install conflicts must:
   2a. identify the plugin that is already installed
   2b. identify the plugin the user asked to install
   2c. explain that HCLI's install layout only allows one installed plugin per bare name

## Non-goals

1. Changing the on-disk plugin directory layout.
2. Allowing two plugins with the same bare name to be installed simultaneously.
3. Re-keying plugin settings in `ida-config.json` by repository URL.
4. Resolving GitHub repository redirects during plugin reference matching.