### PR TITLE
Isolate IDAUSR to avoid loading plugins during python version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update ida-config.json by default on install
 - Explicitly use encoding="utf-8" everywhere and set PYTHONUTF8=1 for subprocesses
 - Better algorithm to detect python executable from idat
+- Use an isolated minimal IDAUSR for idat-based Python detection to avoid headless startup crashes from user plugins
 - Use ida executable in find_current_ida_platform
 - Remove idat invocations for version and platform detection
 - Validate all plugin paths before extracting any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Update ida-config.json by default on install
 - Explicitly use encoding="utf-8" everywhere and set PYTHONUTF8=1 for subprocesses
 - Better algorithm to detect python executable from idat
-- Use an isolated minimal IDAUSR for idat-based Python detection to avoid headless startup crashes from user plugins
+- Use an isolated minimal IDAUSR for idat-based Python detection, while preserving `idapythonrc.py`, to avoid headless startup crashes from user plugins
 - Use ida executable in find_current_ida_platform
 - Remove idat invocations for version and platform detection
 - Validate all plugin paths before extracting any

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -679,10 +679,10 @@ def find_current_idat_executable() -> Path:
 def _prepare_headless_ida_user_dir(source_dir: Path, target_dir: Path) -> None:
     """Copy the minimal IDAUSR state needed for headless idat invocations.
 
-    For Python detection we only need the Python selection state from
-    ``cfg/idapython.cfg`` plus the registry/license files required for IDA to start.
-    We intentionally omit ``plugins/`` and other user content so third-party plugins
-    and startup scripts cannot interfere with ``idat``.
+    For Python detection we need the Python selection state and startup context from
+    ``ida.reg``, optional ``cfg/idapython.cfg``, optional ``idapythonrc.py``, plus the
+    license files required for IDA to start. We intentionally omit ``plugins/`` and
+    other user content so third-party plugins cannot interfere with ``idat``.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
 
@@ -694,6 +694,10 @@ def _prepare_headless_ida_user_dir(source_dir: Path, target_dir: Path) -> None:
     ida_reg = source_dir / "ida.reg"
     if ida_reg.is_file():
         shutil.copy2(ida_reg, target_dir / "ida.reg")
+
+    idapythonrc = source_dir / "idapythonrc.py"
+    if idapythonrc.is_file():
+        shutil.copy2(idapythonrc, target_dir / "idapythonrc.py")
 
     for license_file in source_dir.glob("*.hexlic"):
         if license_file.is_file():

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -676,16 +676,31 @@ def find_current_idat_executable() -> Path:
     return find_current_ida_executable("t")
 
 
-def run_py_in_current_idapython(src: str) -> dict:
-    idat_path = find_current_idat_executable()
-    if not idat_path.exists():
-        raise ValueError(f"can't find idat: {idat_path}")
+def _prepare_headless_ida_user_dir(source_dir: Path, target_dir: Path) -> None:
+    """Copy the minimal IDAUSR state needed for headless idat invocations.
 
-    if get_os() == "linux" and "9.2" in str(idat_path.absolute()) and " " in str(idat_path.absolute()):
-        logger.warning(
-            "invoking idat on IDA 9.2/Linux with a space in the full path, you might encounter HCLI GitHub issue #99"
-        )
+    For Python detection we only need the Python selection state from
+    ``cfg/idapython.cfg`` plus the registry/license files required for IDA to start.
+    We intentionally omit ``plugins/`` and other user content so third-party plugins
+    and startup scripts cannot interfere with ``idat``.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
 
+    idapython_cfg = source_dir / "cfg" / "idapython.cfg"
+    if idapython_cfg.is_file():
+        (target_dir / "cfg").mkdir(parents=True, exist_ok=True)
+        shutil.copy2(idapython_cfg, target_dir / "cfg" / "idapython.cfg")
+
+    ida_reg = source_dir / "ida.reg"
+    if ida_reg.is_file():
+        shutil.copy2(ida_reg, target_dir / "ida.reg")
+
+    for license_file in source_dir.glob("*.hexlic"):
+        if license_file.is_file():
+            shutil.copy2(license_file, target_dir / license_file.name)
+
+
+def _run_ida_batch_script(idat_path: Path, src: str, env: dict[str, str] | None = None) -> dict:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
 
@@ -714,8 +729,18 @@ def run_py_in_current_idapython(src: str) -> dict:
             f"-S{script_path.absolute()!s}",
         ]
 
-        result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            env=env,
+        )
         logger.debug(f"idat command: {' '.join(cmd)}")
+        if env and env.get("IDAUSR"):
+            logger.debug(f"idat IDAUSR: {env['IDAUSR']}")
         logger.debug(f"idat exit code: {result.returncode}")
         if result.stdout:
             logger.debug(f"idat stdout: {result.stdout}")
@@ -725,13 +750,43 @@ def run_py_in_current_idapython(src: str) -> dict:
         if not log_path.exists():
             raise RuntimeError(f"failed to invoke idat: log file was not created: {log_path}")
 
-        for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        log_text = log_path.read_text(encoding="utf-8", errors="replace")
+        for line in log_text.splitlines():
             if not line.startswith("__hcli__:"):
                 continue
 
             return json.loads(line[len("__hcli__:") :])
 
+        log_tail = "\n".join(log_text.splitlines()[-20:])
+        if log_tail:
+            raise RuntimeError(f"failed to invoke idat: could not find expected lines in log output:\n{log_tail}")
+
         raise RuntimeError("failed to invoke idat: could not find expected lines in log output")
+
+
+def run_py_in_current_idapython(src: str) -> dict:
+    idat_path = find_current_idat_executable()
+    if not idat_path.exists():
+        raise ValueError(f"can't find idat: {idat_path}")
+
+    if get_os() == "linux" and "9.2" in str(idat_path.absolute()) and " " in str(idat_path.absolute()):
+        logger.warning(
+            "invoking idat on IDA 9.2/Linux with a space in the full path, you might encounter HCLI GitHub issue #99"
+        )
+
+    idausr = get_ida_user_dir()
+    if not idausr.exists() or not idausr.is_dir():
+        env = os.environ.copy()
+        env["IDAUSR"] = str(idausr)
+        return _run_ida_batch_script(idat_path, src, env=env)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        isolated_idausr = Path(temp_dir) / "idausr"
+        _prepare_headless_ida_user_dir(idausr, isolated_idausr)
+
+        env = os.environ.copy()
+        env["IDAUSR"] = str(isolated_idausr)
+        return _run_ida_batch_script(idat_path, src, env=env)
 
 
 def detect_binary_arch(path: Path) -> str | None:

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -12,12 +12,12 @@ logger = logging.getLogger(__name__)
 
 
 # Script run inside IDA's embedded Python via idat.
-# Returns sys.prefix, sys.base_prefix, and version info
-# so we can detect the Python executable on the hcli side.
+# Returns enough sys/env info to detect the Python executable on the hcli side.
 GET_PYTHON_INFO_PY = """
 import sys
 import io
 import json
+import os
 
 # ensure UTF-8 output for unicode install paths
 if hasattr(sys.stdout, "buffer"):
@@ -27,6 +27,9 @@ print("__hcli__:" + json.dumps({
     "frozen": getattr(sys, "frozen", False),
     "prefix": sys.prefix,
     "base_prefix": sys.base_prefix,
+    "executable": sys.executable,
+    "virtual_env": os.environ.get("VIRTUAL_ENV"),
+    "idapython_venv_executable": os.environ.get("IDAPYTHON_VENV_EXECUTABLE"),
     "version_major": sys.version_info.major,
     "version_minor": sys.version_info.minor,
 }))
@@ -38,38 +41,118 @@ class PythonNotFoundError(RuntimeError):
     """Could not detect IDA's Python executable."""
 
 
-def _derive_python_exe(info: dict) -> Path:
-    """Derive the Python executable path from IDA's embedded Python sys info.
+def _normalize_path(path: str | None) -> str | None:
+    if not path:
+        return None
+    return os.path.normcase(os.path.abspath(path))
 
-    Uses sys.prefix/sys.base_prefix to locate the Python executable.
-    Checks versioned binaries first on Linux/Mac for precision.
+
+def _is_windows_store_shim(path: str | None) -> bool:
+    if path is None:
+        return False
+    lowered = path.lower()
+    return "microsoft\\windowsapps" in lowered or "microsoft/windowsapps" in lowered
+
+
+def _is_python_executable_name(path: str | None) -> bool:
+    if path is None:
+        return False
+    return "python" in os.path.basename(path).lower()
+
+
+def _get_venv_root_from_python(path: str | None) -> Path | None:
+    if not path or not _is_python_executable_name(path):
+        return None
+
+    exe = Path(path)
+    if exe.parent.name not in ("bin", "Scripts"):
+        return None
+
+    venv_root = exe.parent.parent
+    if (venv_root / "pyvenv.cfg").exists():
+        return venv_root
+
+    return None
+
+
+def _get_prefix_candidates(prefix: str | None, version: str, is_windows: bool) -> list[str]:
+    if not prefix:
+        return []
+
+    if is_windows:
+        return [
+            os.path.join(prefix, "Scripts", "python.exe"),
+            os.path.join(prefix, "python.exe"),
+        ]
+
+    bindir = os.path.join(prefix, "bin")
+    return [
+        os.path.join(bindir, f"python{version}"),
+        os.path.join(bindir, "python3"),
+        os.path.join(bindir, "python"),
+    ]
+
+
+def _derive_python_exe(info: dict) -> Path:
+    """Derive the Python executable path from IDA's embedded Python sys/env info.
+
+    Prefers sys.prefix/sys.base_prefix, but falls back to a validated sys.executable
+    when IDA launches a venv interpreter whose sys.prefix remains the base install.
     """
     if info.get("frozen", False):
         raise PythonNotFoundError("IDA is running as a frozen application, cannot detect Python executable")
 
     is_windows = platform.system() == "Windows"
     version = f"{info['version_major']}.{info['version_minor']}"
+    sys_executable = info.get("executable")
+    sys_executable_venv = _get_venv_root_from_python(sys_executable)
+    requested_venv_executable = info.get("idapython_venv_executable")
+    requested_venv_root = _get_venv_root_from_python(requested_venv_executable)
+    virtual_env = info.get("virtual_env")
+    normalized_virtual_env = _normalize_path(virtual_env)
 
     # deduplicate while preserving order: prefix first, then base_prefix
     prefixes = list(dict.fromkeys([info["prefix"], info["base_prefix"]]))
+    prefix_candidates = [
+        os.path.abspath(candidate)
+        for prefix in prefixes
+        for candidate in _get_prefix_candidates(prefix, version, is_windows)
+    ]
 
-    candidates = []
-    for prefix in prefixes:
-        if is_windows:
-            candidates.append(os.path.join(prefix, "Scripts", "python.exe"))
-            candidates.append(os.path.join(prefix, "python.exe"))
-        else:
-            bindir = os.path.join(prefix, "bin")
-            candidates.append(os.path.join(bindir, f"python{version}"))
-            candidates.append(os.path.join(bindir, "python3"))
-            candidates.append(os.path.join(bindir, "python"))
-
-    candidates = [os.path.abspath(c) for c in candidates]
-
-    for candidate in candidates:
+    for candidate in prefix_candidates:
         logger.debug("candidate: %s (exists: %s)", candidate, os.path.exists(candidate))
 
-    for candidate in candidates:
+    # The preferred path: sys.prefix/sys.base_prefix identify the interpreter layout.
+    for candidate in prefix_candidates:
+        if os.path.exists(candidate):
+            candidate_venv = _get_venv_root_from_python(candidate)
+            if requested_venv_root and candidate_venv == requested_venv_root:
+                return Path(candidate)
+            if normalized_virtual_env and _normalize_path(str(candidate_venv)) == normalized_virtual_env:
+                return Path(candidate)
+
+    if info["prefix"] != info["base_prefix"]:
+        for candidate in prefix_candidates:
+            if os.path.exists(candidate):
+                return Path(candidate)
+
+    # macOS can report the base framework prefix even when IDA requested a venv.
+    # In that case, accept sys.executable only when it can be validated as a real venv
+    # interpreter, preferably the one IDA was explicitly told to use.
+    if sys_executable and os.path.exists(sys_executable) and not _is_windows_store_shim(sys_executable):
+        if requested_venv_root and sys_executable_venv == requested_venv_root:
+            logger.debug("using sys.executable validated by IDAPYTHON_VENV_EXECUTABLE: %s", sys_executable)
+            return Path(sys_executable)
+
+        if normalized_virtual_env and _normalize_path(str(sys_executable_venv)) == normalized_virtual_env:
+            logger.debug("using sys.executable validated by VIRTUAL_ENV: %s", sys_executable)
+            return Path(sys_executable)
+
+        if requested_venv_executable and _normalize_path(sys_executable) == _normalize_path(requested_venv_executable):
+            logger.debug("using sys.executable matching IDAPYTHON_VENV_EXECUTABLE: %s", sys_executable)
+            return Path(sys_executable)
+
+    for candidate in prefix_candidates:
         if os.path.exists(candidate):
             return Path(candidate)
 
@@ -78,7 +161,10 @@ def _derive_python_exe(info: dict) -> Path:
         "Please run idapyswitch to select a Python installation, then try again.\n"
         f"sys.prefix: {info['prefix']}\n"
         f"sys.base_prefix: {info['base_prefix']}\n"
-        f"Tried: {candidates}"
+        f"sys.executable: {info.get('executable')}\n"
+        f"VIRTUAL_ENV: {info.get('virtual_env')}\n"
+        f"IDAPYTHON_VENV_EXECUTABLE: {info.get('idapython_venv_executable')}\n"
+        f"Tried: {prefix_candidates}"
     )
 
 

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -95,7 +95,10 @@ def find_current_python_executable() -> Path:
     try:
         info = run_py_in_current_idapython(GET_PYTHON_INFO_PY)
     except RuntimeError as e:
-        raise PythonNotFoundError("failed to run idat to detect IDA's Python interpreter") from e
+        raise PythonNotFoundError(
+            "failed to run idat to detect IDA's Python interpreter. "
+            "If you already know the interpreter path, set HCLI_CURRENT_IDA_PYTHON_EXE=/path/to/python and retry."
+        ) from e
 
     logger.debug("IDA Python info: %s", info)
     return _derive_python_exe(info)

--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from hcli.lib.ida import (
+    _prepare_headless_ida_user_dir,
     detect_binary_arch,
     find_current_ida_install_directory,
     find_current_ida_platform,
@@ -16,6 +17,7 @@ from hcli.lib.ida import (
     get_ida_config_path,
     parse_version_from_dir_name,
     parse_version_from_ida_pro_py,
+    run_py_in_current_idapython,
 )
 
 
@@ -172,3 +174,64 @@ def test_detect_binary_arch_unknown():
         f.flush()
         assert detect_binary_arch(Path(f.name)) is None
     os.unlink(f.name)
+
+
+def test_prepare_headless_ida_user_dir_copies_only_required_files(tmp_path):
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+
+    (source_dir / "cfg").mkdir(parents=True)
+    (source_dir / "cfg" / "idapython.cfg").write_text("configured", encoding="utf-8")
+    (source_dir / "plugins").mkdir()
+    (source_dir / "plugins" / "bad_plugin.py").write_text("raise RuntimeError", encoding="utf-8")
+    (source_dir / "mcp").mkdir()
+    (source_dir / "mcp" / "state.json").write_text("{}", encoding="utf-8")
+    (source_dir / "ida.reg").write_text("registry", encoding="utf-8")
+    (source_dir / "ida-config.json").write_text("{}", encoding="utf-8")
+    (source_dir / "idapythonrc.py").write_text("raise RuntimeError", encoding="utf-8")
+    (source_dir / "license.hexlic").write_text("license", encoding="utf-8")
+
+    _prepare_headless_ida_user_dir(source_dir, target_dir)
+
+    assert (target_dir / "cfg" / "idapython.cfg").read_text(encoding="utf-8") == "configured"
+    assert (target_dir / "ida.reg").read_text(encoding="utf-8") == "registry"
+    assert (target_dir / "license.hexlic").read_text(encoding="utf-8") == "license"
+    assert not (target_dir / "ida-config.json").exists()
+    assert not (target_dir / "idapythonrc.py").exists()
+    assert not (target_dir / "plugins").exists()
+    assert not (target_dir / "mcp").exists()
+
+
+def test_run_py_in_current_idapython_uses_isolated_idausr(tmp_path, monkeypatch):
+    source_idausr = tmp_path / "idausr"
+    (source_idausr / "cfg").mkdir(parents=True)
+    (source_idausr / "cfg" / "idapython.cfg").write_text("configured", encoding="utf-8")
+    (source_idausr / "plugins").mkdir()
+    (source_idausr / "plugins" / "bad_plugin.py").write_text("raise RuntimeError", encoding="utf-8")
+    (source_idausr / "ida.reg").write_text("registry", encoding="utf-8")
+    (source_idausr / "license.hexlic").write_text("license", encoding="utf-8")
+
+    fake_idat = tmp_path / "idat"
+    fake_idat.write_text("", encoding="utf-8")
+
+    calls = []
+
+    def fake_run(idat_path, src, env=None):
+        assert env is not None
+        calls.append(env["IDAUSR"])
+
+        isolated_idausr = Path(env["IDAUSR"])
+        assert isolated_idausr != source_idausr
+        assert (isolated_idausr / "cfg" / "idapython.cfg").read_text(encoding="utf-8") == "configured"
+        assert (isolated_idausr / "ida.reg").read_text(encoding="utf-8") == "registry"
+        assert (isolated_idausr / "license.hexlic").read_text(encoding="utf-8") == "license"
+        assert not (isolated_idausr / "plugins").exists()
+        return {"prefix": "/tmp/python"}
+
+    monkeypatch.setattr("hcli.lib.ida.find_current_idat_executable", lambda: fake_idat)
+    monkeypatch.setattr("hcli.lib.ida.get_ida_user_dir", lambda: source_idausr)
+    monkeypatch.setattr("hcli.lib.ida._run_ida_batch_script", fake_run)
+
+    assert run_py_in_current_idapython("print('hello')") == {"prefix": "/tmp/python"}
+    assert len(calls) == 1
+    assert Path(calls[0]) != source_idausr

--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -195,9 +195,9 @@ def test_prepare_headless_ida_user_dir_copies_only_required_files(tmp_path):
 
     assert (target_dir / "cfg" / "idapython.cfg").read_text(encoding="utf-8") == "configured"
     assert (target_dir / "ida.reg").read_text(encoding="utf-8") == "registry"
+    assert (target_dir / "idapythonrc.py").read_text(encoding="utf-8") == "raise RuntimeError"
     assert (target_dir / "license.hexlic").read_text(encoding="utf-8") == "license"
     assert not (target_dir / "ida-config.json").exists()
-    assert not (target_dir / "idapythonrc.py").exists()
     assert not (target_dir / "plugins").exists()
     assert not (target_dir / "mcp").exists()
 

--- a/tests/lib/test_ida_python.py
+++ b/tests/lib/test_ida_python.py
@@ -1,8 +1,11 @@
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+from hcli.lib.ida import find_current_ida_install_directory, get_ida_user_dir
 from hcli.lib.ida.python import (
     CantInstallPackagesError,
     does_current_ida_have_pip,
@@ -33,6 +36,114 @@ def test_find_current_python_executable_returns_path():
 def test_does_current_ida_have_pip():
     python_exe = find_current_python_executable()
     assert does_current_ida_have_pip(python_exe, timeout=30.0)
+
+
+def _prepare_isolated_idausr_for_python_detection(source_idausr: Path, target_idausr: Path) -> None:
+    target_idausr.mkdir()
+    (target_idausr / "cfg").mkdir()
+
+    ida_reg = source_idausr / "ida.reg"
+    if not ida_reg.exists():
+        pytest.skip("Current IDAUSR does not contain ida.reg")
+    (target_idausr / "ida.reg").write_bytes(ida_reg.read_bytes())
+
+    for license_file in source_idausr.glob("*.hexlic"):
+        (target_idausr / license_file.name).write_bytes(license_file.read_bytes())
+
+
+def _assert_detected_venv_python(result: Path, venv_dir: Path) -> None:
+    if os.name == "nt":
+        assert result == venv_dir / "Scripts" / "python.exe"
+        return
+
+    assert result.parent == venv_dir / "bin"
+    assert result.name.startswith("python")
+
+
+def _venv_launcher_for_ida(venv_dir: Path) -> Path:
+    return venv_dir / "Scripts" / "python.exe" if os.name == "nt" else venv_dir / "bin" / "python3"
+
+
+def _venv_bin_dir(venv_dir: Path) -> Path:
+    return venv_dir / ("Scripts" if os.name == "nt" else "bin")
+
+
+@pytest.mark.skipif(not has_idat(), reason="Skip when idat not present (Free/Home)")
+def test_find_current_python_executable_honors_activated_virtualenv(tmp_path, monkeypatch):
+    source_idausr = get_ida_user_dir()
+    if not source_idausr.exists():
+        pytest.skip("Current IDAUSR directory not available")
+
+    install_dir = find_current_ida_install_directory()
+    venv_dir = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+
+    target_idausr = tmp_path / "idausr-activated"
+    _prepare_isolated_idausr_for_python_detection(source_idausr, target_idausr)
+
+    monkeypatch.setenv("HCLI_IDAUSR", str(target_idausr))
+    monkeypatch.setenv("HCLI_CURRENT_IDA_INSTALL_DIR", str(install_dir))
+    monkeypatch.setenv("VIRTUAL_ENV", str(venv_dir))
+    monkeypatch.setenv("PATH", str(_venv_bin_dir(venv_dir)) + os.pathsep + os.environ.get("PATH", ""))
+    monkeypatch.delenv("IDAPYTHON_VENV_EXECUTABLE", raising=False)
+    monkeypatch.delenv("HCLI_CURRENT_IDA_PYTHON_EXE", raising=False)
+
+    result = find_current_python_executable()
+    _assert_detected_venv_python(result, venv_dir)
+
+
+@pytest.mark.skipif(not has_idat(), reason="Skip when idat not present (Free/Home)")
+def test_find_current_python_executable_honors_idapython_venv_executable(tmp_path, monkeypatch):
+    source_idausr = get_ida_user_dir()
+    if not source_idausr.exists():
+        pytest.skip("Current IDAUSR directory not available")
+
+    install_dir = find_current_ida_install_directory()
+    venv_dir = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+
+    target_idausr = tmp_path / "idausr-venv-executable"
+    _prepare_isolated_idausr_for_python_detection(source_idausr, target_idausr)
+
+    monkeypatch.setenv("HCLI_IDAUSR", str(target_idausr))
+    monkeypatch.setenv("HCLI_CURRENT_IDA_INSTALL_DIR", str(install_dir))
+    monkeypatch.setenv("IDAPYTHON_VENV_EXECUTABLE", str(_venv_launcher_for_ida(venv_dir)))
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("HCLI_CURRENT_IDA_PYTHON_EXE", raising=False)
+
+    result = find_current_python_executable()
+    _assert_detected_venv_python(result, venv_dir)
+
+
+@pytest.mark.skipif(not has_idat(), reason="Skip when idat not present (Free/Home)")
+def test_find_current_python_executable_honors_idapythonrc(tmp_path, monkeypatch):
+    source_idausr = get_ida_user_dir()
+    if not source_idausr.exists():
+        pytest.skip("Current IDAUSR directory not available")
+
+    install_dir = find_current_ida_install_directory()
+    venv_dir = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+
+    target_idausr = tmp_path / "idausr-idapythonrc"
+    _prepare_isolated_idausr_for_python_detection(source_idausr, target_idausr)
+
+    (target_idausr / "idapythonrc.py").write_text(
+        "import os, site, sys\n"
+        "venv = os.environ['HCLI_TEST_VENV']\n"
+        'ver = f"{sys.version_info.major}.{sys.version_info.minor}"\n'
+        "site.addsitedir(os.path.join(venv, 'lib', f'python{ver}', 'site-packages'))\n"
+        "sys.prefix = venv\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HCLI_IDAUSR", str(target_idausr))
+    monkeypatch.setenv("HCLI_CURRENT_IDA_INSTALL_DIR", str(install_dir))
+    monkeypatch.setenv("HCLI_TEST_VENV", str(venv_dir))
+    monkeypatch.delenv("HCLI_CURRENT_IDA_PYTHON_EXE", raising=False)
+
+    result = find_current_python_executable()
+    _assert_detected_venv_python(result, venv_dir)
 
 
 @pytest.mark.skipif(not has_idat(), reason="Skip when idat not present (Free/Home)")

--- a/tests/lib/test_ida_python.py
+++ b/tests/lib/test_ida_python.py
@@ -8,6 +8,7 @@ import pytest
 from hcli.lib.ida import find_current_ida_install_directory, get_ida_user_dir
 from hcli.lib.ida.python import (
     CantInstallPackagesError,
+    _derive_python_exe,
     does_current_ida_have_pip,
     find_current_python_executable,
     verify_pip_can_install_packages,
@@ -66,6 +67,29 @@ def _venv_launcher_for_ida(venv_dir: Path) -> Path:
 
 def _venv_bin_dir(venv_dir: Path) -> Path:
     return venv_dir / ("Scripts" if os.name == "nt" else "bin")
+
+
+def test_derive_python_exe_honors_validated_virtualenv_executable_when_prefix_is_base(tmp_path):
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    (venv_dir / "pyvenv.cfg").write_text("home = /base/python\n", encoding="utf-8")
+    bin_dir = _venv_bin_dir(venv_dir)
+    bin_dir.mkdir()
+    venv_python = _venv_launcher_for_ida(venv_dir)
+    venv_python.write_text("", encoding="utf-8")
+
+    info = {
+        "frozen": False,
+        "prefix": "/Library/Frameworks/Python.framework/Versions/3.14",
+        "base_prefix": "/Library/Frameworks/Python.framework/Versions/3.14",
+        "executable": str(venv_python),
+        "virtual_env": str(venv_dir),
+        "idapython_venv_executable": str(venv_python),
+        "version_major": 3,
+        "version_minor": 14,
+    }
+
+    assert _derive_python_exe(info) == venv_python
 
 
 @pytest.mark.skipif(not has_idat(), reason="Skip when idat not present (Free/Home)")


### PR DESCRIPTION
closes #194

We copy:

- Licenses: `*.hexlic`
- Registry: `ida.reg`
- IDAPython config: `cfg/idapython.cfg`

Into a temporary folder before running `idat` to avoid loading plugins. In my case a plugin crashed IDA when launched headlessly and this resolves the issue. I checked and there is no flag to avoid loading Python plugins in any other way.