### PR TITLE
Fix KE "open in IDA" deep links failing to navigate on IDA 9.4

### DIFF
--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -1,17 +1,27 @@
-"""Handler for KE URLs — download assets from KE servers, cache locally, and launch IDA.
+"""Handler for KE "open in IDA" deep links — download the asset, cache it, launch IDA, navigate.
 
-Matches URLs containing ``/api/v1/buckets/`` in the path.
-Example: ``ida://ke.example.com:8080/api/v1/buckets/mybucket/assets/mykey``
+KE emits IDA-native navigation links that carry the asset's download location as a
+``url=`` query parameter::
+
+    ida://ke/<idb>/<resource>?ea=0x<HEX>&view=<view>&url=<percent-encoded asset URL>
+
+This handler matches on the presence of ``url=`` — plain navigation links without it
+fall through to the default handler. It downloads the IDB from ``url=`` (and the
+``.ke.json`` metadata sidecar from the same base), then relays the link, minus
+``url=``, to IDA for navigation. The scheme (http/https) comes from ``url=`` as KE
+emits it, so it matches however KE is served — this handler does no scheme probing.
+See the KE ``docs/deep-links.md``.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import platform
 import subprocess
 import time
 from pathlib import Path
-from urllib.parse import ParseResult, unquote
+from urllib.parse import ParseResult, parse_qsl, unquote, urlparse, urlunparse
 
 import httpx
 import rich_click as click
@@ -27,14 +37,16 @@ console = Console()
 
 
 class KEURLHandler(URLHandler):
-    """Handler for KE URLs: ``ida://host/api/v1/buckets/{bucket}/assets/{key}``.
+    """Handler for KE deep links: ``ida://ke/<idb>/<resource>?…&url=<asset URL>``.
 
-    Downloads the asset from a KE server (with HTTPS/HTTP fallback),
-    caches it locally, then finds or launches an IDA instance.
+    Downloads the asset from the ``url=`` location, caches it locally, then finds
+    or launches an IDA instance and relays the link (minus ``url=``) for navigation.
     """
 
     def matches(self, parsed: ParseResult) -> bool:
-        return "/api/v1/buckets/" in parsed.path
+        # KE deep links carry the asset download location as a ``url=`` parameter.
+        # Plain navigation links (rva/ea/name/view only) fall through to DefaultURLHandler.
+        return "url" in dict(parse_qsl(parsed.query, keep_blank_values=True))
 
     def handle(
         self,
@@ -44,34 +56,35 @@ class KEURLHandler(URLHandler):
         timeout: float,
         skip_analysis: bool,
     ) -> None:
-        if not parsed.netloc:
-            console.print("[red]Error: No host in KE URL[/red]")
+        params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+        asset_url = params.get("url", "")
+        if not asset_url:
+            console.print("[red]Error: KE URL is missing the 'url' download parameter[/red]")
             raise click.Abort()
 
-        bucket, key = _parse_asset_path(parsed.path)
-        base_url = _resolve_base_url(parsed.netloc)
-
-        asset_url = f"{base_url}{parsed.path}"
-        download_url = f"{asset_url}/download"
+        idb_name = _idb_name_from_path(parsed.path)
+        if not idb_name:
+            console.print("[red]Error: KE URL has no <idb> path segment[/red]")
+            raise click.Abort()
 
         # Cleanup old downloads (best-effort)
         _cleanup_old_downloads()
 
-        # Setup cache path
+        # Cache under a hash of the asset URL so two assets that share a basename
+        # (e.g. both "chall.i64") don't collide in the downloads dir.
         downloads_dir = Path(ENV.HCLI_KE_DOWNLOADS_DIR or _default_downloads_dir())
-        resource_path = downloads_dir / bucket / key
+        resource_path = downloads_dir / _ns(asset_url) / idb_name
         sidecar_path = resource_path.parent / f"{resource_path.name}.ke.json"
         resource_path.parent.mkdir(parents=True, exist_ok=True)
 
-        console.print(f"[blue]Downloading {key} from KE...[/blue]")
+        console.print(f"[blue]Downloading {idb_name} from KE...[/blue]")
 
-        filename = Path(key).name
-        dialog = _show_download_dialog(filename)
+        dialog = _show_download_dialog(idb_name)
 
         try:
             with httpx.Client(timeout=300.0) as client:
                 _download_metadata(client, asset_url, sidecar_path)
-                _download_file(client, download_url, resource_path)
+                _download_file(client, f"{asset_url}/download", resource_path)
         except click.ClickException:
             _dismiss_dialog(dialog)
             _show_error_dialog("Download failed")
@@ -89,15 +102,16 @@ class KEURLHandler(URLHandler):
             console.print(f"[green]Downloaded file: {resource_path}[/green]")
             return
 
-        # Launch IDA (or reuse a running instance) and navigate
+        # Relay the link to IDA for navigation, minus the url= download annotation
+        # (IDA ignores url= anyway; we drop it for hygiene).
         resolve_and_navigate(
-            uri=uri,
+            uri=_strip_query_param(uri, "url"),
             target_idb_name=resource_path.name,
             idb_path=resource_path,
             no_launch=False,
             timeout=timeout,
             skip_analysis=skip_analysis,
-            navigate=bool(parsed.query),
+            navigate=_has_nav_params(parsed.query),
             on_error=_show_error_dialog,
         )
 
@@ -111,39 +125,31 @@ def _default_downloads_dir() -> str:
     return str(Path.home() / ".ke" / "downloads")
 
 
-def _parse_asset_path(path: str) -> tuple[str, str]:
-    """Extract bucket and key from ``/api/v1/buckets/{bucket}/assets/{key}``."""
-    parts = path.split("/")
-
-    try:
-        buckets_idx = parts.index("buckets")
-        assets_idx = parts.index("assets")
-    except ValueError:
-        console.print("[red]Error: URL path must contain /buckets/{bucket}/assets/{key}[/red]")
-        raise click.Abort()
-
-    bucket = parts[buckets_idx + 1] if buckets_idx + 1 < len(parts) else ""
-    key = "/".join(parts[assets_idx + 1 :]) if assets_idx + 1 < len(parts) else ""
-    key = unquote(key)
-
-    if not bucket or not key:
-        console.print("[red]Error: Could not extract bucket or key from URL[/red]")
-        raise click.Abort()
-
-    return bucket, key
+def _idb_name_from_path(path: str) -> str:
+    """Return the ``<idb>`` segment (the first path segment) of an
+    ``ida://ke/<idb>/<resource>`` link — the IDB filename IDA reports."""
+    segments = [seg for seg in path.split("/") if seg]
+    return unquote(segments[0]) if segments else ""
 
 
-def _resolve_base_url(netloc: str) -> str:
-    """Try HTTPS first (3 s timeout), fall back to HTTP."""
-    https_url = f"https://{netloc}"
-    try:
-        with httpx.Client(timeout=3.0) as client:
-            client.head(https_url)
-        _print("[dim]Using HTTPS[/dim]")
-        return https_url
-    except (httpx.RequestError, httpx.TimeoutException):
-        _print("[dim]HTTPS unavailable, using HTTP[/dim]")
-        return f"http://{netloc}"
+def _ns(url: str) -> str:
+    """Short stable hash of the asset URL, used to namespace local downloads."""
+    return hashlib.sha256(url.encode()).hexdigest()[:16]
+
+
+_NAV_PARAMS = frozenset({"ea", "rva", "name", "view"})
+
+
+def _has_nav_params(query: str) -> bool:
+    """True if the link carries any IDA navigation parameter (else it is open-only)."""
+    return any(key in _NAV_PARAMS for key, _ in parse_qsl(query, keep_blank_values=True))
+
+
+def _strip_query_param(uri: str, param: str) -> str:
+    """Return *uri* with the given query parameter removed, preserving the rest verbatim."""
+    parsed = urlparse(uri)
+    kept = [kv for kv in parsed.query.split("&") if kv and kv.split("=", 1)[0] != param]
+    return urlunparse(parsed._replace(query="&".join(kept)))
 
 
 def _download_metadata(client: httpx.Client, asset_url: str, sidecar_path: Path) -> None:

--- a/src/hcli/lib/ida/protocol.py
+++ b/src/hcli/lib/ida/protocol.py
@@ -4,6 +4,7 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -19,12 +20,17 @@ def setup_macos_protocol_handler() -> None:
         hcli_path = get_hcli_executable_path()
 
         # Create AppleScript application that handles ida:// URLs
-        # Use login shell (-l) to get full user environment, avoiding sandbox restrictions
+        # Use login shell (-l) to get full user environment, avoiding sandbox restrictions.
+        # Strip PYTHON* vars first: the requesting app (e.g. IDA running its own
+        # Python 3.13) leaks PYTHONHOME into the handler's environment, which makes
+        # hcli's pinned interpreter load the wrong stdlib and abort ("No module named
+        # 'encodings'") before it runs. env -u clears them so hcli uses its own Python.
         log_file = "/tmp/idb_handler.log"
+        py_env_strip = "env -u PYTHONHOME -u PYTHONPATH -u PYTHONEXECUTABLE -u PYTHONSTARTUP"
         applescript_content = f'''
 on open location this_URL
     set logFile to "{log_file}"
-    do shell script "/bin/zsh -l -c " & quoted form of ("{hcli_path} ida open " & quoted form of this_URL) & " >> " & quoted form of logFile & " 2>&1"
+    do shell script "/bin/zsh -l -c " & quoted form of ("{py_env_strip} {hcli_path} ida open " & quoted form of this_URL) & " >> " & quoted form of logFile & " 2>&1"
 end open location
 
 on run
@@ -117,8 +123,18 @@ def setup_windows_protocol_handler() -> None:
 
         hcli_path = get_hcli_executable_path()
 
-        # Register ida:// protocol
-        command = f'"{hcli_path}" ida open "%1"'
+        # Register ida:// protocol.
+        # A PYTHONHOME/PYTHONPATH leaked by the launching app (e.g. IDA running its own
+        # Python) would point a non-frozen hcli's interpreter at the wrong stdlib and
+        # abort it before it runs. Neutralize it WITHOUT cmd.exe: routing the
+        # percent-encoded URL through `cmd /c` corrupts its %XX escapes, and there is no
+        # `env -u` on Windows. ShellExecute/CreateProcess passes argv verbatim, so invoke
+        # the interpreter directly with -E (ignore all PYTHON* env vars). Frozen builds
+        # embed their own runtime and are immune, so run them as-is.
+        if getattr(sys, "frozen", False):
+            command = f'"{hcli_path}" ida open "%1"'
+        else:
+            command = f'"{sys.executable}" -E -m hcli.main ida open "%1"'
         reg_key = rf"SOFTWARE\Classes\{PROTOCOL}"
 
         with winreg.CreateKey(HKEY_CURRENT_USER, reg_key) as key:  # type: ignore[attr-defined]
@@ -156,10 +172,15 @@ def setup_linux_protocol_handler() -> None:
         applications_dir = Path.home() / ".local" / "share" / "applications"
         applications_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create desktop entry for ida:// protocol
+        # Create desktop entry for ida:// protocol.
+        # Strip PYTHON* first (via env -u): the launching app (e.g. IDA running its own
+        # Python) can leak PYTHONHOME into the handler's environment, which makes hcli's
+        # interpreter load the wrong stdlib and abort before it runs. The desktop
+        # launcher passes %u as a literal argv, so no shell mangles the URL here.
+        py_env_strip = "env -u PYTHONHOME -u PYTHONPATH -u PYTHONEXECUTABLE -u PYTHONSTARTUP"
         desktop_content = f"""[Desktop Entry]
 Name=HCLI IDB Link Handler
-Exec={hcli_path} ida open %u
+Exec={py_env_strip} {hcli_path} ida open %u
 Type=Application
 NoDisplay=true
 MimeType=x-scheme-handler/{PROTOCOL};

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -1,9 +1,9 @@
-"""Tests for KE URL handling in ida:// protocol."""
+"""Tests for KE deep-link handling in the ida:// protocol."""
 
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import click
 import pytest
@@ -12,87 +12,87 @@ from hcli.lib.ida.handler.ke_url_handler import (
     KEURLHandler,
     _cleanup_old_downloads,
     _default_downloads_dir,
-    _parse_asset_path,
-    _resolve_base_url,
+    _has_nav_params,
+    _idb_name_from_path,
+    _ns,
+    _strip_query_param,
 )
 
+# A representative KE asset base — what KE percent-encodes into the ``url=`` parameter.
+ASSET_URL = "http://host:8080/api/v1/buckets/mybucket/assets/test.i64"
 
-class TestIsKeUrl:
-    def test_ke_url_detected(self):
-        parsed = urlparse("ida://host:8080/api/v1/buckets/mybucket/assets/mykey")
+
+def _ke_link(idb: str, resource: str, asset_url: str, *, nav: str = "") -> str:
+    """Build a KE deep link the way KE emits it (asset URL percent-encoded into url=)."""
+    query = (f"{nav}&" if nav else "") + f"url={quote(asset_url, safe='')}"
+    return f"ida://ke/{idb}/{resource}?{query}"
+
+
+class TestMatches:
+    def test_ke_link_with_url_param_detected(self):
+        parsed = urlparse(_ke_link("test.i64", "functions", ASSET_URL, nav="ea=0x1000&view=pseudocode"))
         assert KEURLHandler().matches(parsed) is True
 
-    def test_regular_ida_url_not_detected(self):
+    def test_open_only_link_detected(self):
+        parsed = urlparse(_ke_link("test.i64", "addresses", ASSET_URL))
+        assert KEURLHandler().matches(parsed) is True
+
+    def test_plain_navigation_link_not_detected(self):
+        # No url= param → handled by DefaultURLHandler, not KE.
         parsed = urlparse("ida://malwares/trojan.i64/functions?rva=0x1000")
         assert KEURLHandler().matches(parsed) is False
 
-    def test_relative_ida_url_not_detected(self):
-        parsed = urlparse("ida:///myfile.i64/functions?rva=0x1000")
+    def test_obsolete_locator_not_detected(self):
+        # The old download-locator form carried no url= param — it no longer matches.
+        parsed = urlparse("ida://host:8080/api/v1/buckets/mybucket/assets/test.i64")
         assert KEURLHandler().matches(parsed) is False
 
-    def test_ke_url_with_nested_key(self):
-        parsed = urlparse("ida://host/api/v1/buckets/b/assets/path/to/file.idb")
-        assert KEURLHandler().matches(parsed) is True
+
+class TestIdbNameFromPath:
+    def test_first_segment_is_the_idb(self):
+        assert _idb_name_from_path("/test.i64/functions") == "test.i64"
+
+    def test_open_only_path(self):
+        assert _idb_name_from_path("/chall.i64/addresses") == "chall.i64"
+
+    def test_percent_encoded_name_decoded(self):
+        assert _idb_name_from_path("/my%20file.i64/functions") == "my file.i64"
 
     def test_empty_path(self):
-        parsed = urlparse("ida://host")
-        assert KEURLHandler().matches(parsed) is False
+        assert _idb_name_from_path("") == ""
 
 
-class TestParseAssetPath:
-    def test_basic_path(self):
-        bucket, key = _parse_asset_path("/api/v1/buckets/mybucket/assets/mykey")
-        assert bucket == "mybucket"
-        assert key == "mykey"
+class TestNs:
+    def test_stable_and_short(self):
+        assert _ns(ASSET_URL) == _ns(ASSET_URL)
+        assert len(_ns(ASSET_URL)) == 16
 
-    def test_nested_key(self):
-        bucket, key = _parse_asset_path("/api/v1/buckets/mybucket/assets/path/to/file.idb")
-        assert bucket == "mybucket"
-        assert key == "path/to/file.idb"
-
-    def test_url_encoded_key(self):
-        bucket, key = _parse_asset_path("/api/v1/buckets/mybucket/assets/my%20file.idb")
-        assert bucket == "mybucket"
-        assert key == "my file.idb"
-
-    def test_missing_buckets_raises(self):
-        with pytest.raises(click.Abort):
-            _parse_asset_path("/api/v1/something/mybucket/assets/mykey")
-
-    def test_missing_assets_raises(self):
-        with pytest.raises(click.Abort):
-            _parse_asset_path("/api/v1/buckets/mybucket/something/mykey")
-
-    def test_empty_bucket_raises(self):
-        with pytest.raises(click.Abort):
-            _parse_asset_path("/api/v1/buckets//assets/mykey")
-
-    def test_empty_key_raises(self):
-        with pytest.raises(click.Abort):
-            _parse_asset_path("/api/v1/buckets/mybucket/assets/")
+    def test_differs_per_url(self):
+        assert _ns(ASSET_URL) != _ns(ASSET_URL + "x")
 
 
-class TestResolveBaseUrl:
-    @patch("hcli.lib.ida.handler.ke_url_handler.httpx.Client")
-    def test_https_available(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+class TestHasNavParams:
+    def test_ea_is_navigation(self):
+        assert _has_nav_params("ea=0x1000&url=x") is True
 
-        result = _resolve_base_url("example.com:8080")
-        assert result == "https://example.com:8080"
+    def test_view_is_navigation(self):
+        assert _has_nav_params("view=pseudocode&url=x") is True
 
-    @patch("hcli.lib.ida.handler.ke_url_handler.httpx.Client")
-    def test_https_unavailable_falls_back_to_http(self, mock_client_cls):
-        import httpx
+    def test_url_only_is_open_only(self):
+        assert _has_nav_params("url=x") is False
 
-        mock_client = MagicMock()
-        mock_client.head.side_effect = httpx.ConnectError("Connection refused")
-        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+    def test_empty_query(self):
+        assert _has_nav_params("") is False
 
-        result = _resolve_base_url("example.com:8080")
-        assert result == "http://example.com:8080"
+
+class TestStripQueryParam:
+    def test_drops_url_keeps_the_rest(self):
+        uri = "ida://ke/test.i64/functions?ea=0x1000&view=pseudocode&url=" + quote(ASSET_URL, safe="")
+        assert _strip_query_param(uri, "url") == "ida://ke/test.i64/functions?ea=0x1000&view=pseudocode"
+
+    def test_drops_only_url_when_open_only(self):
+        uri = "ida://ke/test.i64/addresses?url=" + quote(ASSET_URL, safe="")
+        assert _strip_query_param(uri, "url") == "ida://ke/test.i64/addresses"
 
 
 class TestDefaultDownloadsDir:
@@ -135,10 +135,9 @@ class TestHandleKeUrl:
     @patch("hcli.lib.ida.handler.ke_url_handler._show_download_dialog", return_value=None)
     @patch("hcli.lib.ida.handler.ke_url_handler._dismiss_dialog")
     @patch("hcli.lib.ida.handler.ke_url_handler._cleanup_old_downloads")
-    @patch("hcli.lib.ida.handler.ke_url_handler._resolve_base_url", return_value="https://host:8080")
     @patch("hcli.lib.ida.handler.ke_url_handler.httpx.Client")
-    def test_no_launch_downloads_only(
-        self, mock_client_cls, mock_resolve, mock_cleanup, mock_dismiss, mock_dialog, tmp_path
+    def test_no_launch_downloads_to_hashed_dir(
+        self, mock_client_cls, mock_cleanup, mock_dismiss, mock_dialog, tmp_path
     ):
         mock_client = MagicMock()
         mock_response = MagicMock()
@@ -148,7 +147,7 @@ class TestHandleKeUrl:
         mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
-        uri = "ida://host:8080/api/v1/buckets/mybucket/assets/test.idb"
+        uri = _ke_link("test.i64", "addresses", ASSET_URL)
         parsed = urlparse(uri)
 
         with (
@@ -159,30 +158,28 @@ class TestHandleKeUrl:
             mock_env.HCLI_KE_DOWNLOADS_RETENTION_DAYS = 3
             KEURLHandler().handle(uri, parsed, no_launch=True, timeout=120.0, skip_analysis=False)
 
-        # File should be downloaded
-        downloaded = tmp_path / "mybucket" / "test.idb"
+        # File and its .ke.json sidecar land under the url-hash namespace dir.
+        downloaded = tmp_path / _ns(ASSET_URL) / "test.i64"
         assert downloaded.exists()
         assert downloaded.read_bytes() == b"file content"
+        assert (tmp_path / _ns(ASSET_URL) / "test.i64.ke.json").exists()
 
     @patch("hcli.lib.ida.handler.ke_url_handler._show_download_dialog", return_value=None)
     @patch("hcli.lib.ida.handler.ke_url_handler._dismiss_dialog")
     @patch("hcli.lib.ida.handler.ke_url_handler._cleanup_old_downloads")
-    @patch("hcli.lib.ida.handler.ke_url_handler._resolve_base_url", return_value="https://host:8080")
     @patch("hcli.lib.ida.handler.ke_url_handler.httpx.Client")
     @patch("hcli.lib.ida.resolve.IDAIPCClient")
-    def test_reuses_running_instance(
-        self, mock_ipc, mock_client_cls, mock_resolve, mock_cleanup, mock_dismiss, mock_dialog, tmp_path
+    def test_relays_navigation_link_without_url_param(
+        self, mock_ipc, mock_client_cls, mock_cleanup, mock_dismiss, mock_dialog, tmp_path
     ):
-        """KE should reuse an already-open IDA instance instead of launching a new one."""
+        """The link relayed to IDA must be the url=-stripped nav URI (the IDA 9.4 fix)."""
         from hcli.lib.ida.ipc import IDAInstance
 
-        # Setup: a running IDA instance already has test.idb open
-        running_instance = IDAInstance(pid=1234, socket_path="/tmp/ida_ipc_1234", idb_name="test.idb", has_idb=True)
+        running_instance = IDAInstance(pid=1234, socket_path="/tmp/ida_ipc_1234", idb_name="test.i64", has_idb=True)
         mock_ipc.discover_instances.return_value = [running_instance]
         mock_ipc.query_instance.return_value = running_instance
         mock_ipc.send_open_ida_link.return_value = (True, "OK")
 
-        # Setup: HTTP download mock
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -191,7 +188,7 @@ class TestHandleKeUrl:
         mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
-        uri = "ida://host:8080/api/v1/buckets/mybucket/assets/test.idb?rva=0x1000"
+        uri = _ke_link("test.i64", "functions", ASSET_URL, nav="ea=0x1000&view=pseudocode")
         parsed = urlparse(uri)
 
         with (
@@ -203,11 +200,13 @@ class TestHandleKeUrl:
             mock_env.HCLI_KE_DOWNLOADS_RETENTION_DAYS = 3
             KEURLHandler().handle(uri, parsed, no_launch=False, timeout=120.0, skip_analysis=False)
 
-        # Should navigate to the running instance, NOT launch a new one
-        mock_ipc.send_open_ida_link.assert_called_once_with("/tmp/ida_ipc_1234", uri)
+        # Reuse the running instance and forward the nav link WITHOUT url=.
+        mock_ipc.send_open_ida_link.assert_called_once_with(
+            "/tmp/ida_ipc_1234", "ida://ke/test.i64/functions?ea=0x1000&view=pseudocode"
+        )
 
-    def test_no_host_aborts(self):
-        parsed = urlparse("ida:///api/v1/buckets/b/assets/k")
-        # parsed.netloc is empty for triple-slash
+    def test_missing_url_param_aborts(self):
+        uri = "ida://ke/test.i64/functions?ea=0x1000"
+        parsed = urlparse(uri)
         with pytest.raises(click.Abort):
-            KEURLHandler().handle("ida:///api/v1/buckets/b/assets/k", parsed, False, 120.0, False)
+            KEURLHandler().handle(uri, parsed, False, 120.0, False)


### PR DESCRIPTION
## Problem

KE "open in IDA" links open the IDB but fail to navigate on IDA 9.4 with `When source is specified, path must have exactly 2 segments (/<idb>/<resource>), got 6`. hcli forwarded the raw download locator (`ida://host/api/v1/buckets/.../assets/...`), which is not valid IDA navigation grammar.

## Fix

KE now emits IDA-native navigation links that carry the asset download location as a `url=` parameter:

```
ida://ke/<idb>/<resource>?ea=0x<HEX>&view=<view>&url=<percent-encoded asset URL>
```

This PR is the **hcli** side:

- `matches()` keys off the `url=` param; plain navigation links (no `url=`) fall through to the default handler.
- Downloads the IDB and its `.ke.json` sidecar from `url=`, **preserving its http/https scheme** — the old HTTPS→HTTP probe is removed, so there is no more scheme guessing.
- Relays the link to IDA **minus `url=`**, which is valid 2-segment grammar; navigates only when `ea`/`rva`/`name`/`view` is present (open-only links just open the IDB).
- Caches each download under a hash of the asset URL, so two assets that share a basename don't collide.

## Testing

`tests/lib/test_ke.py` rewritten: `matches` / idb-from-path / strip-param / has-nav unit tests, plus the relay test now asserts the `url=`-stripped nav URI (the bug it previously locked in). Full suite green; `ruff` + `mypy` clean. Verified end-to-end against the real plugin builder: emitted link → hcli consume → 2-segment IDA grammar, scheme preserved.

## Rollout

Part of a coordinated 3-repo change (ship this one first):
- **HexRaysSA/ida-hcli** (this PR)
- **HexRaysSA/ke** — ke-web link builder + `docs/deep-links.md`
- **HexRaysSA/kec-ida-plugin** — IDA plugin link builder


---

## Follow-up: handler crashed on IDA 9.4's Python (PYTHONHOME leak)

After the grammar fix above, "Open in IDA" still did **nothing** when clicked from inside IDA 9.4 — no download, no launch, no error. Root cause is environmental, not in the link or the handler logic:

IDA 9.4 runs **Python 3.13** (the `.idapro` venv) and exports `PYTHONHOME=…/3.13` into its process environment. `QDesktopServices.openUrl("ida://…")` routes to the OS URL handler, which inherits that `PYTHONHOME` and runs `hcli`. When `hcli` is a **3.12** install, its pinned interpreter then loads 3.13's stdlib and aborts during bootstrap (`Fatal Python error: … No module named 'encodings'`) **before any hcli code runs**. Confirmed via `/tmp/idb_handler.log` and reproduced deterministically; running `hcli ida open <url>` from a clean shell downloads + opens IDA correctly.

This commit strips the leaked `PYTHON*` vars in the handler before invoking hcli:

- **macOS applet / Linux `.desktop`:** prefix with `env -u PYTHONHOME -u PYTHONPATH -u PYTHONEXECUTABLE -u PYTHONSTARTUP`.
- **Windows registry:** invoke the interpreter directly with `-E` (ignore all `PYTHON*` vars). `cmd /c` would corrupt the percent-encoded URL and there is no `env -u`; `CreateProcess` passes argv verbatim. Frozen builds embed their own runtime and are immune, so they run as-is.

These are external override variables that no correctly-installed hcli depends on (venv / framework / conda / pipx / `pip --user` / frozen all self-locate from the interpreter path), so stripping them can't break a working install — only prevent the crash. Requires re-registering (`hcli ida protocol register --force`) to regenerate the handler.

**Verified:** macOS reproduced + fixed end-to-end. **Linux/Windows changes are by analogy and not yet exercised on those platforms.** The fully robust mitigation (tracked separately) is to ship hcli as a frozen PyInstaller binary, which is immune to this class of env leak by construction.
