### PR TITLE
fix: add hcli/__main__.py so `python -m hcli` works

### DIFF
--- a/src/hcli/__main__.py
+++ b/src/hcli/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point for ``python -m hcli``.
+
+Lets the CLI be launched via the package name (the conventional, discoverable
+form) in addition to the ``hcli`` console script — e.g. when only an interpreter
+path is known. ``get_hcli_executable_path`` relies on this for its fallback.
+"""
+
+from hcli.main import cli
+
+if __name__ == "__main__":
+    cli()

--- a/tests/lib/test_main_module.py
+++ b/tests/lib/test_main_module.py
@@ -1,0 +1,15 @@
+"""`python -m hcli` must launch the CLI (regression guard for the missing __main__)."""
+
+import subprocess
+import sys
+
+
+def test_python_m_hcli_runs_cli():
+    result = subprocess.run(
+        [sys.executable, "-m", "hcli", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "version" in (result.stdout + result.stderr).lower()


### PR DESCRIPTION
## Problem

`hcli` ships no `__main__.py`, so `python -m hcli` fails:

```
No module named hcli.__main__; 'hcli' is a package and cannot be directly executed
```

`get_hcli_executable_path()` (`src/hcli/lib/util/io.py`) uses `"<python>" -m hcli` as its last-resort fallback (when hcli isn't on `PATH` and `uv` isn't available). On such a system the protocol handler / launcher would be handed a command that can't actually run.

## Fix

Add `src/hcli/__main__.py` delegating to `hcli.main:cli`, making `python -m hcli` the conventional, working entrypoint (and fixing the fallback).

```python
from hcli.main import cli

if __name__ == "__main__":
    cli()
```

## Testing

- `tests/lib/test_main_module.py`: asserts `python -m hcli --version` exits 0.
- `uv run python -m hcli --version` → `python -m hcli, version 0.18.2`.
- `ruff check` / `ruff format --check` clean.