### PR TITLE
Add hidden `hcli asset` group (put/delete)

### DIFF
--- a/src/hcli/commands/__init__.py
+++ b/src/hcli/commands/__init__.py
@@ -22,6 +22,7 @@ def register_commands(cli: click.Group) -> None:
     cli.add_command(plugin)
 
     # groups
+    from .asset import asset
     from .auth import auth
     from .extension import extension
     from .ida import ida
@@ -33,3 +34,4 @@ def register_commands(cli: click.Group) -> None:
     cli.add_command(share)
     cli.add_command(license)
     cli.add_command(extension)
+    cli.add_command(asset)

--- a/src/hcli/commands/asset/__init__.py
+++ b/src/hcli/commands/asset/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import rich_click as click
+
+
+@click.group(hidden=True)
+def asset() -> None:
+    """Low-level asset bucket commands."""
+
+
+from .delete import delete
+from .put import put
+
+asset.add_command(put)
+asset.add_command(delete)

--- a/src/hcli/commands/asset/delete.py
+++ b/src/hcli/commands/asset/delete.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import rich_click as click
+
+from hcli.lib.api.asset import asset
+from hcli.lib.commands import async_command, auth_command
+from hcli.lib.console import console
+
+
+@auth_command()
+@click.argument("key", type=str)
+@click.option("-b", "--bucket", required=True, type=str, help="Bucket to delete from")
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+@async_command
+async def delete(
+    key: str,
+    bucket: str,
+    yes: bool = False,
+) -> None:
+    """Delete an asset by key."""
+
+    if not yes:
+        click.confirm(
+            f"Are you sure you want to delete '{key}' from bucket '{bucket}'?",
+            abort=True,
+        )
+
+    await asset.delete_file_by_key(bucket=bucket, key=key)
+
+    console.print("[green]✓ Asset deleted successfully![/green]")
+    console.print(f"[bold]Bucket:[/bold] {bucket}")
+    console.print(f"[bold]Key:[/bold] {key}")

--- a/src/hcli/commands/asset/put.py
+++ b/src/hcli/commands/asset/put.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import rich_click as click
+
+from hcli.lib.api.asset import asset
+from hcli.lib.commands import async_command, auth_command
+from hcli.lib.console import console
+
+
+@auth_command()
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option("-b", "--bucket", required=True, type=str, help="Bucket to upload to")
+@click.option(
+    "-m",
+    "--metadata",
+    required=True,
+    type=str,
+    multiple=True,
+    help="Attach metadata as KEY=VALUE (repeatable). Example: -m version=9.2 -m category=ida-free",
+)
+@click.option(
+    "--allowed-segments",
+    required=False,
+    default=None,
+    help="Comma-separated list of allowed segments (e.g. segment1,segment2,segment3)",
+)
+@click.option(
+    "--allowed-emails",
+    required=False,
+    default=None,
+    help="Comma-separated list of allowed email addresses",
+)
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Upload a new version or overwrite the asset if it exists",
+)
+@async_command
+async def put(
+    path: Path,
+    bucket: str,
+    metadata: tuple[str, ...],
+    allowed_segments: str | None,
+    allowed_emails: str | None,
+    force: bool = False,
+) -> None:
+    """Upload an asset to a bucket."""
+
+    if not path.exists():
+        console.print(f"[red]Error: File not found: {path}[/red]")
+        raise click.Abort()
+
+    if not path.is_file():
+        console.print(f"[red]Error: Path is not a file: {path}[/red]")
+        raise click.Abort()
+
+    bucket_obj = await asset.get_bucket(bucket)
+    if not bucket_obj:
+        console.print(f"[red]Error: Bucket {bucket} does not exist[/red]")
+        raise click.Abort()
+
+    metadata_dict = {}
+    for item in metadata:
+        if "=" not in item:
+            console.print(f"[red]Error: Metadata '{item}' is not in KEY=VALUE format[/red]")
+            raise click.Abort()
+        key, val = item.split("=", 1)
+        metadata_dict[key] = val
+
+    missing_fields = []
+    for required_key in bucket_obj.requiredMetadata:
+        if required_key not in metadata_dict:
+            missing_fields.append(required_key)
+
+    if missing_fields:
+        console.print(f"[red]Error: Missing required metadata fields: {', '.join(missing_fields)}[/red]")
+        console.print("[yellow]Required fields:[/yellow]")
+        for key, field in bucket_obj.requiredMetadata.items():
+            console.print(f"  - {key}: {field.description} (example: {field.example})")
+        raise click.Abort()
+
+    segments = allowed_segments.split(",") if allowed_segments else None
+    emails = allowed_emails.split(",") if allowed_emails else None
+    result = await asset.upload_asset(
+        bucket=bucket,
+        file_path=str(path),
+        allowed_segments=segments,
+        allowed_emails=emails,
+        metadata=metadata_dict,
+        force=force,
+    )
+
+    console.print("[green]✓ File uploaded successfully![/green]")
+    console.print(f"[bold]Bucket:[/bold] {bucket}")
+    console.print(f"[bold]Key:[/bold] {result.key}")
+    console.print(f"[bold]Version:[/bold] {result.version}")

--- a/src/hcli/commands/commands.py
+++ b/src/hcli/commands/commands.py
@@ -11,6 +11,9 @@ def collect_all_commands(group: click.Group, parent_path: str = "") -> list[str]
     commands = []
 
     for name, command in group.commands.items():
+        if command.hidden:
+            continue
+
         current_path = f"{parent_path} {name}".strip()
 
         if isinstance(command, click.Group):


### PR DESCRIPTION
## Summary
- Adds `hcli asset put` and `hcli asset delete` as a hidden command group
- Both commands wrap the same `/api/assets/{bucket}` endpoints that already back `hcli share {put,delete}` (via `hcli.lib.api.asset.AssetAPI`), but expose the raw bucket / metadata / segment / email surface rather than the constrained share-code UX.
- The group uses Click's `hidden=True`, so it does not appear in `hcli --help`. `collect_all_commands` now also skips hidden commands, so it stays out of `hcli commands` output too.
- Not access-controlled at the CLI layer — hiding only narrows the discoverable surface. Server-side bucket permissions remain the source of truth.

## Test plan
- [x] `uv run hcli --help` — `asset` is not listed
- [x] `uv run hcli commands` — `asset` entries do not appear
- [x] `uv run hcli asset --help` — group is reachable and lists `put` / `delete`
- [x] `uv run hcli asset put --help` — shows full option surface (bucket, metadata, segments, emails, force)
- [x] `uv run hcli asset delete --help` — shows bucket / yes options
- [x] `uvx ruff check` on changed files — passes
- [x] `uvx mypy` on changed files — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)