### PR TITLE
plugin: add bundle command and offline install

### DIFF
--- a/docs/advanced/ci-cd-integration.md
+++ b/docs/advanced/ci-cd-integration.md
@@ -304,5 +304,6 @@ jobs:
 
 - Review [Environment Variables](../reference/environment-variables.md) for all configuration options
 - See [Packaging Your Plugin](../reference/packaging-your-existing-plugin.md) for automated plugin builds
+- Build [Plugin Bundles](../reference/plugin-bundle-spec.md) in CI for deploying to air-gapped machines
 - Check [Authentication](../getting-started/authentication.md) for more on API key management
 - Explore real-world examples in the [zydisinfo](https://github.com/milankovo/zydisinfo/blob/main/.github/workflows/build.yml) repository

--- a/docs/how-to/test-plugin-before-publishing.md
+++ b/docs/how-to/test-plugin-before-publishing.md
@@ -424,6 +424,7 @@ For more detailed information:
 - [Plugin Packaging and Format](../reference/plugin-packaging-and-format.md)
 - [Plugin Manager User Guide](../user-guide/plugin-manager.md)
 - [Plugin Repository Architecture](../reference/plugin-repository-architecture.md)
+- [Plugin Bundles](../reference/plugin-bundle-spec.md) for offline distribution
 
 ## Getting Help
 

--- a/docs/reference/plugin-bundle-spec.md
+++ b/docs/reference/plugin-bundle-spec.md
@@ -1,0 +1,284 @@
+# HCLI plugin bundle specification
+
+## Goal
+
+HCLI must be able to install IDA plugins and their Python dependencies on machines that cannot reach the network. A connected machine builds a plugin bundle archive. An offline machine can copy that archive locally and use normal plugin manager commands against it.
+
+The plugin bundle is repository-level. It may contain multiple plugins, multiple versions, and the shared wheelhouses (directories of pre-downloaded `.whl` files) needed to install those plugins. It is not a per-plugin sandbox, and it does not change HCLI's current dependency installation model: Python dependencies are installed into the active IDA Python environment.
+
+## Supported user flows
+
+Create a plugin bundle on a connected machine targeting the current machine's platform and Python:
+
+```console
+hcli plugin bundle create \
+  --path malware-vm-tools-2026-04.hcli-plugin-bundle.zip \
+  --platform current --python current \
+  oplog==0.1.3 \
+  hint-calls==0.1.3
+```
+
+Both `--platform` and `--python` are always required. The special value `current` resolves to the current machine's platform or Python version. The special value `all` resolves to all supported platforms (linux, windows, macos-arm64, macos-intel) or all supported Python versions (3.10–3.14). Otherwise, pass a specific name like `linux` or version like `3.12`.
+
+Create a plugin bundle for all platforms at specific Python versions:
+
+```console
+hcli plugin bundle create \
+  --path bundle.zip \
+  --platform all --python 3.12 --python 3.13 \
+  oplog==0.1.3 \
+  hint-calls==0.1.3
+```
+
+Create a plugin bundle for specific platforms and Python versions:
+
+```console
+hcli plugin bundle create \
+  --path malware-vm-tools-2026-04.hcli-plugin-bundle.zip \
+  --platform linux --platform windows --platform macos-arm64 \
+  --python 3.12 --python 3.13 \
+  oplog==0.1.3 \
+  hint-calls==0.1.3
+```
+
+`--platform` and `--python` are both repeatable. HCLI builds the cross product of all specified platforms and Python versions. Platform accepts short aliases: `linux`, `windows`, `macos-arm64`, `macos-intel`, `win`, etc. Duplicate targets from overlapping aliases (e.g. `--platform all --platform linux`) are deduplicated.
+
+Create a plugin bundle that includes local/private plugin archives:
+
+```console
+hcli plugin bundle create \
+  --path internal-review.hcli-plugin-bundle.zip \
+  --platform current --python current \
+  --repo /path/to/internal-plugin-repository.json \
+  ./dist/internal-plugin-1.2.0.zip \
+  private-helper==2.0.0
+```
+
+Inspect or search a plugin bundle without manual extraction:
+
+```console
+hcli plugin --repo ./malware-vm-tools-2026-04.hcli-plugin-bundle.zip search
+hcli plugin --repo ./malware-vm-tools-2026-04.hcli-plugin-bundle.zip search hints
+```
+
+Install from a plugin bundle on an offline machine:
+
+```console
+hcli plugin --repo ./malware-vm-tools-2026-04.hcli-plugin-bundle.zip install hint-calls
+```
+
+Upgrade from a plugin bundle:
+
+```console
+hcli plugin --repo ./malware-vm-tools-2026-04.hcli-plugin-bundle.zip upgrade hint-calls
+```
+
+In plugin bundle mode, upgrade means "upgrade to the newest compatible version available in this plugin bundle." It does not mean latest upstream.
+
+### Advanced usage
+
+Use a corporate pip index instead of the default pip configuration:
+
+```console
+hcli plugin --pip-index-url https://pypi.example.corp/simple install ipyida
+```
+
+Use an explicit local wheel source:
+
+```console
+hcli plugin --pip-find-links /mnt/wheelhouse --offline install ipyida
+```
+
+## Command-line interface
+
+The plugin command group gains these options:
+
+```console
+hcli plugin [--repo REPO] [--pip-index-url URL] [--pip-extra-index-url URL] [--pip-find-links PATH_OR_URL] [--offline] COMMAND ...
+```
+
+`--repo` accepts the existing repository forms plus a local plugin bundle archive. A plugin bundle archive is a ZIP file containing top-level `plugin-bundle.json`.
+
+`--pip-index-url` is passed to pip as `--index-url`. It may point to PyPI, Artifactory, or any other compatible package index.
+
+`--pip-extra-index-url` is repeatable and passed to pip as `--extra-index-url`.
+
+`--pip-find-links` is repeatable and passed to pip as `--find-links`.
+
+`--offline` forces pip dependency resolution to use only local sources. It passes `--no-index` and must be used with either a plugin bundle wheelhouse or at least one `--pip-find-links` value.
+
+Pip source precedence is:
+
+1. Explicit pip CLI options.
+2. Plugin bundle wheelhouse selected from the active plugin bundle.
+3. Existing configured/default online pip behavior.
+
+If explicit pip CLI options are provided while using a plugin bundle repository, the explicit options control dependency installation. The plugin bundle still controls plugin discovery and plugin archive bytes.
+
+## Plugin bundle archive format
+
+A plugin bundle archive is a ZIP file with this layout:
+
+```text
+plugin-bundle.json
+plugins/
+  <archive-name>.zip
+dependencies/
+  python/
+    <target-id>/
+      <wheel files>.whl
+```
+
+The `plugins/` directory contains unmodified IDA plugin ZIP archives. HCLI discovers bundled plugins by walking `plugins/` and reading `ida-plugin.json` from each archive.
+
+Each `dependencies/python/<target-id>/` directory is a flat wheelhouse for one target tuple. Wheels keep their original filenames. Sdists are rejected by default during bundle creation.
+
+Each target entry in the manifest is a snapshot of the exact compatibility parameters used to fetch wheels for that target. This allows audit and install to verify wheel compatibility without re-deriving the parameters.
+
+`plugin-bundle.json` is UTF-8 JSON. Version 1 has this shape:
+
+```json
+{
+  "version": 1,
+  "kind": "hcli-plugin-bundle",
+  "builtAt": "2026-04-28T16:00:00Z",
+  "createdBy": {
+    "tool": "hcli",
+    "version": "0.0.0"
+  },
+  "targetPlatformTags": [
+    {
+      "id": "linux-x86_64-cp312",
+      "idaPlatform": "linux-x86_64",
+      "pythonVersion": "3.12",
+      "implementation": "cp",
+      "abis": ["cp312", "abi3", "none"],
+      "pipPlatformTags": [
+        "manylinux_2_28_x86_64",
+        "manylinux_2_17_x86_64",
+        "manylinux2014_x86_64"
+      ],
+      "wheelhouse": "dependencies/python/linux-x86_64-cp312"
+    }
+  ]
+}
+```
+
+## Target matching
+
+On install or upgrade, HCLI detects the active IDA platform and active IDA Python interpreter. For IDA 9.0+, the first supported Python line is Python 3.10+.
+
+HCLI selects a wheelhouse whose target tuple matches:
+
+- HCLI/IDA platform, such as `windows-x86_64` or `macos-aarch64`
+- Python major/minor version
+- CPython implementation and ABI expectations
+
+If no target tuple matches, HCLI fails before changing plugins or installing dependencies.
+
+A plugin bundle may contain target tuples for operating systems and Python versions other than the machine that created it. Cross-target creation is supported when every dependency can be obtained as a compatible wheel for the requested target. If a required dependency is available only as an sdist, or only as a wheel with a platform baseline newer than the target, bundle creation or audit must fail for that target unless the user supplies a matching prebuilt wheel.
+
+### IDA version compatibility during bundle creation
+
+Bundle creation does not check IDA version compatibility. The builder machine may run a different IDA version than the target machines, and plugin `idaVersions` metadata is not a useful filtering axis during packaging. Plugins are bundled as-is; IDA version compatibility is checked only at install time on the target machine. This avoids adding IDA version as yet another dimension to the target matrix (alongside platform and Python version) and keeps the bundle creation model simple. If users report problems with this approach, IDA version filtering can be revisited.
+
+## Dependency installation behavior
+
+When installing a plugin with `pythonDependencies`, HCLI installs dependencies with pip before extracting the plugin. In plugin bundle offline mode it extracts the matching wheelhouse to a temporary directory and invokes pip with local-only options:
+
+```console
+python -m pip install \
+  --isolated \
+  --disable-pip-version-check \
+  --no-cache-dir \
+  --no-index \
+  --find-links <temporary-wheelhouse> \
+  <all dependency specs>
+```
+
+HCLI includes dependency specs from already installed HCLI-managed plugins plus the plugin being installed or upgraded. Already installed packages may satisfy requirements if pip considers them compatible. HCLI does not use `--ignore-installed` by default.
+
+No hash pinning is required. The user trusts the plugin bundle author.
+
+HCLI does not uninstall Python dependencies when plugins are uninstalled. Orphaned dependencies are left in the Python environment, matching current behavior.
+
+## Bundle creation behavior
+
+`hcli plugin bundle create` accepts explicit plugin versions and local plugin ZIP paths as positional arguments. Repository plugin references must include an exact version, for example `oplog==0.1.3`. Bare latest resolution is intentionally not part of the first version. `--path` selects the output archive path.
+
+Targeting uses `--platform` and `--python`, both required and repeatable. Each accepts `current` (auto-detect this machine), `all` (all supported values), or a specific value. `--platform` accepts the canonical IDA platform name (e.g. `linux-x86_64`) or short aliases (`linux`, `windows`, `macos-arm64`, `macos-intel`). `--python` accepts a `major.minor` version string (e.g. `3.12`). HCLI builds the cross product of all resolved platforms and Python versions. Duplicate targets are deduplicated.
+
+The supported Python versions for `--python all` are maintained as a hardcoded constant (`SUPPORTED_PYTHON_VERSIONS`): 3.10, 3.11, 3.12, 3.13, 3.14. This is updated when new Python versions release (annually in October). This matches the approach used by cibuildwheel and other ecosystem tools — no package provides this list dynamically.
+
+A legacy `--target` flag (e.g. `--target linux-x86_64-cp312`) is accepted for scripting but hidden from help. It cannot be combined with `--platform` or `--python`.
+
+Bundle creation resolves all selected plugin archives, reads their `ida-plugin.json` metadata, collects all `pythonDependencies`, and materializes a flat wheelhouse per target tuple. A single online Linux builder can create wheelhouses for all target platforms when all dependencies publish compatible wheels.
+
+The preferred wheelhouse materialization path is one `pip download` invocation per target. For cross-target downloads HCLI must pass all compatibility options together:
+
+```console
+python -m pip download \
+  --only-binary=:all: \
+  --implementation cp \
+  --python-version <major.minor> \
+  --abi <cp-abi> --abi abi3 --abi none \
+  --platform <platform-tag> [--platform <platform-tag> ...] \
+  --dest <wheelhouse> \
+  -r <requirements-or-lock>
+```
+
+`--platform` is repeatable. Linux targets should list every manylinux tag HCLI accepts, for example `manylinux_2_28_x86_64`, `manylinux_2_17_x86_64`, and `manylinux2014_x86_64`. macOS x86_64 targets should include the supported deployment baseline. Optional targets such as Windows ARM64 or musllinux should be explicit presets rather than inferred from x86_64 targets. Over-listing compatible tags is safer than under-listing them.
+
+`uv pip compile --universal` may be used to produce one cross-platform lock or constraints file before materializing target wheelhouses. `uv pip install --python-platform ... --python ... --target ...` is also valid for producing an unpacked per-target site-packages tree; because the version 1 plugin bundle format stores wheel files, `pip download` remains the direct path for wheelhouse plugin bundles unless HCLI later adds an unpacked dependency tree format.
+
+By default, bundle creation rejects sdists because offline installation from sdists requires build tools and build dependencies on the target. Missing wheels are handled by failing the affected target, by using a matching builder to produce wheels, or by supplying prebuilt wheels with a local `--find-links` source. Linux wheels can often be built from one Linux host inside a manylinux container. Windows and macOS sdist-only dependencies require native runners or prebuilt vendor wheels.
+
+If selected plugins have incompatible Python dependency constraints, bundle creation fails.
+
+## Additive plugin bundles
+
+Plugin bundles are additive. An offline VM may use one plugin bundle today and a second plugin bundle later. HCLI does not require a single authoritative plugin bundle for the machine.
+
+When a plugin bundle install fails, errors should distinguish where possible: whether the plugin is absent from the bundle, whether it exists but is incompatible with the current IDA version or platform, whether no wheelhouse matches the active IDA Python, whether a dependency wheel is missing from the selected wheelhouse, or whether dependency constraints conflict with already installed packages.
+
+## Private plugin metadata
+
+The `repository` field in `ida-plugin.json` must be a valid GitHub URL (`https://github.com/org/project`). This applies to both public and private plugins. Private plugins should use a GitHub repository URL — either a public repo or a private one. If no real repository exists, a placeholder GitHub URL is acceptable (e.g. `https://github.com/internal/placeholder`) because the public plugin indexer only fetches URLs for plugins it ingests, and offline bundle plugins are never indexed.
+
+The validation is intentionally not relaxed to support arbitrary hosting providers (GitLab, Gitea, etc.) until there are concrete user requirements. Keeping the GitHub constraint preserves the field's usefulness as a consistent, predictable link format across all plugins.
+
+## Plugin spec disambiguation
+
+When the plugin repository contains multiple entries with the same plugin name from different hosts (e.g. forks), `bundle create` requires the `@host` suffix to disambiguate:
+
+```console
+hcli plugin bundle create \
+  --path bundle.zip \
+  --platform all --python all \
+  "efiXplorer==6.2.0@https://github.com/rehints/efixplorer" \
+  "idalib-rust-bindings==0.9.0@https://github.com/idalib-rs/idalib"
+```
+
+The `@host` is parsed from the spec before resolution. Unambiguous plugins do not require it.
+
+## Known limitations observed during all-plugin bundle testing
+
+Bundle creation pools all `pythonDependencies` from every included plugin into a single `pip download` invocation per target. A single unresolvable dependency (nonexistent version, missing wheel for the target) fails the entire wheelhouse for that target. There is no per-plugin isolation.
+
+Plugins observed with broken or unavailable dependencies at the time of testing (2026-05-04):
+
+- `Frida_Tools`, `FridaTools`: require `pyside6>=6.10.2` (no such version on PyPI)
+- `idapcode`: requires `pypcode~=3.3.3` (no such version on PyPI; available versions max at 1.1.2)
+- `IDAssist`: requires `pysqlite3` (no binary wheels for macOS x86_64 or cp310)
+- `ida-cyberchef`: requires `STPyV8` (no binary wheels for cp310 targets)
+- `fwhunt-ida`: requires `fwhunt-scan~=2.3.5` which depends on `uefi-firmware>=1.10` (no wheels for macOS aarch64)
+
+Additionally, `codeload.github.com` URLs produce archives with non-deterministic hashes, causing SHA256 verification failures for plugins that use them as download URLs (e.g. `xray`). This is a plugin repository data issue, not a bundle code issue.
+
+Python 3.14 targets often fail because many packages have not yet published cp314 wheels (as of 2026-05-04). The `--python all` flag includes 3.14 by default; use explicit `--python 3.10 --python 3.11 --python 3.12 --python 3.13` to avoid these failures until ecosystem support improves.
+
+A future improvement could add a `--skip-on-error` flag to bundle creation so that individual plugin dependency failures are reported as warnings rather than aborting the entire build.
+
+## Out of scope
+
+The first version does not address per-plugin dependency sandboxes, dependency removal on uninstall, reproducible builds, or wheel redistribution and license compliance. Plugin bundle signatures and external checksum files are also deferred, as is storing corporate pip index settings in `ida-config.json`.

--- a/docs/reference/plugin-bundle-spec.md
+++ b/docs/reference/plugin-bundle-spec.md
@@ -184,14 +184,14 @@ Bundle creation does not check IDA version compatibility. The builder machine ma
 
 ## Dependency installation behavior
 
-When installing a plugin with `pythonDependencies`, HCLI installs dependencies with pip before extracting the plugin. In plugin bundle offline mode it extracts the matching wheelhouse to a temporary directory and invokes pip with local-only options:
+When installing a plugin with `pythonDependencies`, HCLI installs dependencies with pip before extracting the plugin. When a plugin bundle is in use, HCLI extracts the matching wheelhouse to a temporary directory and adds it as a `--find-links` source. By default pip can still reach online indexes, so a bundle with an incomplete wheelhouse will fall back to downloading missing wheels. When the user passes `--offline`, HCLI adds `--no-index` so pip resolves only from local sources:
 
 ```console
 python -m pip install \
   --isolated \
   --disable-pip-version-check \
   --no-cache-dir \
-  --no-index \
+  [--no-index]           # only when --offline is passed \
   --find-links <temporary-wheelhouse> \
   <all dependency specs>
 ```

--- a/docs/reference/plugin-bundle-spec.md
+++ b/docs/reference/plugin-bundle-spec.md
@@ -282,3 +282,9 @@ A future improvement could add a `--skip-on-error` flag to bundle creation so th
 ## Out of scope
 
 The first version does not address per-plugin dependency sandboxes, dependency removal on uninstall, reproducible builds, or wheel redistribution and license compliance. Plugin bundle signatures and external checksum files are also deferred, as is storing corporate pip index settings in `ida-config.json`.
+
+## See also
+
+- [Plugin packaging and format](./plugin-packaging-and-format.md) — the individual plugin archive format that bundles wrap
+- [Plugin repository architecture](./plugin-repository-architecture.md) — the online repository that bundles replace for offline use
+- [CI/CD Integration](../advanced/ci-cd-integration.md) — building bundles in automated pipelines

--- a/docs/reference/plugin-packaging-and-format.md
+++ b/docs/reference/plugin-packaging-and-format.md
@@ -279,3 +279,5 @@ plugins.zip
     └── ida-plugin.json
 ```
 
+Plugin archives can also be collected into a [plugin bundle](./plugin-bundle-spec.md) for offline installation on air-gapped machines.
+

--- a/docs/user-guide/plugin-manager.md
+++ b/docs/user-guide/plugin-manager.md
@@ -61,6 +61,8 @@ You'll want to know the HCLI commands:
 ❯ hcli plugin uninstall <plugin-name>
 ```
 
+For offline or air-gapped environments, plugins can be installed from a plugin bundle archive. See [Plugin Bundles](../reference/plugin-bundle-spec.md) for details.
+
 Plugins are written to `$IDAUSR/plugins`, which is typically `~/.idapro/plugins` on Unix-like systems, where IDA Pro will load them the next time the application is opened.
 
 You can discover interesting plugins via:
@@ -101,3 +103,4 @@ Check out the following resources and don't hesitate to contact us for support:
   - [Plugin repository architecture](../reference/plugin-repository-architecture.md)
   - [Plugin packaging and format](../reference/plugin-packaging-and-format.md)
   - [Publishing your existing plugin](../reference/packaging-your-existing-plugin.md)
+  - [Plugin bundles](../reference/plugin-bundle-spec.md) for offline distribution

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
     - Repository Architecture: reference/plugin-repository-architecture.md
     - Packaging Format: reference/plugin-packaging-and-format.md
     - Publishing Your Plugin: reference/packaging-your-existing-plugin.md
+    - Plugin Bundles: reference/plugin-bundle-spec.md
   - Reference:
     - Environment Variables: reference/environment-variables.md
   - Changelog: changelog.md

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -47,7 +47,7 @@ def read_repos_file(path: Path) -> list[str]:
 @click.group()
 @click.option(
     "--repo",
-    help="'github', or path to directory containing plugins, or path to JSON file, or URL to JSON file",
+    help="'github', path to directory containing plugins, path to JSON file, URL to JSON file, or path to a plugin bundle .zip",
     hidden=True,
 )
 @click.option("--with-repos-list", help="path to file containing known GitHub repositories", hidden=True)
@@ -76,7 +76,7 @@ def plugin(
     pip_options = PipOptions(
         index_url=pip_index_url,
         extra_index_urls=pip_extra_index_url,
-        find_links=tuple(Path(p) if not p.startswith(("http://", "https://")) else p for p in pip_find_links),
+        find_links=tuple(Path(p).expanduser() if "://" not in p else p for p in pip_find_links),
         offline=offline,
     )
     ctx.obj["pip_options"] = pip_options

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -13,7 +13,10 @@ import hcli.lib.ida.plugin.repo.fs
 import hcli.lib.ida.plugin.repo.github
 from hcli.lib.console import console
 from hcli.lib.ida import get_ida_config
+from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo, is_plugin_bundle_zip
+from hcli.lib.ida.python import PipOptions
 
+from .bundle import bundle
 from .config import config
 from .install import install_plugin
 from .lint import lint_plugin_directory
@@ -49,11 +52,34 @@ def read_repos_file(path: Path) -> list[str]:
 )
 @click.option("--with-repos-list", help="path to file containing known GitHub repositories", hidden=True)
 @click.option("--with-ignored-repos-list", help="path to file containing ignored GitHub repositories", hidden=True)
+@click.option("--pip-index-url", help="pip --index-url for dependency installation", hidden=True)
+@click.option("--pip-extra-index-url", multiple=True, help="pip --extra-index-url (repeatable)", hidden=True)
+@click.option("--pip-find-links", multiple=True, help="pip --find-links (repeatable)", hidden=True)
+@click.option(
+    "--offline", is_flag=True, default=False, help="force pip to use only local sources (--no-index)", hidden=True
+)
 @click.pass_context
-def plugin(ctx, repo: str | None, with_repos_list: str | None, with_ignored_repos_list: str | None) -> None:
+def plugin(
+    ctx,
+    repo: str | None,
+    with_repos_list: str | None,
+    with_ignored_repos_list: str | None,
+    pip_index_url: str | None,
+    pip_extra_index_url: tuple[str, ...],
+    pip_find_links: tuple[str, ...],
+    offline: bool,
+) -> None:
     """Manage IDA Pro plugins."""
     # TODO: cleanup list and anything else touching github
     ctx.ensure_object(dict)
+
+    pip_options = PipOptions(
+        index_url=pip_index_url,
+        extra_index_urls=pip_extra_index_url,
+        find_links=tuple(Path(p) if not p.startswith(("http://", "https://")) else p for p in pip_find_links),
+        offline=offline,
+    )
+    ctx.obj["pip_options"] = pip_options
 
     # fix #190: stale stdout/err handles due to click pytest integration
     hcli.lib.console._sync_console_streams()
@@ -115,6 +141,8 @@ def plugin(ctx, repo: str | None, with_repos_list: str | None, with_ignored_repo
 
             if path.is_dir():
                 plugin_repo = hcli.lib.ida.plugin.repo.fs.FileSystemPluginRepo(path)
+            elif is_plugin_bundle_zip(path):
+                plugin_repo = PluginBundleRepo(path)
             else:
                 plugin_repo = hcli.lib.ida.plugin.repo.file.JSONFilePluginRepo.from_file(path)
 
@@ -132,6 +160,10 @@ def plugin(ctx, repo: str | None, with_repos_list: str | None, with_ignored_repo
 
     ctx.obj["plugin_repo"] = plugin_repo
 
+    if offline and not pip_find_links and not isinstance(plugin_repo, PluginBundleRepo):
+        console.print("[red]--offline requires --pip-find-links or a plugin bundle repository[/red]")
+        raise click.Abort()
+
 
 plugin.add_command(get_plugin_status, name="status")
 plugin.add_command(search_plugins, name="search")
@@ -142,3 +174,4 @@ plugin.add_command(uninstall_plugin, name="uninstall")
 plugin.add_command(repo, name="repo")
 plugin.add_command(config, name="config")
 plugin.add_command(schema, name="schema")
+plugin.add_command(bundle, name="bundle")

--- a/src/hcli/commands/plugin/bundle.py
+++ b/src/hcli/commands/plugin/bundle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import shutil
@@ -76,12 +77,15 @@ def _resolve_plugin_bytes(
     plugin_repo=None,
     current_platform: str | None = None,
 ) -> tuple[str, bytes]:
-    path = Path(spec)
+    path = Path(spec).expanduser()
     if path.exists() and spec.endswith(".zip"):
         buf = path.read_bytes()
         items = list(get_metadatas_with_paths_from_plugin_archive(buf))
         if not items:
             raise ValueError(f"no ida-plugin.json found in {spec}")
+        if len(items) != 1:
+            names = ", ".join(item[1].plugin.name for item in items)
+            raise ValueError(f"plugin archive must contain a single plugin, found: {names}")
         return items[0][1].plugin.name, buf
 
     host: str | None = None
@@ -94,7 +98,8 @@ def _resolve_plugin_bytes(
         pass
 
     if "==" not in clean_spec:
-        raise click.BadParameter(f"repository plugin specs must include exact version (e.g. {spec}==1.0.0)")
+        example = f"{clean_spec}==1.0.0@{host}" if host else f"{clean_spec}==1.0.0"
+        raise click.BadParameter(f"repository plugin specs must include exact version (e.g. {example})")
 
     if plugin_repo is None:
         raise click.BadParameter("no plugin repository available to resolve spec")
@@ -234,7 +239,7 @@ def create(
     for t in pip_targets:
         stderr_console.print(f"  {t.ida_platform}  Python {t.python_version}  ({t.id})")
 
-    current_platform: str | None = None
+    target_platforms = sorted({t.ida_platform for t in pip_targets})
 
     with tempfile.TemporaryDirectory(prefix="hcli-bundle-staging-") as staging_dir:
         staging = Path(staging_dir)
@@ -247,26 +252,47 @@ def create(
         plugin_index = PluginArchiveIndex()
 
         for spec in plugin_specs:
-            if not (Path(spec).exists() and spec.endswith(".zip")) and current_platform is None:
-                from hcli.lib.ida import find_current_ida_platform
+            is_local = Path(spec).exists() and spec.endswith(".zip")
 
-                current_platform = find_current_ida_platform()
+            archives_by_hash: dict[str, tuple[str, bytes]] = {}
+            hash_by_platform: dict[str, str] = {}
 
-            with rich.status.Status(f"resolving {spec}", console=stderr_console):
-                name, buf = _resolve_plugin_bytes(spec, pip_options, parent_repo, current_platform)
-
-            archive_filename = f"{name}-{get_version_from_plugin_archive(buf, name)}.zip"
-            dest = plugins_dir / archive_filename
-            if dest.exists():
-                logger.debug("plugin archive already staged: %s", archive_filename)
+            if is_local:
+                with rich.status.Status(f"resolving {spec}", console=stderr_console):
+                    name, buf = _resolve_plugin_bytes(spec, pip_options, parent_repo)
+                h = hashlib.sha256(buf).hexdigest()
+                archives_by_hash[h] = (name, buf)
+                for plat in target_platforms:
+                    hash_by_platform[plat] = h
             else:
-                dest.write_bytes(buf)
+                for plat in target_platforms:
+                    with rich.status.Status(f"resolving {spec} for {plat}", console=stderr_console):
+                        name, buf = _resolve_plugin_bytes(spec, pip_options, parent_repo, plat)
+                    h = hashlib.sha256(buf).hexdigest()
+                    archives_by_hash[h] = (name, buf)
+                    hash_by_platform[plat] = h
 
-            plugin_index.index_plugin_archive(buf, f"hcli-bundle:plugins/{archive_filename}")
+            unique_hashes = set(hash_by_platform.values())
+            needs_platform_suffix = len(unique_hashes) > 1
 
-            for _, metadata in get_metadatas_with_paths_from_plugin_archive(buf):
-                if isinstance(metadata.plugin.python_dependencies, list):
-                    all_python_deps.extend(metadata.plugin.python_dependencies)
+            for h, (name, buf) in archives_by_hash.items():
+                version = get_version_from_plugin_archive(buf, name)
+                if needs_platform_suffix:
+                    platforms_for_hash = sorted(p for p, ph in hash_by_platform.items() if ph == h)
+                    suffix = "-" + "+".join(platforms_for_hash)
+                    archive_filename = f"{name}-{version}{suffix}.zip"
+                else:
+                    archive_filename = f"{name}-{version}.zip"
+
+                dest = plugins_dir / archive_filename
+                if not dest.exists():
+                    dest.write_bytes(buf)
+
+                plugin_index.index_plugin_archive(buf, f"hcli-bundle:plugins/{archive_filename}")
+
+                for _, metadata in get_metadatas_with_paths_from_plugin_archive(buf):
+                    if isinstance(metadata.plugin.python_dependencies, list):
+                        all_python_deps.extend(metadata.plugin.python_dependencies)
 
         target_manifests = []
         if all_python_deps:

--- a/src/hcli/commands/plugin/bundle.py
+++ b/src/hcli/commands/plugin/bundle.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import rich.status
+import rich_click as click
+
+from hcli import __version__ as hcli_version
+from hcli.lib.console import _sync_console_streams, console, stderr_console
+from hcli.lib.ida.plugin import (
+    get_metadatas_with_paths_from_plugin_archive,
+    get_version_from_plugin_archive,
+)
+from hcli.lib.ida.plugin.bundle import (
+    ALL_PLATFORMS,
+    SUPPORTED_PYTHON_VERSIONS,
+    PipTarget,
+    resolve_platform_alias,
+    to_manifest_target,
+)
+from hcli.lib.ida.plugin.reference import parse_plugin_reference
+from hcli.lib.ida.plugin.repo import PluginArchiveIndex
+from hcli.lib.ida.plugin.repo.bundle import (
+    PluginBundleRepo,
+    is_plugin_bundle_zip,
+)
+from hcli.lib.ida.python import PIP_OPTIONS_DEFAULT, PipOptions, find_current_python_executable
+
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+def bundle() -> None:
+    """Manage plugin bundles for offline installation."""
+    _sync_console_streams()
+
+
+@bundle.command()
+@click.argument("bundle_path", type=click.Path(exists=True))
+def info(bundle_path: str) -> None:
+    """Show plugin bundle metadata."""
+    path = Path(bundle_path)
+    if not is_plugin_bundle_zip(path):
+        console.print(f"[red]Error[/red]: {path} is not a plugin bundle")
+        raise click.Abort()
+
+    repo = PluginBundleRepo(path)
+    try:
+        console.print(f"[bold]plugin bundle[/bold]: {path}")
+        console.print(f"  built: {repo.built_at.isoformat()}")
+        console.print(f"  created by: {repo.manifest.created_by.tool} {repo.manifest.created_by.version}")
+        console.print(f"  targets: {', '.join(repo.target_ids)}")
+
+        plugins = repo.get_plugins()
+        if plugins:
+            console.print(f"  plugins: {len(plugins)}")
+            for plugin in plugins:
+                versions = sorted(plugin.versions.keys())
+                console.print(f"    {plugin.name}: {', '.join(versions)}")
+        else:
+            console.print("  plugins: (none)")
+    finally:
+        repo.close()
+
+
+def _resolve_plugin_bytes(
+    spec: str,
+    pip_options: PipOptions,
+    plugin_repo=None,
+    current_platform: str | None = None,
+) -> tuple[str, bytes]:
+    path = Path(spec)
+    if path.exists() and spec.endswith(".zip"):
+        buf = path.read_bytes()
+        items = list(get_metadatas_with_paths_from_plugin_archive(buf))
+        if not items:
+            raise ValueError(f"no ida-plugin.json found in {spec}")
+        return items[0][1].plugin.name, buf
+
+    host: str | None = None
+    clean_spec = spec
+    try:
+        ref = parse_plugin_reference(spec)
+        host = ref.host
+        clean_spec = f"{ref.name}{ref.version_spec}" if ref.version_spec else ref.name
+    except ValueError:
+        pass
+
+    if "==" not in clean_spec:
+        raise click.BadParameter(f"repository plugin specs must include exact version (e.g. {spec}==1.0.0)")
+
+    if plugin_repo is None:
+        raise click.BadParameter("no plugin repository available to resolve spec")
+
+    return plugin_repo.fetch_plugin_from_spec(clean_spec, current_platform, host=host)
+
+
+def _resolve_targets(
+    platforms: tuple[str, ...],
+    pythons: tuple[str, ...],
+    targets: tuple[str, ...],
+) -> list[PipTarget]:
+    """Resolve CLI options into a list of PipTarget instances.
+
+    Raises:
+        click.BadParameter: on invalid input.
+    """
+    if targets and (platforms or pythons):
+        raise click.BadParameter("--target cannot be combined with --platform or --python")
+
+    if targets:
+        parsed: list[PipTarget] = []
+        for t in targets:
+            try:
+                parsed.append(PipTarget.parse(t))
+            except ValueError as e:
+                raise click.BadParameter(str(e))
+        return parsed
+
+    if not platforms:
+        raise click.BadParameter(
+            "--platform is required\n"
+            "  use --platform current for this machine, or --platform all for all supported platforms"
+        )
+    if not pythons:
+        raise click.BadParameter(
+            "--python is required\n  use --python current for this machine, or --python all for all supported versions"
+        )
+
+    resolved_platforms: list[str] = []
+    for p in platforms:
+        lower = p.lower().strip()
+        if lower == "all":
+            resolved_platforms.extend(ALL_PLATFORMS)
+        elif lower == "current":
+            from hcli.lib.ida import find_current_ida_platform
+
+            resolved_platforms.append(find_current_ida_platform())
+        else:
+            try:
+                resolved_platforms.append(resolve_platform_alias(p))
+            except ValueError as e:
+                raise click.BadParameter(str(e))
+
+    resolved_pythons: list[str] = []
+    for py in pythons:
+        lower = py.lower().strip()
+        if lower == "all":
+            resolved_pythons.extend(SUPPORTED_PYTHON_VERSIONS)
+        elif lower == "current":
+            from hcli.lib.ida.python import detect_current_python_version
+
+            resolved_pythons.append(detect_current_python_version())
+        else:
+            resolved_pythons.append(py)
+
+    from hcli.lib.ida.plugin.bundle import MINIMUM_PYTHON_VERSION, _parse_python_version
+
+    seen: set[str] = set()
+    result: list[PipTarget] = []
+    for plat in resolved_platforms:
+        for pyv in resolved_pythons:
+            try:
+                resolve_platform_alias(plat)
+                ver = _parse_python_version(pyv)
+                if ver < MINIMUM_PYTHON_VERSION:
+                    raise ValueError(
+                        f"python {pyv} is below minimum {MINIMUM_PYTHON_VERSION[0]}.{MINIMUM_PYTHON_VERSION[1]}"
+                    )
+                target = PipTarget(ida_platform=plat, python_version=pyv)
+            except ValueError as e:
+                raise click.BadParameter(str(e))
+            if target.id not in seen:
+                seen.add(target.id)
+                result.append(target)
+    return result
+
+
+@bundle.command("create")
+@click.pass_context
+@click.option("--path", "output_path", required=True, type=click.Path(), help="output archive path")
+@click.option(
+    "--platform",
+    "platforms",
+    multiple=True,
+    help="target platform: 'current', 'all', or a name like 'linux', 'windows', 'macos-arm64' (repeatable)",
+)
+@click.option(
+    "--python",
+    "pythons",
+    multiple=True,
+    help="target Python version: 'current', 'all', or a version like '3.12', '3.13' (repeatable)",
+)
+@click.option("--target", "targets", multiple=True, hidden=True, help="exact target ID (e.g. linux-x86_64-cp312)")
+@click.option("--repo", "bundle_repo", default=None, help="plugin repository for resolving specs")
+@click.argument("plugin_specs", nargs=-1, required=True)
+def create(
+    ctx,
+    output_path: str,
+    platforms: tuple[str, ...],
+    pythons: tuple[str, ...],
+    targets: tuple[str, ...],
+    bundle_repo: str | None,
+    plugin_specs: tuple[str, ...],
+) -> None:
+    """Create a plugin bundle from plugin specs and/or local ZIPs."""
+    pip_options: PipOptions = ctx.obj.get("pip_options", PIP_OPTIONS_DEFAULT)
+    parent_repo = ctx.obj.get("plugin_repo")
+
+    if bundle_repo is not None:
+        from hcli.lib.ida.plugin.repo.file import JSONFilePluginRepo
+        from hcli.lib.ida.plugin.repo.fs import FileSystemPluginRepo
+
+        repo_path = Path(bundle_repo)
+        if repo_path.is_dir():
+            parent_repo = FileSystemPluginRepo(repo_path)
+        elif repo_path.exists():
+            parent_repo = JSONFilePluginRepo.from_file(repo_path)
+
+    try:
+        pip_targets = _resolve_targets(platforms, pythons, targets)
+    except click.BadParameter as e:
+        console.print(f"[red]error[/red]: {e.format_message()}")
+        raise click.Abort()
+
+    stderr_console.print(f"targets ({len(pip_targets)}):")
+    for t in pip_targets:
+        stderr_console.print(f"  {t.ida_platform}  Python {t.python_version}  ({t.id})")
+
+    current_platform: str | None = None
+
+    with tempfile.TemporaryDirectory(prefix="hcli-bundle-staging-") as staging_dir:
+        staging = Path(staging_dir)
+        plugins_dir = staging / "plugins"
+        plugins_dir.mkdir()
+        deps_dir = staging / "dependencies" / "python"
+        deps_dir.mkdir(parents=True)
+
+        all_python_deps: list[str] = []
+        plugin_index = PluginArchiveIndex()
+
+        for spec in plugin_specs:
+            if not (Path(spec).exists() and spec.endswith(".zip")) and current_platform is None:
+                from hcli.lib.ida import find_current_ida_platform
+
+                current_platform = find_current_ida_platform()
+
+            with rich.status.Status(f"resolving {spec}", console=stderr_console):
+                name, buf = _resolve_plugin_bytes(spec, pip_options, parent_repo, current_platform)
+
+            archive_filename = f"{name}-{get_version_from_plugin_archive(buf, name)}.zip"
+            dest = plugins_dir / archive_filename
+            if dest.exists():
+                logger.debug("plugin archive already staged: %s", archive_filename)
+            else:
+                dest.write_bytes(buf)
+
+            plugin_index.index_plugin_archive(buf, f"hcli-bundle:plugins/{archive_filename}")
+
+            for _, metadata in get_metadatas_with_paths_from_plugin_archive(buf):
+                if isinstance(metadata.plugin.python_dependencies, list):
+                    all_python_deps.extend(metadata.plugin.python_dependencies)
+
+        target_manifests = []
+        if all_python_deps:
+            for target in pip_targets:
+                wh_rel = f"dependencies/python/{target.id}"
+                wh_dir = deps_dir / target.id
+                wh_dir.mkdir(parents=True, exist_ok=True)
+
+                with rich.status.Status(
+                    f"downloading wheels for {target.ida_platform} Python {target.python_version}",
+                    console=stderr_console,
+                ):
+                    _download_wheelhouse(all_python_deps, target, wh_dir, pip_options)
+
+                _verify_wheelhouse(wh_dir, target)
+                target_manifests.append(to_manifest_target(target, wh_rel))
+        else:
+            for target in pip_targets:
+                wh_rel = f"dependencies/python/{target.id}"
+                wh_dir = deps_dir / target.id
+                wh_dir.mkdir(parents=True, exist_ok=True)
+                target_manifests.append(to_manifest_target(target, wh_rel))
+
+        manifest = {
+            "version": 1,
+            "kind": "hcli-plugin-bundle",
+            "builtAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "createdBy": {"tool": "hcli", "version": hcli_version},
+            "targetPlatformTags": [t.model_dump(by_alias=True) for t in target_manifests],
+        }
+
+        manifest_bytes = json.dumps(manifest, indent=2).encode("utf-8")
+
+        out = Path(output_path)
+        with rich.status.Status("writing bundle archive", console=stderr_console):
+            _write_bundle_zip(out, manifest_bytes, staging)
+
+    console.print(f"[green]created[/green] plugin bundle: {out}")
+    console.print(f"  plugins: {len(plugin_specs)}")
+    console.print(f"  targets: {len(pip_targets)}")
+    for t in pip_targets:
+        console.print(f"    {t.ida_platform}  Python {t.python_version}")
+
+
+def _download_wheelhouse(
+    deps: list[str],
+    target: PipTarget,
+    dest: Path,
+    pip_options: PipOptions,
+) -> None:
+    python_exe = find_current_python_executable()
+    cmd = [
+        str(python_exe),
+        "-m",
+        "pip",
+        "download",
+        *target.pip_download_args(),
+        "--dest",
+        str(dest),
+    ]
+
+    if pip_options.index_url:
+        cmd.extend(["--index-url", pip_options.index_url])
+    for url in pip_options.extra_index_urls:
+        cmd.extend(["--extra-index-url", url])
+    for link in pip_options.find_links:
+        cmd.extend(["--find-links", str(link)])
+    if pip_options.offline:
+        cmd.append("--no-index")
+
+    cmd.extend(deps)
+
+    logger.debug("pip download: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, check=False)
+    if result.returncode != 0:
+        stderr_text = result.stderr.decode("utf-8", errors="replace")
+        stdout_text = result.stdout.decode("utf-8", errors="replace")
+        raise RuntimeError(f"pip download failed for target {target.id}:\n{stdout_text}\n{stderr_text}")
+
+
+def _verify_wheelhouse(wh_dir: Path, target: PipTarget) -> None:
+    for f in wh_dir.iterdir():
+        if f.suffix == ".whl":
+            continue
+        if f.name.endswith((".tar.gz", ".tar.bz2", ".zip")):
+            raise ValueError(f"sdist found in wheelhouse for {target.id}: {f.name}")
+
+
+def _write_bundle_zip(output: Path, manifest_bytes: bytes, staging: Path) -> None:
+    tmp_output = output.with_suffix(".tmp.zip")
+    try:
+        with zipfile.ZipFile(tmp_output, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("plugin-bundle.json", manifest_bytes)
+
+            for file_path in sorted(staging.rglob("*")):
+                if file_path.is_file():
+                    arcname = file_path.relative_to(staging).as_posix()
+                    zf.write(file_path, arcname)
+
+        shutil.move(str(tmp_output), str(output))
+    except Exception:
+        tmp_output.unlink(missing_ok=True)
+        raise

--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from hcli.lib.ida.plugin import (
     get_metadata_from_plugin_archive,
     get_metadatas_with_paths_from_plugin_archive,
 )
+from hcli.lib.ida.plugin.bundle import bundle_dependency_source
 from hcli.lib.ida.plugin.exceptions import (
     AmbiguousPluginReferenceError,
     InstalledPluginNameConflictError,
@@ -43,8 +45,10 @@ from hcli.lib.ida.plugin.reference import (
     parse_plugin_reference,
 )
 from hcli.lib.ida.plugin.repo import BasePluginRepo, fetch_plugin_archive
+from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo
 from hcli.lib.ida.plugin.repo.github import fetch_github_release_zip_asset, parse_github_url
 from hcli.lib.ida.plugin.settings import has_plugin_setting, parse_setting_value, set_plugin_setting
+from hcli.lib.ida.python import PIP_OPTIONS_DEFAULT, PipOptions, detect_current_python_version
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +73,8 @@ logger = logging.getLogger(__name__)
 )
 def install_plugin(ctx, plugin: str, editable: bool, config: tuple[str, ...], no_build_isolation: bool) -> None:
     """Install a plugin from a repository, local directory, local .zip file, or URL."""
+    pip_options: PipOptions = ctx.obj.get("pip_options", PIP_OPTIONS_DEFAULT)
+    plugin_repo_obj = ctx.obj.get("plugin_repo")
     plugin_spec = plugin
     try:
         with rich.status.Status("collecting environment", console=stderr_console):
@@ -215,17 +221,26 @@ def install_plugin(ctx, plugin: str, editable: bool, config: tuple[str, ...], no
                 parsed_value = parse_setting_value(descr, value_str)
                 descr.validate_value(parsed_value)
 
-        # No outer Status here -- both install paths below have their own
-        # inner Status calls on stderr_console, and Rich allows only one Live
-        # per console. Wrapping in an outer Status raises
-        # "Only one live display may be active at once" on a real TTY (it's
-        # silently a no-op when stderr is piped, which is why this bug went
-        # unnoticed for so long).
         if editable:
             install_plugin_directory_editable(source_dir, plugin_name, no_build_isolation=no_build_isolation)
         else:
-            assert buf is not None  # invariant: only the editable branch leaves buf as None
-            install_plugin_archive(buf, plugin_name, no_build_isolation=no_build_isolation)
+            assert buf is not None
+            effective_pip_options = pip_options
+            if isinstance(plugin_repo_obj, PluginBundleRepo) and pip_options == PIP_OPTIONS_DEFAULT:
+                with bundle_dependency_source(
+                    plugin_repo_obj, current_ida_platform, detect_current_python_version()
+                ) as bundle_opts:
+                    if bundle_opts is not None:
+                        effective_pip_options = bundle_opts
+                    if no_build_isolation:
+                        effective_pip_options = dataclasses.replace(effective_pip_options, no_build_isolation=True)
+                    with rich.status.Status("installing plugin", console=stderr_console):
+                        install_plugin_archive(buf, plugin_name, pip_options=effective_pip_options)
+            else:
+                if no_build_isolation:
+                    effective_pip_options = dataclasses.replace(effective_pip_options, no_build_isolation=True)
+                with rich.status.Status("installing plugin", console=stderr_console):
+                    install_plugin_archive(buf, plugin_name, pip_options=effective_pip_options)
 
         try:
             if metadata.plugin.settings:

--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -48,7 +48,7 @@ from hcli.lib.ida.plugin.repo import BasePluginRepo, fetch_plugin_archive
 from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo
 from hcli.lib.ida.plugin.repo.github import fetch_github_release_zip_asset, parse_github_url
 from hcli.lib.ida.plugin.settings import has_plugin_setting, parse_setting_value, set_plugin_setting
-from hcli.lib.ida.python import PIP_OPTIONS_DEFAULT, PipOptions, detect_current_python_version
+from hcli.lib.ida.python import PIP_OPTIONS_DEFAULT, PipOptions, detect_current_python_version, merge_bundle_pip_options
 
 logger = logging.getLogger(__name__)
 
@@ -226,12 +226,20 @@ def install_plugin(ctx, plugin: str, editable: bool, config: tuple[str, ...], no
         else:
             assert buf is not None
             effective_pip_options = pip_options
-            if isinstance(plugin_repo_obj, PluginBundleRepo) and pip_options == PIP_OPTIONS_DEFAULT:
+            if isinstance(plugin_repo_obj, PluginBundleRepo) and not pip_options.has_custom_sources:
+                current_python_version = detect_current_python_version()
                 with bundle_dependency_source(
-                    plugin_repo_obj, current_ida_platform, detect_current_python_version()
+                    plugin_repo_obj, current_ida_platform, current_python_version
                 ) as bundle_opts:
-                    if bundle_opts is not None:
-                        effective_pip_options = bundle_opts
+                    if bundle_opts is None:
+                        available = ", ".join(plugin_repo_obj.target_ids) or "none"
+                        console.print(
+                            f"[red]Error[/red]: plugin bundle does not include dependencies"
+                            f" for {current_ida_platform}, Python {current_python_version}."
+                        )
+                        console.print(f"Available targets in this bundle: {available}")
+                        raise click.Abort()
+                    effective_pip_options = merge_bundle_pip_options(pip_options, bundle_opts)
                     if no_build_isolation:
                         effective_pip_options = dataclasses.replace(effective_pip_options, no_build_isolation=True)
                     with rich.status.Status("installing plugin", console=stderr_console):

--- a/src/hcli/commands/plugin/upgrade.py
+++ b/src/hcli/commands/plugin/upgrade.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 from pathlib import Path
 
@@ -16,10 +17,13 @@ from hcli.lib.ida import (
     find_current_ida_version,
 )
 from hcli.lib.ida.plugin import get_metadata_from_plugin_archive
+from hcli.lib.ida.plugin.bundle import bundle_dependency_source
 from hcli.lib.ida.plugin.exceptions import PluginNotInstalledError
 from hcli.lib.ida.plugin.install import find_installed_plugin, upgrade_plugin_archive
 from hcli.lib.ida.plugin.reference import normalize_plugin_host, parse_plugin_reference
 from hcli.lib.ida.plugin.repo import BasePluginRepo
+from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo
+from hcli.lib.ida.python import PIP_OPTIONS_DEFAULT, PipOptions
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +39,7 @@ logger = logging.getLogger(__name__)
 )
 def upgrade_plugin(ctx, plugin: str, no_build_isolation: bool) -> None:
     """Upgrade an installed plugin to the latest compatible version."""
+    pip_options: PipOptions = ctx.obj.get("pip_options", PIP_OPTIONS_DEFAULT)
     plugin_spec = plugin
     try:
         current_ida_platform = find_current_ida_platform()
@@ -88,7 +93,22 @@ def upgrade_plugin(ctx, plugin: str, no_build_isolation: bool) -> None:
             console.print("Please check your internet connection.")
             raise click.Abort()
 
-        upgrade_plugin_archive(buf, plugin_name, no_build_isolation=no_build_isolation)
+        effective_pip_options = pip_options
+        if isinstance(plugin_repo, PluginBundleRepo) and pip_options == PIP_OPTIONS_DEFAULT:
+            from hcli.lib.ida.python import detect_current_python_version
+
+            with bundle_dependency_source(
+                plugin_repo, current_ida_platform, detect_current_python_version()
+            ) as bundle_opts:
+                if bundle_opts is not None:
+                    effective_pip_options = bundle_opts
+                if no_build_isolation:
+                    effective_pip_options = dataclasses.replace(effective_pip_options, no_build_isolation=True)
+                upgrade_plugin_archive(buf, plugin_name, pip_options=effective_pip_options)
+        else:
+            if no_build_isolation:
+                effective_pip_options = dataclasses.replace(effective_pip_options, no_build_isolation=True)
+            upgrade_plugin_archive(buf, plugin_name, pip_options=effective_pip_options)
 
         _, metadata = get_metadata_from_plugin_archive(buf, plugin_name)
 

--- a/src/hcli/commands/plugin/upgrade.py
+++ b/src/hcli/commands/plugin/upgrade.py
@@ -94,14 +94,20 @@ def upgrade_plugin(ctx, plugin: str, no_build_isolation: bool) -> None:
             raise click.Abort()
 
         effective_pip_options = pip_options
-        if isinstance(plugin_repo, PluginBundleRepo) and pip_options == PIP_OPTIONS_DEFAULT:
-            from hcli.lib.ida.python import detect_current_python_version
+        if isinstance(plugin_repo, PluginBundleRepo) and not pip_options.has_custom_sources:
+            from hcli.lib.ida.python import detect_current_python_version, merge_bundle_pip_options
 
-            with bundle_dependency_source(
-                plugin_repo, current_ida_platform, detect_current_python_version()
-            ) as bundle_opts:
-                if bundle_opts is not None:
-                    effective_pip_options = bundle_opts
+            current_python_version = detect_current_python_version()
+            with bundle_dependency_source(plugin_repo, current_ida_platform, current_python_version) as bundle_opts:
+                if bundle_opts is None:
+                    available = ", ".join(plugin_repo.target_ids) or "none"
+                    console.print(
+                        f"[red]Error[/red]: plugin bundle does not include dependencies"
+                        f" for {current_ida_platform}, Python {current_python_version}."
+                    )
+                    console.print(f"Available targets in this bundle: {available}")
+                    raise click.Abort()
+                effective_pip_options = merge_bundle_pip_options(pip_options, bundle_opts)
                 if no_build_isolation:
                     effective_pip_options = dataclasses.replace(effective_pip_options, no_build_isolation=True)
                 upgrade_plugin_archive(buf, plugin_name, pip_options=effective_pip_options)

--- a/src/hcli/lib/ida/plugin/__init__.py
+++ b/src/hcli/lib/ida/plugin/__init__.py
@@ -738,6 +738,13 @@ def get_metadata_path_from_plugin_archive(zip_data: bytes, name: str) -> Path:
     raise ValueError(f"plugin '{name}' not found in zip archive")
 
 
+def get_version_from_plugin_archive(zip_data: bytes, name: str) -> str:
+    for _, metadata in get_metadatas_with_paths_from_plugin_archive(zip_data):
+        if metadata.plugin.name == name:
+            return metadata.plugin.version
+    raise ValueError(f"plugin '{name}' not found in archive")
+
+
 def get_metadata_from_plugin_archive(zip_data: bytes, name: str) -> tuple[Path, IDAMetadataDescriptor]:
     """Extract ida-plugin.json metadata for plugin with the given name from zip archive without extracting"""
 

--- a/src/hcli/lib/ida/plugin/bundle.py
+++ b/src/hcli/lib/ida/plugin/bundle.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import logging
+import re
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.tags import mac_platforms
+
+from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo, PluginBundleTargetPlatformTag
+from hcli.lib.ida.python import PipOptions
+
+logger = logging.getLogger(__name__)
+
+MINIMUM_PYTHON_VERSION = (3, 10)
+
+SUPPORTED_PYTHON_VERSIONS: tuple[str, ...] = ("3.10", "3.11", "3.12", "3.13", "3.14")
+
+PLATFORM_ALIASES: dict[str, list[str]] = {
+    "windows-x86_64": ["windows", "win", "win64"],
+    "linux-x86_64": ["linux", "linux64"],
+    "macos-aarch64": ["macos-arm64", "macos-arm", "mac-arm64"],
+    "macos-x86_64": ["macos-intel", "mac-intel", "macos-x64"],
+}
+
+ALL_PLATFORMS: tuple[str, ...] = tuple(PLATFORM_ALIASES.keys())
+
+
+def resolve_platform_alias(name: str) -> str:
+    """Resolve a platform name or alias to the canonical ida_platform string.
+
+    Raises:
+        ValueError: with a helpful message listing valid names.
+    """
+    lower = name.lower().strip()
+    if lower in _PLATFORM_CONFIG:
+        return lower
+    for canonical, aliases in PLATFORM_ALIASES.items():
+        if lower in aliases:
+            return canonical
+    valid = []
+    for canonical, aliases in PLATFORM_ALIASES.items():
+        valid.append(f"  {canonical} (or: {', '.join(aliases)})")
+    raise ValueError(f"unknown platform: {name!r}\nvalid platforms:\n" + "\n".join(valid))
+
+
+_PLATFORM_CONFIG: dict[str, dict] = {
+    "windows-x86_64": {
+        "pip_platform_tags": ("win_amd64",),
+    },
+    "linux-x86_64": {
+        "max_glibc": (2, 28),
+        "arch": "x86_64",
+    },
+    "macos-aarch64": {
+        "mac_version": (11, 0),
+        "arch": "arm64",
+    },
+    "macos-x86_64": {
+        "mac_version": (10, 13),
+        "arch": "x86_64",
+    },
+}
+
+
+def _manylinux_tags(max_glibc: tuple[int, int], arch: str) -> tuple[str, ...]:
+    major, minor = max_glibc
+    tags: list[str] = []
+    for m in range(minor, 4, -1):
+        tags.append(f"manylinux_{major}_{m}_{arch}")
+    if max_glibc >= (2, 17):
+        tags.append(f"manylinux2014_{arch}")
+    if max_glibc >= (2, 12):
+        tags.append(f"manylinux2010_{arch}")
+    if max_glibc >= (2, 5):
+        tags.append(f"manylinux1_{arch}")
+    return tuple(tags)
+
+
+def _mac_platform_tags(version: tuple[int, int], arch: str) -> tuple[str, ...]:
+    return tuple(mac_platforms(version=version, arch=arch))
+
+
+def _build_pip_platform_tags(ida_platform: str) -> tuple[str, ...]:
+    config = _PLATFORM_CONFIG.get(ida_platform)
+    if config is None:
+        available = ", ".join(sorted(_PLATFORM_CONFIG))
+        raise ValueError(f"unsupported platform: {ida_platform} (available: {available})")
+
+    if "pip_platform_tags" in config:
+        return config["pip_platform_tags"]
+    elif "max_glibc" in config:
+        return _manylinux_tags(config["max_glibc"], config["arch"])
+    elif "mac_version" in config:
+        return _mac_platform_tags(config["mac_version"], config["arch"])
+    else:
+        raise ValueError(f"incomplete platform config for {ida_platform}")
+
+
+def _parse_python_version(version: str) -> tuple[int, int]:
+    m = re.match(r"^(\d+)\.(\d+)$", version)
+    if not m:
+        raise ValueError(f"invalid python version: {version!r} (expected 'major.minor')")
+    return int(m.group(1)), int(m.group(2))
+
+
+@dataclass(frozen=True)
+class PipTarget:
+    ida_platform: str
+    python_version: str
+
+    @classmethod
+    def parse(cls, target_id: str) -> PipTarget:
+        """Parse a target ID like 'linux-x86_64-cp312' into a PipTarget.
+
+        Raises:
+            ValueError: if the string can't be parsed or represents an unsupported target.
+        """
+        m = re.match(r"^(.+)-cp(\d)(\d+)$", target_id)
+        if not m:
+            raise ValueError(
+                f"invalid target ID: {target_id!r}\n"
+                f"expected format: <platform>-cp<ver> (e.g. 'linux-x86_64-cp312')\n"
+                f"hint: prefer --platform and --python instead of --target"
+            )
+        ida_platform = m.group(1)
+        python_version = f"{m.group(2)}.{m.group(3)}"
+        resolve_platform_alias(ida_platform)
+        ver = _parse_python_version(python_version)
+        if ver < MINIMUM_PYTHON_VERSION:
+            raise ValueError(
+                f"python {python_version} is below minimum {MINIMUM_PYTHON_VERSION[0]}.{MINIMUM_PYTHON_VERSION[1]}"
+            )
+        return cls(ida_platform=ida_platform, python_version=python_version)
+
+    @property
+    def id(self) -> str:
+        return f"{self.ida_platform}-cp{self.python_version.replace('.', '')}"
+
+    @property
+    def abis(self) -> tuple[str, ...]:
+        ver = self.python_version.replace(".", "")
+        return (f"cp{ver}", "abi3", "none")
+
+    @property
+    def pip_platform_tags(self) -> tuple[str, ...]:
+        return _build_pip_platform_tags(self.ida_platform)
+
+    def pip_download_args(self) -> list[str]:
+        args = [
+            "--only-binary=:all:",
+            "--implementation",
+            "cp",
+            "--python-version",
+            self.python_version,
+        ]
+        for abi in self.abis:
+            args.extend(["--abi", abi])
+        for tag in self.pip_platform_tags:
+            args.extend(["--platform", tag])
+        return args
+
+
+def to_manifest_target(target: PipTarget, wheelhouse_path: str) -> PluginBundleTargetPlatformTag:
+    return PluginBundleTargetPlatformTag.model_validate(
+        {
+            "id": target.id,
+            "idaPlatform": target.ida_platform,
+            "pythonVersion": target.python_version,
+            "implementation": "cp",
+            "abis": list(target.abis),
+            "pipPlatformTags": list(target.pip_platform_tags),
+            "wheelhouse": wheelhouse_path,
+        }
+    )
+
+
+@contextmanager
+def bundle_dependency_source(
+    repo: PluginBundleRepo,
+    ida_platform: str,
+    python_version: str,
+) -> Iterator[PipOptions | None]:
+    target = repo.find_target_for_platform(ida_platform, python_version)
+    if target is None:
+        yield None
+        return
+
+    with tempfile.TemporaryDirectory(prefix="hcli-bundle-wh-") as tmpdir:
+        wh_path = Path(tmpdir)
+        repo.extract_wheelhouse(target, wh_path)
+        yield PipOptions(
+            offline=True,
+            isolated=True,
+            no_cache_dir=True,
+            disable_pip_version_check=True,
+            find_links=(wh_path,),
+        )

--- a/src/hcli/lib/ida/plugin/bundle.py
+++ b/src/hcli/lib/ida/plugin/bundle.py
@@ -193,7 +193,6 @@ def bundle_dependency_source(
         wh_path = Path(tmpdir)
         repo.extract_wheelhouse(target, wh_path)
         yield PipOptions(
-            offline=True,
             isolated=True,
             no_cache_dir=True,
             disable_pip_version_check=True,

--- a/src/hcli/lib/ida/plugin/install.py
+++ b/src/hcli/lib/ida/plugin/install.py
@@ -42,7 +42,9 @@ from hcli.lib.ida.plugin.exceptions import (
 )
 from hcli.lib.ida.plugin.reference import normalize_plugin_host
 from hcli.lib.ida.python import (
+    PIP_OPTIONS_DEFAULT,
     CantInstallPackagesError,
+    PipOptions,
     does_current_ida_have_pip,
     find_current_python_executable,
     pip_install_packages,
@@ -330,6 +332,7 @@ def validate_can_install_python_dependencies(
     excluded_plugins: list[str] | None = None,
     python_exe: Path | None = None,
     no_build_isolation: bool = False,
+    pip_options: PipOptions = PIP_OPTIONS_DEFAULT,
 ) -> Path | None:
     """Verify Python dependencies can be installed.
 
@@ -362,7 +365,9 @@ def validate_can_install_python_dependencies(
             raise PipNotAvailableError(python_exe)
 
         try:
-            verify_pip_can_install_packages(python_exe, all_python_dependencies, no_build_isolation=no_build_isolation)
+            verify_pip_can_install_packages(
+                python_exe, all_python_dependencies, pip_options=pip_options, no_build_isolation=no_build_isolation
+            )
         except CantInstallPackagesError as e:
             logger.debug("can't install dependencies: %s", e)
             raise DependencyInstallationError(python_dependencies, str(e)) from e
@@ -378,6 +383,7 @@ def validate_can_install_plugin(
     current_platform: str,
     current_version: str,
     no_build_isolation: bool = False,
+    pip_options: PipOptions = PIP_OPTIONS_DEFAULT,
 ) -> Path | None:
     """Verify plugin can be installed.
 
@@ -412,7 +418,9 @@ def validate_can_install_plugin(
         logger.warning(f"Current IDA version not supported: {current_version}")
         raise IDAVersionIncompatibleError(current_version, metadata.plugin.ida_versions)
 
-    return validate_can_install_python_dependencies(zip_data, metadata, no_build_isolation=no_build_isolation)
+    return validate_can_install_python_dependencies(
+        zip_data, metadata, no_build_isolation=no_build_isolation, pip_options=pip_options
+    )
 
 
 def validate_archive_entry(file_info: zipfile.ZipInfo, relative_path: pathlib.PurePosixPath) -> None:
@@ -523,7 +531,12 @@ def extract_zip_subdirectory_to(zip_data: bytes, subdirectory: Path, destination
                 raise
 
 
-def _install_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool = False):
+def _install_plugin_archive(
+    zip_data: bytes,
+    name: str,
+    no_build_isolation: bool = False,
+    pip_options: PipOptions = PIP_OPTIONS_DEFAULT,
+):
     path, metadata = get_metadata_from_plugin_archive(zip_data, name)
     validate_metadata_in_plugin_archive(zip_data, path, metadata)
 
@@ -533,21 +546,17 @@ def _install_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool
         current_platform = find_current_ida_platform()
         current_version = find_current_ida_version()
 
-    # This will raise specific exceptions if installation is not possible.
-    # If the plugin has pip dependencies, validation discovers the python exe
-    # via idat so we can reuse it below without a second idat invocation.
     python_exe = validate_can_install_plugin(
-        zip_data, metadata, current_platform, current_version, no_build_isolation=no_build_isolation
+        zip_data,
+        metadata,
+        current_platform,
+        current_version,
+        no_build_isolation=no_build_isolation,
+        pip_options=pip_options,
     )
 
-    # path within IDAUSR/plugins to the new plugin
-    #
-    # note: there's a potential for collision here:
-    # user1/plugin destination directory ($IDAUSER/plugins/plugin) collides with user2/plugin
-    # we could fix this by prefixing the user/org name, like user1--plugin
     destination_path = get_plugin_directory(metadata.plugin.name)
 
-    # path within the zip to ida-plugin.json
     metadata_path = get_metadata_path_from_plugin_archive(zip_data, name)
     plugin_subdirectory = metadata_path.parent
 
@@ -570,7 +579,9 @@ def _install_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool
         ):
             assert python_exe is not None
             try:
-                pip_install_packages(python_exe, all_python_dependencies, no_build_isolation=no_build_isolation)
+                pip_install_packages(
+                    python_exe, all_python_dependencies, pip_options=pip_options, no_build_isolation=no_build_isolation
+                )
             except CantInstallPackagesError:
                 logger.debug("can't install dependencies")
                 raise
@@ -578,19 +589,25 @@ def _install_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool
     extract_zip_subdirectory_to(zip_data, plugin_subdirectory, destination_path)
 
 
-def install_source_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool = False):
-    return _install_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation)
+def install_source_plugin_archive(
+    zip_data: bytes, name: str, no_build_isolation: bool = False, pip_options: PipOptions = PIP_OPTIONS_DEFAULT
+):
+    return _install_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation, pip_options=pip_options)
 
 
-def install_binary_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool = False):
-    return _install_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation)
+def install_binary_plugin_archive(
+    zip_data: bytes, name: str, no_build_isolation: bool = False, pip_options: PipOptions = PIP_OPTIONS_DEFAULT
+):
+    return _install_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation, pip_options=pip_options)
 
 
-def install_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool = False):
+def install_plugin_archive(
+    zip_data: bytes, name: str, no_build_isolation: bool = False, pip_options: PipOptions = PIP_OPTIONS_DEFAULT
+):
     if is_source_plugin_archive(zip_data, name):
-        install_source_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation)
+        install_source_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation, pip_options=pip_options)
     elif is_binary_plugin_archive(zip_data, name):
-        install_binary_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation)
+        install_binary_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation, pip_options=pip_options)
     else:
         raise ValueError("Invalid plugin archive")
 
@@ -767,6 +784,7 @@ def validate_can_upgrade_plugin(
     current_platform: str,
     current_version: str,
     no_build_isolation: bool = False,
+    pip_options: PipOptions = PIP_OPTIONS_DEFAULT,
 ) -> None:
     """Verify plugin can be upgraded.
 
@@ -799,11 +817,13 @@ def validate_can_upgrade_plugin(
         raise IDAVersionIncompatibleError(current_version, metadata.plugin.ida_versions)
 
     validate_can_install_python_dependencies(
-        zip_data, metadata, excluded_plugins=[name], no_build_isolation=no_build_isolation
+        zip_data, metadata, excluded_plugins=[name], no_build_isolation=no_build_isolation, pip_options=pip_options
     )
 
 
-def upgrade_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool = False):
+def upgrade_plugin_archive(
+    zip_data: bytes, name: str, no_build_isolation: bool = False, pip_options: PipOptions = PIP_OPTIONS_DEFAULT
+):
     path, metadata = get_metadata_from_plugin_archive(zip_data, name)
     validate_metadata_in_plugin_archive(zip_data, path, metadata)
 
@@ -813,9 +833,13 @@ def upgrade_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool 
     current_platform = find_current_ida_platform()
     current_version = find_current_ida_version()
 
-    # This will raise specific exceptions if upgrade is not possible
     validate_can_upgrade_plugin(
-        zip_data, metadata, current_platform, current_version, no_build_isolation=no_build_isolation
+        zip_data,
+        metadata,
+        current_platform,
+        current_version,
+        no_build_isolation=no_build_isolation,
+        pip_options=pip_options,
     )
 
     plugin_path = get_plugin_directory(metadata.plugin.name)
@@ -832,19 +856,13 @@ def upgrade_plugin_archive(zip_data: bytes, name: str, no_build_isolation: bool 
             metadata.plugin.name, existing_metadata.plugin.version, metadata.plugin.version
         )
 
-    # as long as uninstallation is as simple as removing the directory
-    # inline that logic here (the checkpoint/rollback).
-
-    # note: this could conflict with a malicious plugin name, like `foo.rollback`
-    # maybe put this into a different directory (XDG_CACHE_HOME?)
     rollback_path = plugin_path.parent / (metadata.plugin.name + ".rollback")
     if rollback_path.exists():
         raise RuntimeError("rollback path already exists for some reason")
-    # `move` rather than `rename` to support cross-filesystem operations
     shutil.move(plugin_path, rollback_path)
 
     try:
-        install_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation)
+        install_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation, pip_options=pip_options)
     except Exception as e:
         logger.debug("error during upgrade: install: %s", e)
         logger.debug("rolling back to prior version")

--- a/src/hcli/lib/ida/plugin/repo/__init__.py
+++ b/src/hcli/lib/ida/plugin/repo/__init__.py
@@ -149,9 +149,23 @@ class BasePluginRepo(ABC):
     def get_plugin_by_name(self, name: str, host: str | None = None) -> Plugin:
         return get_plugin_by_name(self.get_plugins(), name, host=host)
 
-    def find_compatible_plugin_from_spec(
-        self, plugin_spec: str, current_platform: str, current_version: str, host: str | None = None
+    def find_plugin_from_spec(
+        self,
+        plugin_spec: str,
+        current_platform: str | None = None,
+        current_version: str | None = None,
+        host: str | None = None,
     ) -> PluginArchiveLocation:
+        """Find a plugin location, filtering by whichever parameters are provided.
+
+        Matches on version spec always. Additionally filters by platform and/or
+        IDA version when those parameters are not None. Returns the first
+        matching location from the highest matching version.
+
+        Callers that know the target environment should prefer
+        ``find_compatible_plugin_from_spec`` which requires both platform and
+        IDA version, preventing accidental omission.
+        """
         plugin_name, _ = split_plugin_version_spec(plugin_spec)
         wanted_spec = semantic_version.SimpleSpec(plugin_spec[len(plugin_name) :] or ">=0")
 
@@ -166,7 +180,7 @@ class BasePluginRepo(ABC):
 
             logger.debug("found matching version: %s", version)
             for i, location in enumerate(plugin.versions[version]):
-                if current_platform not in location.metadata.plugin.platforms:
+                if current_platform is not None and current_platform not in location.metadata.plugin.platforms:
                     logger.debug(
                         "skipping location %d: unsupported platforms: %s",
                         i,
@@ -174,7 +188,9 @@ class BasePluginRepo(ABC):
                     )
                     continue
 
-                if not is_ida_version_compatible(current_version, location.metadata.plugin.ida_versions):
+                if current_version is not None and not is_ida_version_compatible(
+                    current_version, location.metadata.plugin.ida_versions
+                ):
                     logger.debug(
                         "skipping location %d: unsupported IDA versions: %s",
                         i,
@@ -186,22 +202,56 @@ class BasePluginRepo(ABC):
 
         raise KeyError(f"plugin not found: {plugin_spec}")
 
-    def fetch_compatible_plugin_from_spec(
-        self, plugin_spec: str, current_platform: str, current_version: str, host: str | None = None
+    def find_compatible_plugin_from_spec(
+        self,
+        plugin_spec: str,
+        current_platform: str,
+        current_version: str,
+        host: str | None = None,
+    ) -> PluginArchiveLocation:
+        """Find a plugin location matching spec, platform, and IDA version.
+
+        Use this for operations on a live IDA installation (install, upgrade,
+        status) where the target environment is known. For packaging workflows
+        where some parameters are unavailable, use ``find_plugin_from_spec``
+        directly.
+        """
+        return self.find_plugin_from_spec(plugin_spec, current_platform, current_version, host=host)
+
+    def fetch_plugin_from_spec(
+        self,
+        plugin_spec: str,
+        current_platform: str | None = None,
+        current_version: str | None = None,
+        host: str | None = None,
     ) -> tuple[str, bytes]:
-        """Fetch compatible plugin from spec with SHA256 verification.
+        """Fetch a plugin, filtering by whichever parameters are provided.
 
-        Args:
-            plugin_spec: Plugin specification (e.g., "plugin1", "plugin1==1.0.0")
-            current_platform: Current IDA platform (e.g., "macos-aarch64")
-            current_version: Current IDA version (e.g., "9.1")
-            host: optional repository URL to disambiguate colliding plugin names.
+        Callers that know the target environment should prefer
+        ``fetch_compatible_plugin_from_spec`` which requires both platform and
+        IDA version, preventing accidental omission.
+        """
+        location = self.find_plugin_from_spec(plugin_spec, current_platform, current_version, host=host)
+        return self._fetch_and_verify(location)
 
-        Returns:
-            Tuple of (actual_plugin_name, plugin_archive_bytes).
-            The plugin name returned uses the correct casing from the metadata.
+    def fetch_compatible_plugin_from_spec(
+        self,
+        plugin_spec: str,
+        current_platform: str,
+        current_version: str,
+        host: str | None = None,
+    ) -> tuple[str, bytes]:
+        """Fetch a plugin matching spec, platform, and IDA version.
+
+        Use this for operations on a live IDA installation (install, upgrade,
+        status) where the target environment is known. For packaging workflows
+        where some parameters are unavailable, use ``fetch_plugin_from_spec``
+        directly.
         """
         location = self.find_compatible_plugin_from_spec(plugin_spec, current_platform, current_version, host=host)
+        return self._fetch_and_verify(location)
+
+    def _fetch_and_verify(self, location: PluginArchiveLocation) -> tuple[str, bytes]:
         plugin_name = location.metadata.plugin.name
         logger.debug("plugin name: %s", plugin_name)
         buf = fetch_plugin_archive(location.url)

--- a/src/hcli/lib/ida/plugin/repo/bundle.py
+++ b/src/hcli/lib/ida/plugin/repo/bundle.py
@@ -177,6 +177,7 @@ class PluginBundleRepo(BasePluginRepo):
     def extract_wheelhouse(self, target: PluginBundleTargetPlatformTag, dest: Path) -> None:
         dest.mkdir(parents=True, exist_ok=True)
         wh_prefix = target.wheelhouse.rstrip("/") + "/"
+        seen: set[str] = set()
 
         for info in self._zf.infolist():
             if not info.filename.startswith(wh_prefix):
@@ -192,6 +193,10 @@ class PluginBundleRepo(BasePluginRepo):
 
             if (info.external_attr >> 28) == 0xA:
                 raise ValueError(f"symlink in wheelhouse: {info.filename}")
+
+            if relative.name in seen:
+                raise ValueError(f"duplicate filename in wheelhouse: {relative.name} (from {info.filename})")
+            seen.add(relative.name)
 
             target_file = dest / relative.name
             with self._zf.open(info.filename) as src, target_file.open("wb") as dst:

--- a/src/hcli/lib/ida/plugin/repo/bundle.py
+++ b/src/hcli/lib/ida/plugin/repo/bundle.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import pathlib
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from hcli.lib.ida.plugin.repo import (
+    BasePluginRepo,
+    Plugin,
+    PluginArchiveIndex,
+    PluginArchiveLocation,
+)
+
+logger = logging.getLogger(__name__)
+
+BUNDLE_KIND = "hcli-plugin-bundle"
+BUNDLE_VERSION = 1
+
+
+class PluginBundleCreatedBy(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    tool: str
+    version: str
+
+
+class PluginBundleTargetPlatformTag(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    ida_platform: str = Field(alias="idaPlatform")
+    python_version: str = Field(alias="pythonVersion")
+    implementation: str
+    abis: list[str]
+    pip_platform_tags: list[str] = Field(alias="pipPlatformTags")
+    wheelhouse: str
+
+
+class PluginBundleManifest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    version: Literal[1]
+    kind: Literal["hcli-plugin-bundle"]
+    built_at: datetime = Field(alias="builtAt")
+    created_by: PluginBundleCreatedBy = Field(alias="createdBy")
+    target_platform_tags: list[PluginBundleTargetPlatformTag] = Field(alias="targetPlatformTags")
+
+    @field_validator("target_platform_tags")
+    @classmethod
+    def no_duplicate_target_ids(cls, v: list[PluginBundleTargetPlatformTag]) -> list[PluginBundleTargetPlatformTag]:
+        ids = [t.id for t in v]
+        if len(set(ids)) != len(ids):
+            raise ValueError(f"duplicate target IDs: {ids}")
+        return v
+
+
+def _validate_bundle_path(member_path: str) -> None:
+    p = pathlib.PurePosixPath(member_path)
+    if p.is_absolute():
+        raise ValueError(f"absolute path in bundle: {member_path}")
+    if ".." in p.parts:
+        raise ValueError(f"path traversal in bundle: {member_path}")
+    if "\\" in member_path:
+        raise ValueError(f"backslash in bundle path: {member_path}")
+
+
+def is_plugin_bundle_zip(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    if path.suffix != ".zip":
+        return False
+    try:
+        with zipfile.ZipFile(path, "r") as zf:
+            return "plugin-bundle.json" in zf.namelist()
+    except (zipfile.BadZipFile, OSError):
+        return False
+
+
+def load_manifest_from_zip(zf: zipfile.ZipFile) -> PluginBundleManifest:
+    raw = zf.read("plugin-bundle.json").decode("utf-8")
+    manifest = PluginBundleManifest.model_validate_json(raw)
+
+    for target in manifest.target_platform_tags:
+        _validate_bundle_path(target.wheelhouse)
+        wh_prefix = target.wheelhouse.rstrip("/") + "/"
+        if not any(name.startswith(wh_prefix) or name == target.wheelhouse + "/" for name in zf.namelist()):
+            logger.debug("wheelhouse path not found in archive: %s", target.wheelhouse)
+
+    return manifest
+
+
+class PluginBundleRepo(BasePluginRepo):
+    def __init__(self, path: Path):
+        self._path = path
+        self._zf = zipfile.ZipFile(path, "r")
+        try:
+            self._manifest = load_manifest_from_zip(self._zf)
+        except Exception:
+            self._zf.close()
+            raise
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def manifest(self) -> PluginBundleManifest:
+        return self._manifest
+
+    @property
+    def built_at(self) -> datetime:
+        return self._manifest.built_at
+
+    @property
+    def target_ids(self) -> list[str]:
+        return [t.id for t in self._manifest.target_platform_tags]
+
+    def close(self):
+        self._zf.close()
+
+    def get_plugins(self) -> list[Plugin]:
+        return self._load_plugins_by_walking()
+
+    def _load_plugins_by_walking(self) -> list[Plugin]:
+        index = PluginArchiveIndex()
+        for name in self._zf.namelist():
+            if not name.startswith("plugins/"):
+                continue
+            if not name.endswith(".zip"):
+                continue
+            _validate_bundle_path(name)
+
+            try:
+                plugin_zip_data = self._zf.read(name)
+            except (KeyError, zipfile.BadZipFile) as e:
+                logger.debug("skipping unreadable plugin archive %s: %s", name, e)
+                continue
+
+            bundle_url = f"hcli-bundle:{name}"
+            index.index_plugin_archive(plugin_zip_data, bundle_url, context={"bundle_member": name})
+
+        return index.get_plugins()
+
+    def _fetch_and_verify(self, location: PluginArchiveLocation) -> tuple[str, bytes]:
+        plugin_name = location.metadata.plugin.name
+        url = location.url
+
+        if url.startswith("hcli-bundle:"):
+            member_path = url[len("hcli-bundle:") :]
+            buf = self._zf.read(member_path)
+        else:
+            from hcli.lib.ida.plugin.repo import fetch_plugin_archive
+
+            buf = fetch_plugin_archive(url)
+
+        h = hashlib.sha256()
+        h.update(buf)
+        sha256 = h.hexdigest()
+
+        if sha256 != location.sha256:
+            raise ValueError(f"hash mismatch: expected {location.sha256} but found {sha256} for {url}")
+
+        return plugin_name, buf
+
+    def find_target_for_platform(self, ida_platform: str, python_version: str) -> PluginBundleTargetPlatformTag | None:
+        for target in self._manifest.target_platform_tags:
+            if target.ida_platform == ida_platform and target.python_version == python_version:
+                return target
+        return None
+
+    def extract_wheelhouse(self, target: PluginBundleTargetPlatformTag, dest: Path) -> None:
+        dest.mkdir(parents=True, exist_ok=True)
+        wh_prefix = target.wheelhouse.rstrip("/") + "/"
+
+        for info in self._zf.infolist():
+            if not info.filename.startswith(wh_prefix):
+                continue
+            if info.is_dir():
+                continue
+
+            _validate_bundle_path(info.filename)
+
+            relative = pathlib.PurePosixPath(info.filename).relative_to(wh_prefix.rstrip("/"))
+            if ".." in relative.parts:
+                raise ValueError(f"path traversal in wheelhouse: {info.filename}")
+
+            if (info.external_attr >> 28) == 0xA:
+                raise ValueError(f"symlink in wheelhouse: {info.filename}")
+
+            target_file = dest / relative.name
+            with self._zf.open(info.filename) as src, target_file.open("wb") as dst:
+                import shutil
+
+                shutil.copyfileobj(src, dst)

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -3,6 +3,7 @@ import logging
 import os
 import platform
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 from hcli.env import ENV
@@ -204,8 +205,42 @@ def does_current_ida_have_pip(python_exe: Path, timeout=10.0) -> bool:
 class CantInstallPackagesError(ValueError): ...
 
 
+@dataclass(frozen=True)
+class PipOptions:
+    index_url: str | None = None
+    extra_index_urls: tuple[str, ...] = ()
+    find_links: tuple[Path | str, ...] = ()
+    offline: bool = False
+    isolated: bool = False
+    no_cache_dir: bool = False
+    disable_pip_version_check: bool = False
+    no_build_isolation: bool = False
+
+    def build_args(self) -> list[str]:
+        args: list[str] = []
+        if self.isolated:
+            args.append("--isolated")
+        if self.disable_pip_version_check:
+            args.append("--disable-pip-version-check")
+        if self.no_cache_dir:
+            args.append("--no-cache-dir")
+        if self.offline:
+            args.append("--no-index")
+        if self.index_url:
+            args.extend(["--index-url", self.index_url])
+        for url in self.extra_index_urls:
+            args.extend(["--extra-index-url", url])
+        for link in self.find_links:
+            args.extend(["--find-links", str(link)])
+        if self.no_build_isolation:
+            args.append("--no-build-isolation")
+        return args
+
+
+PIP_OPTIONS_DEFAULT = PipOptions()
+
+
 def _format_pip_error(stdout: bytes, stderr: bytes) -> str:
-    """Format pip error output for display."""
     stdout_text = stdout.decode("utf-8", errors="replace").strip()
     stderr_text = stderr.decode("utf-8", errors="replace").strip()
 
@@ -218,14 +253,20 @@ def _format_pip_error(stdout: bytes, stderr: bytes) -> str:
     return "\n".join(parts) if parts else stdout_text
 
 
-def verify_pip_can_install_packages(python_exe: Path, packages: list[str], no_build_isolation: bool = False):
+def verify_pip_can_install_packages(
+    python_exe: Path,
+    packages: list[str],
+    pip_options: PipOptions = PIP_OPTIONS_DEFAULT,
+    no_build_isolation: bool = False,
+):
     """Check if the given Python packages (e.g., "foo>=v1.0,<3") can be installed.
 
-    This allows pip to determine if there are any version conflicts
+    Raises:
+        CantInstallPackagesError: if pip dry-run fails.
     """
-    extra_args = ["--no-build-isolation"] if no_build_isolation else []
+    effective = _merge_no_build_isolation(pip_options, no_build_isolation)
     process = subprocess.run(
-        [str(python_exe), "-m", "pip", "install", "--dry-run"] + extra_args + packages,
+        [str(python_exe), "-m", "pip", "install", "--dry-run"] + effective.build_args() + packages,
         capture_output=True,
         check=False,
     )
@@ -237,11 +278,20 @@ def verify_pip_can_install_packages(python_exe: Path, packages: list[str], no_bu
         raise CantInstallPackagesError(_format_pip_error(stdout, stderr))
 
 
-def pip_install_packages(python_exe: Path, packages: list[str], no_build_isolation: bool = False):
-    """Install the given Python packages (e.g., "foo>=v1.0,<3")."""
-    extra_args = ["--no-build-isolation"] if no_build_isolation else []
+def pip_install_packages(
+    python_exe: Path,
+    packages: list[str],
+    pip_options: PipOptions = PIP_OPTIONS_DEFAULT,
+    no_build_isolation: bool = False,
+):
+    """Install the given Python packages (e.g., "foo>=v1.0,<3").
+
+    Raises:
+        CantInstallPackagesError: if pip install fails.
+    """
+    effective = _merge_no_build_isolation(pip_options, no_build_isolation)
     process = subprocess.run(
-        [str(python_exe), "-m", "pip", "install"] + extra_args + packages,
+        [str(python_exe), "-m", "pip", "install"] + effective.build_args() + packages,
         capture_output=True,
         check=False,
     )
@@ -251,6 +301,42 @@ def pip_install_packages(python_exe: Path, packages: list[str], no_build_isolati
         logger.debug(stdout.decode("utf-8", errors="replace"))
         logger.debug(stderr.decode("utf-8", errors="replace"))
         raise CantInstallPackagesError(_format_pip_error(stdout, stderr))
+
+
+def _merge_no_build_isolation(pip_options: PipOptions, no_build_isolation: bool) -> PipOptions:
+    if no_build_isolation and not pip_options.no_build_isolation:
+        return PipOptions(
+            index_url=pip_options.index_url,
+            extra_index_urls=pip_options.extra_index_urls,
+            find_links=pip_options.find_links,
+            offline=pip_options.offline,
+            isolated=pip_options.isolated,
+            no_cache_dir=pip_options.no_cache_dir,
+            disable_pip_version_check=pip_options.disable_pip_version_check,
+            no_build_isolation=True,
+        )
+    return pip_options
+
+
+def detect_current_python_version() -> str:
+    """Detect the major.minor Python version of the active IDA Python.
+
+    Falls back to the current interpreter's version if detection fails.
+    """
+    import sys as _sys
+
+    try:
+        python_exe = find_current_python_executable()
+        result = subprocess.run(
+            [str(python_exe), "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return f"{_sys.version_info.major}.{_sys.version_info.minor}"
 
 
 def pip_freeze(python_exe: Path):

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -216,6 +216,10 @@ class PipOptions:
     disable_pip_version_check: bool = False
     no_build_isolation: bool = False
 
+    @property
+    def has_custom_sources(self) -> bool:
+        return self.index_url is not None or len(self.extra_index_urls) > 0 or len(self.find_links) > 0
+
     def build_args(self) -> list[str]:
         args: list[str] = []
         if self.isolated:
@@ -238,6 +242,19 @@ class PipOptions:
 
 
 PIP_OPTIONS_DEFAULT = PipOptions()
+
+
+def merge_bundle_pip_options(user_options: PipOptions, bundle_options: PipOptions) -> PipOptions:
+    return PipOptions(
+        index_url=user_options.index_url,
+        extra_index_urls=user_options.extra_index_urls,
+        find_links=bundle_options.find_links + user_options.find_links,
+        offline=bundle_options.offline or user_options.offline,
+        isolated=bundle_options.isolated or user_options.isolated,
+        no_cache_dir=bundle_options.no_cache_dir or user_options.no_cache_dir,
+        disable_pip_version_check=bundle_options.disable_pip_version_check or user_options.disable_pip_version_check,
+        no_build_isolation=user_options.no_build_isolation,
+    )
 
 
 def _format_pip_error(stdout: bytes, stderr: bytes) -> str:

--- a/tests/lib/test_ida_python.py
+++ b/tests/lib/test_ida_python.py
@@ -12,6 +12,7 @@ from hcli.lib.ida.python import (
     _derive_python_exe,
     does_current_ida_have_pip,
     find_current_python_executable,
+    merge_bundle_pip_options,
     verify_pip_can_install_packages,
 )
 
@@ -262,3 +263,59 @@ def test_pip_options_combined_index_and_find_links():
     args = opts.build_args()
     assert "--index-url" in args
     assert "--find-links" in args
+
+
+def test_pip_options_has_custom_sources_default():
+    assert not PipOptions().has_custom_sources
+
+
+def test_pip_options_has_custom_sources_offline_only():
+    assert not PipOptions(offline=True).has_custom_sources
+
+
+def test_pip_options_has_custom_sources_index_url():
+    assert PipOptions(index_url="https://example.com").has_custom_sources
+
+
+def test_pip_options_has_custom_sources_extra_index():
+    assert PipOptions(extra_index_urls=("https://example.com",)).has_custom_sources
+
+
+def test_pip_options_has_custom_sources_find_links():
+    assert PipOptions(find_links=("/tmp/wh",)).has_custom_sources
+
+
+def test_merge_bundle_pip_options_offline_user():
+    user = PipOptions(offline=True)
+    bundle = PipOptions(
+        offline=True,
+        isolated=True,
+        no_cache_dir=True,
+        disable_pip_version_check=True,
+        find_links=("/tmp/wh",),
+    )
+    merged = merge_bundle_pip_options(user, bundle)
+    assert merged.offline is True
+    assert merged.find_links == ("/tmp/wh",)
+    assert merged.isolated is True
+
+
+def test_merge_bundle_pip_options_preserves_no_build_isolation():
+    user = PipOptions(no_build_isolation=True)
+    bundle = PipOptions(find_links=("/tmp/wh",), offline=True)
+    merged = merge_bundle_pip_options(user, bundle)
+    assert merged.no_build_isolation is True
+    assert merged.find_links == ("/tmp/wh",)
+
+
+def test_merge_bundle_pip_options_default_user():
+    user = PipOptions()
+    bundle = PipOptions(
+        offline=True,
+        isolated=True,
+        no_cache_dir=True,
+        disable_pip_version_check=True,
+        find_links=("/tmp/wh",),
+    )
+    merged = merge_bundle_pip_options(user, bundle)
+    assert merged == bundle

--- a/tests/lib/test_ida_python.py
+++ b/tests/lib/test_ida_python.py
@@ -8,6 +8,7 @@ import pytest
 from hcli.lib.ida import find_current_ida_install_directory, get_ida_user_dir
 from hcli.lib.ida.python import (
     CantInstallPackagesError,
+    PipOptions,
     _derive_python_exe,
     does_current_ida_have_pip,
     find_current_python_executable,
@@ -203,3 +204,61 @@ def test_verify_pip_can_install_packages():
 
     with pytest.raises(CantInstallPackagesError):
         verify_pip_can_install_packages(python_exe, ["flare-capa==v1.2.0", "flare-capa<=v1.0.0"])
+
+
+def test_pip_options_default_builds_empty_args():
+    opts = PipOptions()
+    assert opts.build_args() == []
+
+
+def test_pip_options_online_index_url():
+    opts = PipOptions(index_url="https://pypi.example.corp/simple")
+    args = opts.build_args()
+    assert args == ["--index-url", "https://pypi.example.corp/simple"]
+
+
+def test_pip_options_extra_index_urls():
+    opts = PipOptions(extra_index_urls=("https://a.example.com/simple", "https://b.example.com/simple"))
+    args = opts.build_args()
+    assert "--extra-index-url" in args
+    assert args.count("--extra-index-url") == 2
+
+
+def test_pip_options_find_links_offline():
+    opts = PipOptions(find_links=("/tmp/wheelhouse",), offline=True)
+    args = opts.build_args()
+    assert "--no-index" in args
+    assert "--find-links" in args
+    assert "/tmp/wheelhouse" in args
+
+
+def test_pip_options_bundle_mode():
+    opts = PipOptions(
+        offline=True,
+        isolated=True,
+        no_cache_dir=True,
+        disable_pip_version_check=True,
+        find_links=("/tmp/wh",),
+    )
+    args = opts.build_args()
+    assert "--isolated" in args
+    assert "--disable-pip-version-check" in args
+    assert "--no-cache-dir" in args
+    assert "--no-index" in args
+    assert "--find-links" in args
+
+
+def test_pip_options_no_build_isolation():
+    opts = PipOptions(no_build_isolation=True)
+    args = opts.build_args()
+    assert "--no-build-isolation" in args
+
+
+def test_pip_options_combined_index_and_find_links():
+    opts = PipOptions(
+        index_url="https://pypi.example.corp/simple",
+        find_links=("/local/wheels",),
+    )
+    args = opts.build_args()
+    assert "--index-url" in args
+    assert "--find-links" in args

--- a/tests/lib/test_plugin_bundle.py
+++ b/tests/lib/test_plugin_bundle.py
@@ -1,0 +1,472 @@
+import io
+import json
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+import pytest
+
+from hcli.commands.plugin.bundle import (
+    _resolve_targets,
+)
+from hcli.lib.ida.plugin.bundle import (
+    ALL_PLATFORMS,
+    SUPPORTED_PYTHON_VERSIONS,
+    PipTarget,
+    bundle_dependency_source,
+    resolve_platform_alias,
+)
+from hcli.lib.ida.plugin.repo.bundle import (
+    PluginBundleManifest,
+    PluginBundleRepo,
+    _validate_bundle_path,
+    is_plugin_bundle_zip,
+)
+
+TESTS_DIR = Path(__file__).parent.parent
+PLUGIN1_V1 = TESTS_DIR / "data" / "plugins" / "plugin1" / "plugin1-v1.0.0.zip"
+PLUGIN1_V2 = TESTS_DIR / "data" / "plugins" / "plugin1" / "plugin1-v2.0.0.zip"
+
+
+def _make_manifest(**overrides) -> dict:
+    base = {
+        "version": 1,
+        "kind": "hcli-plugin-bundle",
+        "builtAt": "2026-04-28T16:00:00Z",
+        "createdBy": {"tool": "hcli", "version": "0.0.0"},
+        "targetPlatformTags": [
+            {
+                "id": "linux-x86_64-cp312",
+                "idaPlatform": "linux-x86_64",
+                "pythonVersion": "3.12",
+                "implementation": "cp",
+                "abis": ["cp312", "abi3", "none"],
+                "pipPlatformTags": ["manylinux_2_28_x86_64"],
+                "wheelhouse": "dependencies/python/linux-x86_64-cp312",
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _build_bundle_zip(
+    manifest_dict: dict,
+    plugin_zips: dict[str, bytes] | None = None,
+    wheelhouse_files: dict[str, bytes] | None = None,
+) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("plugin-bundle.json", json.dumps(manifest_dict))
+
+        if plugin_zips:
+            for name, data in plugin_zips.items():
+                zf.writestr(f"plugins/{name}", data)
+
+        if wheelhouse_files:
+            for name, data in wheelhouse_files.items():
+                zf.writestr(name, data)
+        else:
+            for target in manifest_dict.get("targetPlatformTags", []):
+                wh = target["wheelhouse"]
+                zf.writestr(f"{wh}/placeholder.whl", b"fake-wheel")
+
+    return buf.getvalue()
+
+
+def _write_bundle(tmp_path, manifest=None, plugin_zips=None, **kwargs):
+    if manifest is None:
+        manifest = _make_manifest()
+    data = _build_bundle_zip(manifest, plugin_zips=plugin_zips, **kwargs)
+    p = tmp_path / "bundle.zip"
+    p.write_bytes(data)
+    return p
+
+
+def test_manifest_valid():
+    m = PluginBundleManifest.model_validate(_make_manifest())
+    assert m.version == 1
+    assert m.kind == "hcli-plugin-bundle"
+    assert len(m.target_platform_tags) == 1
+    assert m.target_platform_tags[0].id == "linux-x86_64-cp312"
+
+
+def test_manifest_wrong_version_rejected():
+    with pytest.raises(ValueError):
+        PluginBundleManifest.model_validate(_make_manifest(version=2))
+
+
+def test_manifest_wrong_kind_rejected():
+    with pytest.raises(ValueError):
+        PluginBundleManifest.model_validate(_make_manifest(kind="something-else"))
+
+
+def test_manifest_duplicate_target_ids_rejected():
+    tags = _make_manifest()["targetPlatformTags"]
+    with pytest.raises(ValueError, match="duplicate target IDs"):
+        PluginBundleManifest.model_validate(_make_manifest(targetPlatformTags=[tags[0], tags[0]]))
+
+
+def test_manifest_built_at_parsed():
+    m = PluginBundleManifest.model_validate(_make_manifest())
+    assert m.built_at == datetime(2026, 4, 28, 16, 0, 0, tzinfo=timezone.utc)
+
+
+def test_bundle_path_relative_ok():
+    _validate_bundle_path("plugins/foo.zip")
+
+
+def test_bundle_path_absolute_rejected():
+    with pytest.raises(ValueError, match="absolute"):
+        _validate_bundle_path("/etc/passwd")
+
+
+def test_bundle_path_traversal_rejected():
+    with pytest.raises(ValueError, match="traversal"):
+        _validate_bundle_path("plugins/../../../etc/passwd")
+
+
+def test_bundle_path_backslash_rejected():
+    with pytest.raises(ValueError, match="backslash"):
+        _validate_bundle_path("plugins\\foo.zip")
+
+
+def test_is_plugin_bundle_zip_valid(tmp_path):
+    data = _build_bundle_zip(_make_manifest())
+    p = tmp_path / "test.zip"
+    p.write_bytes(data)
+    assert is_plugin_bundle_zip(p)
+
+
+def test_is_plugin_bundle_zip_regular_zip_not_bundle(tmp_path):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("readme.txt", "hello")
+    p = tmp_path / "test.zip"
+    p.write_bytes(buf.getvalue())
+    assert not is_plugin_bundle_zip(p)
+
+
+def test_is_plugin_bundle_zip_nonexistent_file(tmp_path):
+    assert not is_plugin_bundle_zip(tmp_path / "nope.zip")
+
+
+def test_is_plugin_bundle_zip_directory_not_bundle(tmp_path):
+    assert not is_plugin_bundle_zip(tmp_path)
+
+
+def test_plugin_bundle_repo_get_plugins_by_walking(tmp_path):
+    plugin_data = PLUGIN1_V1.read_bytes()
+    p = _write_bundle(tmp_path, plugin_zips={"plugin1-v1.0.0.zip": plugin_data})
+    repo = PluginBundleRepo(p)
+    try:
+        plugins = repo.get_plugins()
+        assert len(plugins) == 1
+        assert plugins[0].name == "plugin1"
+        assert "1.0.0" in plugins[0].versions
+    finally:
+        repo.close()
+
+
+def test_plugin_bundle_repo_get_plugins_multiple_versions(tmp_path):
+    p = _write_bundle(
+        tmp_path,
+        plugin_zips={
+            "plugin1-v1.0.0.zip": PLUGIN1_V1.read_bytes(),
+            "plugin1-v2.0.0.zip": PLUGIN1_V2.read_bytes(),
+        },
+    )
+    repo = PluginBundleRepo(p)
+    try:
+        plugins = repo.get_plugins()
+        assert len(plugins) == 1
+        assert "1.0.0" in plugins[0].versions
+        assert "2.0.0" in plugins[0].versions
+    finally:
+        repo.close()
+
+
+def test_plugin_bundle_repo_fetch_plugin_from_bundle(tmp_path):
+    plugin_data = PLUGIN1_V1.read_bytes()
+    p = _write_bundle(tmp_path, plugin_zips={"plugin1-v1.0.0.zip": plugin_data})
+    repo = PluginBundleRepo(p)
+    try:
+        name, buf = repo.fetch_compatible_plugin_from_spec("plugin1==1.0.0", "macos-aarch64", "9.1")
+        assert name == "plugin1"
+        assert buf == plugin_data
+    finally:
+        repo.close()
+
+
+def test_plugin_bundle_repo_manifest_properties(tmp_path):
+    p = _write_bundle(tmp_path)
+    repo = PluginBundleRepo(p)
+    try:
+        assert repo.target_ids == ["linux-x86_64-cp312"]
+        assert repo.built_at == datetime(2026, 4, 28, 16, 0, 0, tzinfo=timezone.utc)
+    finally:
+        repo.close()
+
+
+def test_plugin_bundle_repo_find_target_for_platform(tmp_path):
+    p = _write_bundle(tmp_path)
+    repo = PluginBundleRepo(p)
+    try:
+        target = repo.find_target_for_platform("linux-x86_64", "3.12")
+        assert target is not None
+        assert target.id == "linux-x86_64-cp312"
+
+        assert repo.find_target_for_platform("windows-x86_64", "3.12") is None
+    finally:
+        repo.close()
+
+
+def test_plugin_bundle_repo_extract_wheelhouse(tmp_path):
+    manifest = _make_manifest()
+    wh_files = {
+        "dependencies/python/linux-x86_64-cp312/some_pkg-1.0-py3-none-any.whl": b"wheel-bytes",
+    }
+    p = _write_bundle(tmp_path, manifest=manifest, wheelhouse_files=wh_files)
+    repo = PluginBundleRepo(p)
+    try:
+        target = repo.find_target_for_platform("linux-x86_64", "3.12")
+        assert target is not None
+        dest = tmp_path / "extracted_wh"
+        repo.extract_wheelhouse(target, dest)
+        assert (dest / "some_pkg-1.0-py3-none-any.whl").read_bytes() == b"wheel-bytes"
+    finally:
+        repo.close()
+
+
+def test_plugin_bundle_repo_empty_bundle_returns_no_plugins(tmp_path):
+    p = _write_bundle(tmp_path)
+    repo = PluginBundleRepo(p)
+    try:
+        assert repo.get_plugins() == []
+    finally:
+        repo.close()
+
+
+def test_pip_target_parse_valid():
+    target = PipTarget.parse("linux-x86_64-cp312")
+    assert target.ida_platform == "linux-x86_64"
+    assert target.python_version == "3.12"
+    assert target.id == "linux-x86_64-cp312"
+
+
+def test_pip_target_parse_unknown_platform_raises():
+    with pytest.raises(ValueError, match="unknown platform"):
+        PipTarget.parse("solaris-sparc-cp313")
+
+
+def test_pip_target_parse_invalid_format_raises():
+    with pytest.raises(ValueError, match="invalid target ID"):
+        PipTarget.parse("not-a-valid-target")
+
+
+def test_pip_target_parse_below_minimum_python_raises():
+    with pytest.raises(ValueError, match="below minimum"):
+        PipTarget.parse("linux-x86_64-cp39")
+
+
+def test_pip_target_linux_includes_manylinux_ladder():
+    target = PipTarget.parse("linux-x86_64-cp312")
+    assert "manylinux_2_28_x86_64" in target.pip_platform_tags
+    assert "manylinux_2_17_x86_64" in target.pip_platform_tags
+    assert "manylinux2014_x86_64" in target.pip_platform_tags
+    assert "manylinux1_x86_64" in target.pip_platform_tags
+
+
+def test_pip_target_abis_include_abi3_and_none():
+    for platform in ("linux-x86_64", "windows-x86_64", "macos-aarch64", "macos-x86_64"):
+        target = PipTarget(ida_platform=platform, python_version="3.12")
+        assert "abi3" in target.abis, f"{platform} missing abi3"
+        assert "none" in target.abis, f"{platform} missing none"
+
+
+def test_pip_target_pip_download_args_format():
+    target = PipTarget.parse("linux-x86_64-cp312")
+    args = target.pip_download_args()
+    assert "--only-binary=:all:" in args
+    assert "--implementation" in args
+    assert args[args.index("--implementation") + 1] == "cp"
+    assert "--python-version" in args
+    assert args[args.index("--python-version") + 1] == "3.12"
+    assert args.count("--abi") == 3
+    assert args.count("--platform") >= 3
+
+
+def test_pip_target_macos_includes_version_ladder():
+    target = PipTarget.parse("macos-x86_64-cp312")
+    tags = target.pip_platform_tags
+    assert "macosx_10_13_x86_64" in tags
+    assert "macosx_10_9_x86_64" in tags
+    assert any("universal2" in t for t in tags)
+
+
+def test_pip_target_macos_arm64_includes_universal2():
+    target = PipTarget.parse("macos-aarch64-cp312")
+    tags = target.pip_platform_tags
+    assert "macosx_11_0_arm64" in tags
+    assert any("universal2" in t for t in tags)
+
+
+def test_pip_target_windows_tags():
+    target = PipTarget.parse("windows-x86_64-cp312")
+    assert target.pip_platform_tags == ("win_amd64",)
+
+
+def test_pip_target_id_derivation():
+    target = PipTarget(ida_platform="macos-aarch64", python_version="3.13")
+    assert target.id == "macos-aarch64-cp313"
+
+
+def test_pip_target_python_314_works():
+    target = PipTarget(ida_platform="linux-x86_64", python_version="3.14")
+    assert target.id == "linux-x86_64-cp314"
+    assert "cp314" in target.abis
+
+
+def test_bundle_dependency_source_matching_target_returns_pip_options(tmp_path):
+    manifest = _make_manifest()
+    wh_files = {
+        "dependencies/python/linux-x86_64-cp312/pkg-1.0-py3-none-any.whl": b"wheel",
+    }
+    p = tmp_path / "bundle.zip"
+    p.write_bytes(_build_bundle_zip(manifest, wheelhouse_files=wh_files))
+    repo = PluginBundleRepo(p)
+    try:
+        with bundle_dependency_source(repo, "linux-x86_64", "3.12") as opts:
+            assert opts is not None
+            assert opts.offline is True
+            assert opts.isolated is True
+            assert opts.no_cache_dir is True
+            assert opts.disable_pip_version_check is True
+            assert len(opts.find_links) == 1
+    finally:
+        repo.close()
+
+
+def test_bundle_dependency_source_no_matching_target_returns_none(tmp_path):
+    manifest = _make_manifest()
+    p = tmp_path / "bundle.zip"
+    p.write_bytes(_build_bundle_zip(manifest))
+    repo = PluginBundleRepo(p)
+    try:
+        with bundle_dependency_source(repo, "windows-x86_64", "3.12") as opts:
+            assert opts is None
+    finally:
+        repo.close()
+
+
+def test_resolve_platform_alias_canonical():
+    assert resolve_platform_alias("linux-x86_64") == "linux-x86_64"
+    assert resolve_platform_alias("windows-x86_64") == "windows-x86_64"
+
+
+def test_resolve_platform_alias_short():
+    assert resolve_platform_alias("linux") == "linux-x86_64"
+    assert resolve_platform_alias("windows") == "windows-x86_64"
+    assert resolve_platform_alias("win") == "windows-x86_64"
+    assert resolve_platform_alias("macos-arm64") == "macos-aarch64"
+    assert resolve_platform_alias("macos-intel") == "macos-x86_64"
+
+
+def test_resolve_platform_alias_case_insensitive():
+    assert resolve_platform_alias("Linux") == "linux-x86_64"
+    assert resolve_platform_alias("WINDOWS") == "windows-x86_64"
+
+
+def test_resolve_platform_alias_unknown_raises():
+    with pytest.raises(ValueError, match="unknown platform"):
+        resolve_platform_alias("solaris")
+
+
+def test_resolve_platform_alias_error_lists_valid():
+    with pytest.raises(ValueError, match="linux") as exc_info:
+        resolve_platform_alias("solaris")
+    msg = str(exc_info.value)
+    assert "windows" in msg
+    assert "macos-arm64" in msg
+
+
+def test_pip_target_from_alias_platforms():
+    target = PipTarget(ida_platform="linux-x86_64", python_version="3.12")
+    assert target.id == "linux-x86_64-cp312"
+
+
+def test_resolve_targets_platform_and_python_cross_product():
+    targets = _resolve_targets(("linux", "windows"), ("3.12", "3.13"), ())
+    ids = {t.id for t in targets}
+    assert ids == {"linux-x86_64-cp312", "linux-x86_64-cp313", "windows-x86_64-cp312", "windows-x86_64-cp313"}
+
+
+def test_resolve_targets_missing_python_raises():
+    with pytest.raises(click.BadParameter, match="--python is required"):
+        _resolve_targets(("linux",), (), ())
+
+
+def test_resolve_targets_missing_platform_raises():
+    with pytest.raises(click.BadParameter, match="--platform is required"):
+        _resolve_targets((), ("3.12",), ())
+
+
+def test_resolve_targets_neither_specified_raises():
+    with pytest.raises(click.BadParameter, match="--platform is required"):
+        _resolve_targets((), (), ())
+
+
+def test_resolve_targets_platform_all():
+    targets = _resolve_targets(("all",), ("3.12",), ())
+    assert len(targets) == len(ALL_PLATFORMS)
+    platforms = {t.ida_platform for t in targets}
+    assert platforms == set(ALL_PLATFORMS)
+
+
+def test_resolve_targets_python_all():
+    targets = _resolve_targets(("linux",), ("all",), ())
+    assert len(targets) == len(SUPPORTED_PYTHON_VERSIONS)
+    versions = {t.python_version for t in targets}
+    assert versions == set(SUPPORTED_PYTHON_VERSIONS)
+
+
+def test_resolve_targets_all_and_all():
+    targets = _resolve_targets(("all",), ("all",), ())
+    assert len(targets) == len(ALL_PLATFORMS) * len(SUPPORTED_PYTHON_VERSIONS)
+
+
+def test_resolve_targets_current_platform(monkeypatch):
+    monkeypatch.setattr("hcli.lib.ida.find_current_ida_platform", lambda: "linux-x86_64")
+    targets = _resolve_targets(("current",), ("3.12",), ())
+    assert len(targets) == 1
+    assert targets[0].ida_platform == "linux-x86_64"
+
+
+def test_resolve_targets_current_python(monkeypatch):
+    monkeypatch.setattr("hcli.lib.ida.python.detect_current_python_version", lambda: "3.13")
+    targets = _resolve_targets(("linux",), ("current",), ())
+    assert len(targets) == 1
+    assert targets[0].python_version == "3.13"
+
+
+def test_resolve_targets_deduplicates():
+    targets = _resolve_targets(("linux", "linux"), ("3.12", "3.12"), ())
+    assert len(targets) == 1
+    assert targets[0].id == "linux-x86_64-cp312"
+
+
+def test_resolve_targets_legacy_target_flag():
+    targets = _resolve_targets((), (), ("linux-x86_64-cp312",))
+    assert len(targets) == 1
+    assert targets[0].id == "linux-x86_64-cp312"
+
+
+def test_resolve_targets_target_and_platform_raises():
+    with pytest.raises(click.BadParameter, match="cannot be combined"):
+        _resolve_targets(("linux",), (), ("linux-x86_64-cp312",))
+
+
+def test_resolve_targets_bad_platform_raises():
+    with pytest.raises(click.BadParameter, match="unknown platform"):
+        _resolve_targets(("solaris",), ("3.12",), ())

--- a/tests/lib/test_plugin_bundle.py
+++ b/tests/lib/test_plugin_bundle.py
@@ -339,7 +339,7 @@ def test_bundle_dependency_source_matching_target_returns_pip_options(tmp_path):
     try:
         with bundle_dependency_source(repo, "linux-x86_64", "3.12") as opts:
             assert opts is not None
-            assert opts.offline is True
+            assert opts.offline is False
             assert opts.isolated is True
             assert opts.no_cache_dir is True
             assert opts.disable_pip_version_check is True

--- a/tests/lib/test_plugin_bundle_commands.py
+++ b/tests/lib/test_plugin_bundle_commands.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from hcli.commands.plugin.bundle import bundle
+from hcli.lib.ida.python import PipOptions
+
+TESTS_DIR = Path(__file__).parent.parent
+PLUGIN1_V1 = TESTS_DIR / "data" / "plugins" / "plugin1" / "plugin1-v1.0.0.zip"
+
+sys.path.insert(0, str(Path(__file__).parent))
+from test_plugin_bundle import _build_bundle_zip, _make_manifest
+
+VALID_WHEEL = "some_pkg-1.0-py3-none-any.whl"
+VALID_WH_FILES = {
+    f"dependencies/python/linux-x86_64-cp312/{VALID_WHEEL}": b"fake-wheel",
+}
+
+
+def test_bundle_info_valid_bundle(tmp_path):
+    plugin_data = PLUGIN1_V1.read_bytes()
+    data = _build_bundle_zip(
+        _make_manifest(),
+        plugin_zips={"plugin1-v1.0.0.zip": plugin_data},
+        wheelhouse_files=VALID_WH_FILES,
+    )
+    p = tmp_path / "bundle.zip"
+    p.write_bytes(data)
+
+    runner = CliRunner()
+    result = runner.invoke(bundle, ["info", str(p)])
+
+    assert result.exit_code == 0, result.output
+    assert "plugin bundle" in result.output
+    assert "built:" in result.output
+    assert "targets:" in result.output
+    assert "plugins:" in result.output
+
+
+def test_bundle_info_not_a_bundle(tmp_path):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("readme.txt", "hello")
+    p = tmp_path / "regular.zip"
+    p.write_bytes(buf.getvalue())
+
+    runner = CliRunner()
+    result = runner.invoke(bundle, ["info", str(p)])
+
+    assert result.exit_code != 0
+
+
+def test_bundle_info_empty_bundle(tmp_path):
+    data = _build_bundle_zip(_make_manifest(), wheelhouse_files=VALID_WH_FILES)
+    p = tmp_path / "bundle.zip"
+    p.write_bytes(data)
+
+    runner = CliRunner()
+    result = runner.invoke(bundle, ["info", str(p)])
+
+    assert result.exit_code == 0, result.output
+    assert "plugins: (none)" in result.output
+
+
+def test_bundle_create_from_local_zip_no_deps(tmp_path):
+    out = tmp_path / "output.zip"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        bundle,
+        ["create", "--path", str(out), "--target", "linux-x86_64-cp312", str(PLUGIN1_V1)],
+        obj={"pip_options": PipOptions()},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+
+    with zipfile.ZipFile(out, "r") as zf:
+        names = zf.namelist()
+        assert "plugin-bundle.json" in names
+        plugin_members = [n for n in names if n.startswith("plugins/") and n.endswith(".zip")]
+        assert len(plugin_members) == 1
+
+    from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo
+
+    repo = PluginBundleRepo(out)
+    try:
+        assert "linux-x86_64-cp312" in repo.target_ids
+        plugins = repo.get_plugins()
+        assert len(plugins) == 1
+        assert plugins[0].name == "plugin1"
+    finally:
+        repo.close()
+
+
+def test_bundle_create_unknown_target_rejected(tmp_path):
+    out = tmp_path / "output.zip"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        bundle,
+        ["create", "--path", str(out), "--target", "nonexistent-target", str(PLUGIN1_V1)],
+        obj={"pip_options": PipOptions()},
+    )
+
+    assert result.exit_code != 0
+    assert "unknown target" in result.output.lower() or "error" in result.output.lower()
+
+
+def test_bundle_create_requires_version_for_repo_spec(tmp_path):
+    out = tmp_path / "output.zip"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        bundle,
+        ["create", "--path", str(out), "--target", "linux-x86_64-cp312", "someplugin"],
+        obj={"pip_options": PipOptions()},
+    )
+
+    assert result.exit_code != 0

--- a/tests/lib/test_plugin_bundle_install.py
+++ b/tests/lib/test_plugin_bundle_install.py
@@ -1,0 +1,147 @@
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from fixtures import *
+
+from hcli.lib.ida.plugin.exceptions import PluginVersionDowngradeError
+from hcli.lib.ida.plugin.install import (
+    get_installed_plugins,
+    install_plugin_archive,
+    is_plugin_installed,
+    upgrade_plugin_archive,
+)
+from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo
+
+TESTS_DIR = Path(__file__).parent.parent
+PLUGIN1_V1 = TESTS_DIR / "data" / "plugins" / "plugin1" / "plugin1-v1.0.0.zip"
+PLUGIN1_V2 = TESTS_DIR / "data" / "plugins" / "plugin1" / "plugin1-v2.0.0.zip"
+
+
+def _make_manifest(**overrides) -> dict:
+    base = {
+        "version": 1,
+        "kind": "hcli-plugin-bundle",
+        "builtAt": "2026-04-28T16:00:00Z",
+        "createdBy": {"tool": "hcli", "version": "0.0.0"},
+        "targetPlatformTags": [
+            {
+                "id": "macos-aarch64-cp312",
+                "idaPlatform": "macos-aarch64",
+                "pythonVersion": "3.12",
+                "implementation": "cp",
+                "abis": ["cp312", "abi3", "none"],
+                "pipPlatformTags": ["macosx_11_0_arm64"],
+                "wheelhouse": "dependencies/python/macos-aarch64-cp312",
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _build_bundle_zip(
+    manifest_dict: dict,
+    plugin_zips: dict[str, bytes] | None = None,
+) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("plugin-bundle.json", json.dumps(manifest_dict))
+        if plugin_zips:
+            for name, data in plugin_zips.items():
+                zf.writestr(f"plugins/{name}", data)
+        for target in manifest_dict.get("targetPlatformTags", []):
+            wh = target["wheelhouse"]
+            zf.writestr(f"{wh}/placeholder.whl", b"fake-wheel")
+    return buf.getvalue()
+
+
+def test_bundle_install_plugin_from_bundle(virtual_ida_environment, tmp_path):
+    bundle_path = tmp_path / "bundle.zip"
+    bundle_path.write_bytes(
+        _build_bundle_zip(
+            _make_manifest(),
+            plugin_zips={"plugin1-v1.0.0.zip": PLUGIN1_V1.read_bytes()},
+        )
+    )
+    repo = PluginBundleRepo(bundle_path)
+    try:
+        name, buf = repo.fetch_compatible_plugin_from_spec("plugin1==1.0.0", "macos-aarch64", "9.1")
+    finally:
+        repo.close()
+
+    install_plugin_archive(buf, name)
+
+    assert is_plugin_installed("plugin1")
+    assert ("plugin1", "1.0.0") in get_installed_plugins()
+
+
+def test_bundle_install_upgrade_plugin_from_bundle(virtual_ida_environment, tmp_path):
+    bundle_path = tmp_path / "bundle.zip"
+    bundle_path.write_bytes(
+        _build_bundle_zip(
+            _make_manifest(),
+            plugin_zips={
+                "plugin1-v1.0.0.zip": PLUGIN1_V1.read_bytes(),
+                "plugin1-v2.0.0.zip": PLUGIN1_V2.read_bytes(),
+            },
+        )
+    )
+    repo = PluginBundleRepo(bundle_path)
+    try:
+        name_v1, buf_v1 = repo.fetch_compatible_plugin_from_spec("plugin1==1.0.0", "macos-aarch64", "9.1")
+        name_v2, buf_v2 = repo.fetch_compatible_plugin_from_spec("plugin1==2.0.0", "macos-aarch64", "9.1")
+    finally:
+        repo.close()
+
+    install_plugin_archive(buf_v1, name_v1)
+    assert ("plugin1", "1.0.0") in get_installed_plugins()
+
+    upgrade_plugin_archive(buf_v2, name_v2)
+    assert ("plugin1", "2.0.0") in get_installed_plugins()
+    assert ("plugin1", "1.0.0") not in get_installed_plugins()
+
+
+def test_bundle_install_downgrade_raises(virtual_ida_environment, tmp_path):
+    bundle_path = tmp_path / "bundle.zip"
+    bundle_path.write_bytes(
+        _build_bundle_zip(
+            _make_manifest(),
+            plugin_zips={
+                "plugin1-v1.0.0.zip": PLUGIN1_V1.read_bytes(),
+                "plugin1-v2.0.0.zip": PLUGIN1_V2.read_bytes(),
+            },
+        )
+    )
+    repo = PluginBundleRepo(bundle_path)
+    try:
+        name_v1, buf_v1 = repo.fetch_compatible_plugin_from_spec("plugin1==1.0.0", "macos-aarch64", "9.1")
+        name_v2, buf_v2 = repo.fetch_compatible_plugin_from_spec("plugin1==2.0.0", "macos-aarch64", "9.1")
+    finally:
+        repo.close()
+
+    install_plugin_archive(buf_v2, name_v2)
+    assert ("plugin1", "2.0.0") in get_installed_plugins()
+
+    with pytest.raises(PluginVersionDowngradeError):
+        upgrade_plugin_archive(buf_v1, name_v1)
+
+    assert ("plugin1", "2.0.0") in get_installed_plugins()
+
+
+def test_bundle_install_fetch_unsatisfiable_spec_raises(tmp_path):
+    bundle_path = tmp_path / "bundle.zip"
+    bundle_path.write_bytes(
+        _build_bundle_zip(
+            _make_manifest(),
+            plugin_zips={"plugin1-v2.0.0.zip": PLUGIN1_V2.read_bytes()},
+        )
+    )
+    repo = PluginBundleRepo(bundle_path)
+    try:
+        with pytest.raises((KeyError, ValueError)):
+            repo.fetch_compatible_plugin_from_spec("plugin1==1.0.0", "macos-aarch64", "9.1")
+    finally:
+        repo.close()


### PR DESCRIPTION
# HCLI plugin bundle specification

## Goal

HCLI must be able to install IDA plugins and their Python dependencies on machines that cannot reach the network. A connected machine builds a plugin bundle archive. An offline machine can copy that archive locally and use normal plugin manager commands against it.

The plugin bundle is repository-level. It may contain multiple plugins, multiple versions, and the shared wheelhouses (directories of pre-downloaded `.whl` files) needed to install those plugins. It is not a per-plugin sandbox, and it does not change HCLI's current dependency installation model: Python dependencies are installed into the active IDA Python environment.

## Supported user flows

Create a plugin bundle on a connected machine targeting the current machine's platform and Python:

```console
hcli plugin bundle create \
  --path malware-vm-tools-2026-04.hcli-plugin-bundle.zip \
  --platform current --python current \
  oplog==0.1.3 \
  hint-calls==0.1.3
```

Both `--platform` and `--python` are always required. The special value `current` resolves to the current machine's platform or Python version. The special value `all` resolves to all supported platforms (linux, windows, macos-arm64, macos-intel) or all supported Python versions (3.10–3.14). Otherwise, pass a specific name like `linux` or version like `3.12`.

Create a plugin bundle for all platforms at specific Python versions:

```console
hcli plugin bundle create \
  --path bundle.zip \
  --platform all --python 3.12 --python 3.13 \
  oplog==0.1.3 \
  hint-calls==0.1.3
```

Create a plugin bundle for specific platforms and Python versions:

```console
hcli plugin bundle create \
  --path malware-vm-tools-2026-04.hcli-plugin-bundle.zip \
  --platform linux --platform windows --platform macos-arm64 \
  --python 3.12 --python 3.13 \
  oplog==0.1.3 \
  hint-calls==0.1.3
```

`--platform` and `--python` are both repeatable. HCLI builds the cross product of all specified platforms and Python versions. Platform accepts short aliases: `linux`, `windows`, `macos-arm64`, `macos-intel`, `win`, etc. Duplicate targets from overlapping aliases (e.g. `--platform all --platform linux`) are deduplicated.

Create a plugin bundle that includes local/private plugin archives:

```console
hcli plugin bundle create \
  --path internal-review.hcli-plugin-bundle.zip \
  --platform current --python current \
  --repo /path/to/internal-plugin-repository.json \
  ./dist/internal-plugin-1.2.0.zip \
  private-helper==2.0.0
```

Inspect or search a plugin bundle without manual extraction:

```console
hcli plugin --repo ./malware-vm-tools-2026-04.hcli-plugin-bundle.zip search
hcli plugin --repo ./malware-vm-tools-2026-04.hcli-plugin-bundle.zip search hints
```

Install from a plugin bundle on an offline machine:

```console
hcli plugin --repo ./malware-vm-tools-2026-04.hcli-plugin-bundle.zip install hint-calls
```

Upgrade from a plugin bundle:

```console
hcli plugin --repo ./malware-vm-tools-2026-04.hcli-plugin-bundle.zip upgrade hint-calls
```

In plugin bundle mode, upgrade means "upgrade to the newest compatible version available in this plugin bundle." It does not mean latest upstream.

### Advanced usage

Use a corporate pip index instead of the default pip configuration:

```console
hcli plugin --pip-index-url https://pypi.example.corp/simple install ipyida
```

Use an explicit local wheel source:

```console
hcli plugin --pip-find-links /mnt/wheelhouse --offline install ipyida
```

## Command-line interface

The plugin command group gains these options:

```console
hcli plugin [--repo REPO] [--pip-index-url URL] [--pip-extra-index-url URL] [--pip-find-links PATH_OR_URL] [--offline] COMMAND ...
```

`--repo` accepts the existing repository forms plus a local plugin bundle archive. A plugin bundle archive is a ZIP file containing top-level `plugin-bundle.json`.

`--pip-index-url` is passed to pip as `--index-url`. It may point to PyPI, Artifactory, or any other compatible package index.

`--pip-extra-index-url` is repeatable and passed to pip as `--extra-index-url`.

`--pip-find-links` is repeatable and passed to pip as `--find-links`.

`--offline` forces pip dependency resolution to use only local sources. It passes `--no-index` and must be used with either a plugin bundle wheelhouse or at least one `--pip-find-links` value.

Pip source precedence is:

1. Explicit pip CLI options.
2. Plugin bundle wheelhouse selected from the active plugin bundle.
3. Existing configured/default online pip behavior.

If explicit pip CLI options are provided while using a plugin bundle repository, the explicit options control dependency installation. The plugin bundle still controls plugin discovery and plugin archive bytes.

## Plugin bundle archive format

A plugin bundle archive is a ZIP file with this layout:

```text
plugin-bundle.json
plugins/
  <archive-name>.zip
dependencies/
  python/
    <target-id>/
      <wheel files>.whl
```

The `plugins/` directory contains unmodified IDA plugin ZIP archives. HCLI discovers bundled plugins by walking `plugins/` and reading `ida-plugin.json` from each archive.

Each `dependencies/python/<target-id>/` directory is a flat wheelhouse for one target tuple. Wheels keep their original filenames. Sdists are rejected by default during bundle creation.

Each target entry in the manifest is a snapshot of the exact compatibility parameters used to fetch wheels for that target. This allows audit and install to verify wheel compatibility without re-deriving the parameters.

`plugin-bundle.json` is UTF-8 JSON. Version 1 has this shape:

```json
{
  "version": 1,
  "kind": "hcli-plugin-bundle",
  "builtAt": "2026-04-28T16:00:00Z",
  "createdBy": {
    "tool": "hcli",
    "version": "0.0.0"
  },
  "targetPlatformTags": [
    {
      "id": "linux-x86_64-cp312",
      "idaPlatform": "linux-x86_64",
      "pythonVersion": "3.12",
      "implementation": "cp",
      "abis": ["cp312", "abi3", "none"],
      "pipPlatformTags": [
        "manylinux_2_28_x86_64",
        "manylinux_2_17_x86_64",
        "manylinux2014_x86_64"
      ],
      "wheelhouse": "dependencies/python/linux-x86_64-cp312"
    }
  ]
}
```

## Target matching

On install or upgrade, HCLI detects the active IDA platform and active IDA Python interpreter. For IDA 9.0+, the first supported Python line is Python 3.10+.

HCLI selects a wheelhouse whose target tuple matches:

- HCLI/IDA platform, such as `windows-x86_64` or `macos-aarch64`
- Python major/minor version
- CPython implementation and ABI expectations

If no target tuple matches, HCLI fails before changing plugins or installing dependencies.

A plugin bundle may contain target tuples for operating systems and Python versions other than the machine that created it. Cross-target creation is supported when every dependency can be obtained as a compatible wheel for the requested target. If a required dependency is available only as an sdist, or only as a wheel with a platform baseline newer than the target, bundle creation or audit must fail for that target unless the user supplies a matching prebuilt wheel.

### IDA version compatibility during bundle creation

Bundle creation does not check IDA version compatibility. The builder machine may run a different IDA version than the target machines, and plugin `idaVersions` metadata is not a useful filtering axis during packaging. Plugins are bundled as-is; IDA version compatibility is checked only at install time on the target machine. This avoids adding IDA version as yet another dimension to the target matrix (alongside platform and Python version) and keeps the bundle creation model simple. If users report problems with this approach, IDA version filtering can be revisited.

## Dependency installation behavior

When installing a plugin with `pythonDependencies`, HCLI installs dependencies with pip before extracting the plugin. In plugin bundle offline mode it extracts the matching wheelhouse to a temporary directory and invokes pip with local-only options:

```console
python -m pip install \
  --isolated \
  --disable-pip-version-check \
  --no-cache-dir \
  --no-index \
  --find-links <temporary-wheelhouse> \
  <all dependency specs>
```

HCLI includes dependency specs from already installed HCLI-managed plugins plus the plugin being installed or upgraded. Already installed packages may satisfy requirements if pip considers them compatible. HCLI does not use `--ignore-installed` by default.

No hash pinning is required. The user trusts the plugin bundle author.

HCLI does not uninstall Python dependencies when plugins are uninstalled. Orphaned dependencies are left in the Python environment, matching current behavior.

## Bundle creation behavior

`hcli plugin bundle create` accepts explicit plugin versions and local plugin ZIP paths as positional arguments. Repository plugin references must include an exact version, for example `oplog==0.1.3`. Bare latest resolution is intentionally not part of the first version. `--path` selects the output archive path.

Targeting uses `--platform` and `--python`, both required and repeatable. Each accepts `current` (auto-detect this machine), `all` (all supported values), or a specific value. `--platform` accepts the canonical IDA platform name (e.g. `linux-x86_64`) or short aliases (`linux`, `windows`, `macos-arm64`, `macos-intel`). `--python` accepts a `major.minor` version string (e.g. `3.12`). HCLI builds the cross product of all resolved platforms and Python versions. Duplicate targets are deduplicated.

The supported Python versions for `--python all` are maintained as a hardcoded constant (`SUPPORTED_PYTHON_VERSIONS`): 3.10, 3.11, 3.12, 3.13, 3.14. This is updated when new Python versions release (annually in October). This matches the approach used by cibuildwheel and other ecosystem tools — no package provides this list dynamically.

A legacy `--target` flag (e.g. `--target linux-x86_64-cp312`) is accepted for scripting but hidden from help. It cannot be combined with `--platform` or `--python`.

Bundle creation resolves all selected plugin archives, reads their `ida-plugin.json` metadata, collects all `pythonDependencies`, and materializes a flat wheelhouse per target tuple. A single online Linux builder can create wheelhouses for all target platforms when all dependencies publish compatible wheels.

The preferred wheelhouse materialization path is one `pip download` invocation per target. For cross-target downloads HCLI must pass all compatibility options together:

```console
python -m pip download \
  --only-binary=:all: \
  --implementation cp \
  --python-version <major.minor> \
  --abi <cp-abi> --abi abi3 --abi none \
  --platform <platform-tag> [--platform <platform-tag> ...] \
  --dest <wheelhouse> \
  -r <requirements-or-lock>
```

`--platform` is repeatable. Linux targets should list every manylinux tag HCLI accepts, for example `manylinux_2_28_x86_64`, `manylinux_2_17_x86_64`, and `manylinux2014_x86_64`. macOS x86_64 targets should include the supported deployment baseline. Optional targets such as Windows ARM64 or musllinux should be explicit presets rather than inferred from x86_64 targets. Over-listing compatible tags is safer than under-listing them.

`uv pip compile --universal` may be used to produce one cross-platform lock or constraints file before materializing target wheelhouses. `uv pip install --python-platform ... --python ... --target ...` is also valid for producing an unpacked per-target site-packages tree; because the version 1 plugin bundle format stores wheel files, `pip download` remains the direct path for wheelhouse plugin bundles unless HCLI later adds an unpacked dependency tree format.

By default, bundle creation rejects sdists because offline installation from sdists requires build tools and build dependencies on the target. Missing wheels are handled by failing the affected target, by using a matching builder to produce wheels, or by supplying prebuilt wheels with a local `--find-links` source. Linux wheels can often be built from one Linux host inside a manylinux container. Windows and macOS sdist-only dependencies require native runners or prebuilt vendor wheels.

If selected plugins have incompatible Python dependency constraints, bundle creation fails.

## Additive plugin bundles

Plugin bundles are additive. An offline VM may use one plugin bundle today and a second plugin bundle later. HCLI does not require a single authoritative plugin bundle for the machine.

When a plugin bundle install fails, errors should distinguish where possible: whether the plugin is absent from the bundle, whether it exists but is incompatible with the current IDA version or platform, whether no wheelhouse matches the active IDA Python, whether a dependency wheel is missing from the selected wheelhouse, or whether dependency constraints conflict with already installed packages.

## Private plugin metadata

The `repository` field in `ida-plugin.json` must be a valid GitHub URL (`https://github.com/org/project`). This applies to both public and private plugins. Private plugins should use a GitHub repository URL — either a public repo or a private one. If no real repository exists, a placeholder GitHub URL is acceptable (e.g. `https://github.com/internal/placeholder`) because the public plugin indexer only fetches URLs for plugins it ingests, and offline bundle plugins are never indexed.

The validation is intentionally not relaxed to support arbitrary hosting providers (GitLab, Gitea, etc.) until there are concrete user requirements. Keeping the GitHub constraint preserves the field's usefulness as a consistent, predictable link format across all plugins.

## Plugin spec disambiguation

When the plugin repository contains multiple entries with the same plugin name from different hosts (e.g. forks), `bundle create` requires the `@host` suffix to disambiguate:

```console
hcli plugin bundle create \
  --path bundle.zip \
  --platform all --python all \
  "efiXplorer==6.2.0@https://github.com/rehints/efixplorer" \
  "idalib-rust-bindings==0.9.0@https://github.com/idalib-rs/idalib"
```

The `@host` is parsed from the spec before resolution. Unambiguous plugins do not require it.

## Known limitations observed during all-plugin bundle testing

Bundle creation pools all `pythonDependencies` from every included plugin into a single `pip download` invocation per target. A single unresolvable dependency (nonexistent version, missing wheel for the target) fails the entire wheelhouse for that target. There is no per-plugin isolation.

Plugins observed with broken or unavailable dependencies at the time of testing (2026-05-04):

- `Frida_Tools`, `FridaTools`: require `pyside6>=6.10.2` (no such version on PyPI)
- `idapcode`: requires `pypcode~=3.3.3` (no such version on PyPI; available versions max at 1.1.2)
- `IDAssist`: requires `pysqlite3` (no binary wheels for macOS x86_64 or cp310)
- `ida-cyberchef`: requires `STPyV8` (no binary wheels for cp310 targets)
- `fwhunt-ida`: requires `fwhunt-scan~=2.3.5` which depends on `uefi-firmware>=1.10` (no wheels for macOS aarch64)

Additionally, `codeload.github.com` URLs produce archives with non-deterministic hashes, causing SHA256 verification failures for plugins that use them as download URLs (e.g. `xray`). This is a plugin repository data issue, not a bundle code issue.

Python 3.14 targets often fail because many packages have not yet published cp314 wheels (as of 2026-05-04). The `--python all` flag includes 3.14 by default; use explicit `--python 3.10 --python 3.11 --python 3.12 --python 3.13` to avoid these failures until ecosystem support improves.

A future improvement could add a `--skip-on-error` flag to bundle creation so that individual plugin dependency failures are reported as warnings rather than aborting the entire build.

## Out of scope

The first version does not address per-plugin dependency sandboxes, dependency removal on uninstall, reproducible builds, or wheel redistribution and license compliance. Plugin bundle signatures and external checksum files are also deferred, as is storing corporate pip index settings in `ida-config.json`.