### PR TITLE
fix(asset): strip leading slash from asset key in API paths

### DIFF
--- a/src/hcli/lib/api/asset.py
+++ b/src/hcli/lib/api/asset.py
@@ -98,6 +98,13 @@ class UploadResponse(BaseModel):
 class AssetAPI:
     """File sharing API client."""
 
+    @staticmethod
+    def _asset_path(bucket: str, key: str) -> str:
+        # Strip leading slashes from the key so a key copied verbatim from CLI
+        # output (which prints it as "/eap/...") doesn't produce a double slash
+        # ("/api/assets/installers//eap/..."), which the backend fails to match.
+        return f"/api/assets/{bucket}/{key.lstrip('/')}"
+
     async def upload_asset(
         self,
         bucket: str,
@@ -155,7 +162,7 @@ class AssetAPI:
             # Upload the file (without content parameter to use streaming)
             await client.put_file(upload_url, file_path_obj)
             # Confirm upload
-            response = await client.post_json(f"/api/assets/{bucket}/{key}", {})
+            response = await client.post_json(self._asset_path(bucket, key), {})
 
         return UploadResponse(
             bucket=bucket,
@@ -169,7 +176,7 @@ class AssetAPI:
     async def delete_file_by_key(self, bucket: str, key: str) -> None:
         """Delete a file."""
         client = await get_api_client()
-        await client.delete_json(f"/api/assets/{bucket}/{key}")
+        await client.delete_json(self._asset_path(bucket, key))
 
     async def get_shared_file_by_code(self, code: str, version: int = -1) -> Asset | None:
         """Get information about a file."""
@@ -193,7 +200,7 @@ class AssetAPI:
 
     async def get_file(self, bucket: str, key: str) -> Asset | None:
         client = await get_api_client()
-        data = await client.get_json(f"/api/assets/{bucket}/{key}")
+        data = await client.get_json(self._asset_path(bucket, key))
         return Asset(**data)
 
     async def get_files_tree(self, bucket: str, filter_params: PagingFilter | None = None) -> list[TreeNode]:


### PR DESCRIPTION
## Problem

A key copied verbatim from CLI output is printed with a leading slash (e.g. `Key: /eap/ida-teams-vault2git/1.0.2/vault2git-linux-amd64`). Pasting it back into `hcli asset delete <key> -b installers` builds the request URL by concatenating it after the bucket:

```
/api/assets/installers//eap/ida-teams-vault2git/1.0.2/vault2git-linux-amd64
                      ^^ double slash
```

The backend then captures the key **with** a leading slash, which never matches a stored key (stored keys carry no leading slash). The lookup silently misses, so the operation no-ops — and `delete` still returns `200`, printing "✓ Asset deleted successfully!" while the asset is untouched.

## Fix

Route the three key-bearing asset API paths (`delete_file_by_key`, `get_file`, and the upload-confirm in `upload_asset`) through a shared `_asset_path()` helper that strips leading slashes from the key.

A matching defense-in-depth fix landed on the backend (ea-public-api `normalizeKeyParam`), but fixing it client-side too means a pasted key Just Works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)