### PR TITLE
Build for Linux aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest,  platform: linux,   artifact-name: hcli-linux-x86_64 }
-          - { os: windows-latest, platform: windows, artifact-name: hcli-windows-x86_64 }
-          - { os: macos-latest,   platform: macos,   artifact-name: hcli-mac-arm64 }
+          - { os: ubuntu-latest,    platform: linux,   artifact-name: hcli-linux-x86_64 }
+          - { os: ubuntu-24.04-arm, platform: linux,   artifact-name: hcli-linux-aarch64 }
+          - { os: windows-latest,   platform: windows, artifact-name: hcli-windows-x86_64 }
+          - { os: macos-latest,     platform: macos,   artifact-name: hcli-mac-arm64 }
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Github has ARM runners for Linux and it would be useful to have a prebuilt package for running inside Linux containers on MacOS