### PR TITLE
Harden ida:// KE deep-link handler (RCE, path traversal, SSRF, drive-by)

### DIFF
--- a/src/hcli/env.py
+++ b/src/hcli/env.py
@@ -45,6 +45,10 @@ class ENV:
     # KE download settings
     HCLI_KE_DOWNLOADS_DIR: str | None = os.getenv("HCLI_KE_DOWNLOADS_DIR")
     HCLI_KE_DOWNLOADS_RETENTION_DAYS: int = int(os.getenv("HCLI_KE_DOWNLOADS_RETENTION_DAYS", "3"))
+    # Allow KE deep links to download from private/loopback/link-local hosts. Off by
+    # default so a clicked ida:// link cannot make hcli reach internal services; set
+    # to 1/true/yes for self-hosted KE deployments on an internal network.
+    HCLI_KE_ALLOW_PRIVATE_HOSTS: bool = os.getenv("HCLI_KE_ALLOW_PRIVATE_HOSTS", "").lower() in ("1", "true", "yes")
 
 
 # Constants

--- a/src/hcli/env.py
+++ b/src/hcli/env.py
@@ -3,11 +3,19 @@ import os
 from . import __version__
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Parse a boolean environment variable using one consistent truthy set."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("true", "yes", "on", "1")
+
+
 class ENV:
     """Environment configuration mirroring the Deno version."""
 
     HCLI_API_KEY: str | None = os.getenv("HCLI_API_KEY")
-    HCLI_DEBUG: bool = os.getenv("HCLI_DEBUG", "").lower() in ("true", "yes", "on", "1")
+    HCLI_DEBUG: bool = _env_bool("HCLI_DEBUG")
     HCLI_API_URL: str = os.getenv("HCLI_API_URL", "https://api.eu.hex-rays.com")
     HCLI_CLOUD_URL: str = os.getenv("HCLI_CLOUD_URL", "https://api.hcli.run")
     HCLI_PORTAL_URL: str = os.getenv("HCLI_PORTAL_URL", "https://my.hex-rays.com")
@@ -30,7 +38,7 @@ class ENV:
     HCLI_MODE: str = os.getenv("HCLI_MODE", "user")
     QUIET: bool = False
 
-    HCLI_DISABLE_UPDATES: bool = os.getenv("HCLI_DISABLE_UPDATES", "").lower() in ("true", "yes", "on", "1")
+    HCLI_DISABLE_UPDATES: bool = _env_bool("HCLI_DISABLE_UPDATES")
 
     IDAUSR: str | None = os.getenv("IDAUSR")
     IDADIR: str | None = os.getenv("IDADIR")
@@ -47,8 +55,8 @@ class ENV:
     HCLI_KE_DOWNLOADS_RETENTION_DAYS: int = int(os.getenv("HCLI_KE_DOWNLOADS_RETENTION_DAYS", "3"))
     # Allow KE deep links to download from private/loopback/link-local hosts. Off by
     # default so a clicked ida:// link cannot make hcli reach internal services; set
-    # to 1/true/yes for self-hosted KE deployments on an internal network.
-    HCLI_KE_ALLOW_PRIVATE_HOSTS: bool = os.getenv("HCLI_KE_ALLOW_PRIVATE_HOSTS", "").lower() in ("1", "true", "yes")
+    # to true/yes/on/1 for self-hosted KE deployments on an internal network.
+    HCLI_KE_ALLOW_PRIVATE_HOSTS: bool = _env_bool("HCLI_KE_ALLOW_PRIVATE_HOSTS")
 
 
 # Constants

--- a/src/hcli/env.py
+++ b/src/hcli/env.py
@@ -11,6 +11,21 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return raw.strip().lower() in ("true", "yes", "on", "1")
 
 
+def _env_int(name: str, default: int) -> int:
+    """Parse an integer environment variable, falling back to *default* on a bad value.
+
+    Parsed at class-body eval and imported by the CLI entrypoint, so a malformed
+    value must not raise — that would brick every command, not just the feature.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        return default
+
+
 class ENV:
     """Environment configuration mirroring the Deno version."""
 
@@ -52,7 +67,7 @@ class ENV:
 
     # KE download settings
     HCLI_KE_DOWNLOADS_DIR: str | None = os.getenv("HCLI_KE_DOWNLOADS_DIR")
-    HCLI_KE_DOWNLOADS_RETENTION_DAYS: int = int(os.getenv("HCLI_KE_DOWNLOADS_RETENTION_DAYS", "3"))
+    HCLI_KE_DOWNLOADS_RETENTION_DAYS: int = _env_int("HCLI_KE_DOWNLOADS_RETENTION_DAYS", 3)
     # Allow KE deep links to download from private/loopback/link-local hosts. Off by
     # default so a clicked ida:// link cannot make hcli reach internal services; set
     # to true/yes/on/1 for self-hosted KE deployments on an internal network.
@@ -63,7 +78,7 @@ class ENV:
     HCLI_KE_SKIP_CONFIRM: bool = _env_bool("HCLI_KE_SKIP_CONFIRM")
     # Optional cap (in MB) on a single KE asset download; 0 means no limit. Downloads
     # always stream to disk regardless, so this only bounds total bytes written.
-    HCLI_KE_MAX_DOWNLOAD_MB: int = int(os.getenv("HCLI_KE_MAX_DOWNLOAD_MB", "0"))
+    HCLI_KE_MAX_DOWNLOAD_MB: int = _env_int("HCLI_KE_MAX_DOWNLOAD_MB", 0)
 
 
 # Constants

--- a/src/hcli/env.py
+++ b/src/hcli/env.py
@@ -78,7 +78,9 @@ class ENV:
     HCLI_KE_SKIP_CONFIRM: bool = _env_bool("HCLI_KE_SKIP_CONFIRM")
     # Optional cap (in MB) on a single KE asset download; 0 means no limit. Downloads
     # always stream to disk regardless, so this only bounds total bytes written.
-    HCLI_KE_MAX_DOWNLOAD_MB: int = _env_int("HCLI_KE_MAX_DOWNLOAD_MB", 0)
+    # Clamp negatives to 0: a misconfigured "-1" must not silently disable the cap
+    # (the consumer's `> 0` test would otherwise read a negative value as "no limit").
+    HCLI_KE_MAX_DOWNLOAD_MB: int = max(0, _env_int("HCLI_KE_MAX_DOWNLOAD_MB", 0))
 
 
 # Constants

--- a/src/hcli/env.py
+++ b/src/hcli/env.py
@@ -57,6 +57,13 @@ class ENV:
     # default so a clicked ida:// link cannot make hcli reach internal services; set
     # to true/yes/on/1 for self-hosted KE deployments on an internal network.
     HCLI_KE_ALLOW_PRIVATE_HOSTS: bool = _env_bool("HCLI_KE_ALLOW_PRIVATE_HOSTS")
+    # Suppress the "open downloaded IDB in IDA?" confirmation prompt. The KE download
+    # path is reachable from any web page, so by default hcli asks before handing
+    # attacker-influenced content to IDA; set to true/yes/on/1 for one-click flows.
+    HCLI_KE_SKIP_CONFIRM: bool = _env_bool("HCLI_KE_SKIP_CONFIRM")
+    # Optional cap (in MB) on a single KE asset download; 0 means no limit. Downloads
+    # always stream to disk regardless, so this only bounds total bytes written.
+    HCLI_KE_MAX_DOWNLOAD_MB: int = int(os.getenv("HCLI_KE_MAX_DOWNLOAD_MB", "0"))
 
 
 # Constants

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -217,7 +217,16 @@ _CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
 
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """True for addresses an attacker-supplied download must never reach."""
-    if ip.version == 4 and ip in _CGNAT_NET:
+    if isinstance(ip, ipaddress.IPv6Address):
+        # IPv6 forms that embed an IPv4 address (e.g. "::ffff:127.0.0.1") are NOT
+        # flagged by is_private/is_loopback on Python <= 3.10 — the ::ffff:0:0/96
+        # range was only classified in 3.11 — yet the OS connects them to the
+        # embedded IPv4 (so ::ffff:127.0.0.1 reaches loopback). Recurse on the
+        # embedded address so the SSRF guard holds on every supported Python.
+        embedded = ip.ipv4_mapped or ip.sixtofour
+        if embedded is not None:
+            return _is_blocked_ip(embedded)
+    elif ip in _CGNAT_NET:
         return True
     return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
 

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -15,6 +15,7 @@ See the KE ``docs/deep-links.md``.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import ipaddress
 import json
@@ -355,46 +356,93 @@ def _pinned_attempts(pinned_ips: list[str] | None) -> list[str | None]:
     return list(pinned_ips) if pinned_ips else [None]
 
 
+# KE serves assets via a redirect (e.g. to object storage), so we must follow 3xx —
+# but httpx's own follow_redirects would connect straight to the Location host,
+# bypassing the SSRF pin. So we follow manually and re-validate/re-pin every hop.
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_MAX_REDIRECTS = 5
+
+
+def _connect_first_pinned(
+    client: httpx.Client, stack: contextlib.ExitStack, url: str, pinned_ips: list[str] | None
+) -> httpx.Response:
+    """Open a streaming GET, trying each validated IP in turn for failover.
+
+    The opened response is registered on *stack* so the caller controls when the
+    connection is released. Raises ClickException if no validated IP will connect.
+    """
+    attempts = _pinned_attempts(pinned_ips)
+    last_err: Exception | None = None
+    for pinned_ip in attempts:
+        req_url, kwargs = _pinned_request_args(url, pinned_ip)
+        try:
+            return stack.enter_context(client.stream("GET", req_url, **kwargs))
+        except _RETRYABLE_CONNECT as e:
+            last_err = e  # this IP wouldn't connect — try the next validated one
+    raise click.ClickException(f"Download failed: {last_err}")
+
+
+@contextlib.contextmanager
+def _open_validated_stream(client: httpx.Client, url: str, pinned_ips: list[str] | None):
+    """Stream a GET to *url*, following up to ``_MAX_REDIRECTS`` redirects safely.
+
+    Each redirect ``Location`` is resolved and re-checked through
+    :func:`_validate_asset_url` (SSRF guard + fresh IP pin) before the next hop, so a
+    3xx — from KE or anything in the chain — can never steer the fetch to a private,
+    loopback, or otherwise non-public address. Yields the final non-redirect response,
+    still open for streaming; the connection is released when the ``with`` block exits.
+    """
+    with contextlib.ExitStack() as stack:
+        for _hop in range(_MAX_REDIRECTS + 1):
+            response = _connect_first_pinned(client, stack, url, pinned_ips)
+            if response.status_code in _REDIRECT_STATUSES and "location" in response.headers:
+                target = str(httpx.URL(url).join(response.headers["location"]))
+                stack.close()  # release the redirect response before fetching the next hop
+                # Re-validate (and re-pin) the new target exactly like the original url=.
+                pinned_ips = _validate_asset_url(target)
+                url = target
+                continue
+            yield response
+            return
+        raise click.ClickException("Download failed: too many redirects")
+
+
 def _download_metadata(
     client: httpx.Client, asset_url: str, sidecar_path: Path, pinned_ips: list[str] | None = None
 ) -> None:
     """Download asset metadata and save as ``.ke.json`` sidecar (best-effort, bounded).
 
-    Tries each validated IP in turn when an IP won't accept a connection; any other
-    failure (non-200, read error, timeout) is reported as a warning — the sidecar is
-    optional, so a missing one never blocks the download.
+    Tries each validated IP in turn when an IP won't accept a connection and follows
+    redirects (re-validated per hop); any other failure (non-200, read error, timeout,
+    SSRF reject on a redirect) is reported as a warning — the sidecar is optional, so a
+    missing one never blocks the download.
     """
-    attempts = _pinned_attempts(pinned_ips)
-    for index, pinned_ip in enumerate(attempts):
-        url, kwargs = _pinned_request_args(asset_url, pinned_ip)
-        try:
-            with client.stream("GET", url, **kwargs) as response:
-                if response.status_code != 200:
-                    _print(f"[yellow]Warning: Metadata fetch failed (HTTP {response.status_code})[/yellow]")
-                    return
-                data = bytearray()
-                for chunk in response.iter_bytes():
-                    data += chunk
-                    if len(data) > _METADATA_MAX_BYTES:
-                        _print("[yellow]Warning: Metadata exceeded size limit; skipping sidecar[/yellow]")
-                        return
-                # The body is attacker-influenced; only persist it as the .ke.json
-                # sidecar if it's actually JSON, so the sidecar can't become an
-                # arbitrary-content write primitive.
-                try:
-                    json.loads(bytes(data))
-                except ValueError:
-                    _print("[yellow]Warning: Metadata is not valid JSON; skipping sidecar[/yellow]")
-                    return
-                sidecar_path.write_bytes(bytes(data))
+    try:
+        with _open_validated_stream(client, asset_url, pinned_ips) as response:
+            if response.status_code != 200:
+                _print(f"[yellow]Warning: Metadata fetch failed (HTTP {response.status_code})[/yellow]")
                 return
-        except _RETRYABLE_CONNECT as e:
-            if index < len(attempts) - 1:
-                continue  # this IP wouldn't connect — try the next validated one
-            _print(f"[yellow]Warning: Metadata fetch failed: {e}[/yellow]")
-        except (httpx.RequestError, httpx.TimeoutException) as e:
-            _print(f"[yellow]Warning: Metadata fetch failed: {e}[/yellow]")
-            return
+            data = bytearray()
+            for chunk in response.iter_bytes():
+                data += chunk
+                if len(data) > _METADATA_MAX_BYTES:
+                    _print("[yellow]Warning: Metadata exceeded size limit; skipping sidecar[/yellow]")
+                    return
+            # The body is attacker-influenced; only persist it as the .ke.json
+            # sidecar if it's actually JSON, so the sidecar can't become an
+            # arbitrary-content write primitive.
+            try:
+                json.loads(bytes(data))
+            except ValueError:
+                _print("[yellow]Warning: Metadata is not valid JSON; skipping sidecar[/yellow]")
+                return
+            sidecar_path.write_bytes(bytes(data))
+    except click.ClickException as e:
+        # Connect failure, too-many-redirects, or an SSRF reject on a redirect: the
+        # sidecar is best-effort, so warn rather than abort the whole download.
+        _print(f"[yellow]Warning: Metadata fetch failed: {e.message}[/yellow]")
+    except (httpx.RequestError, httpx.TimeoutException) as e:
+        _print(f"[yellow]Warning: Metadata fetch failed: {e}[/yellow]")
 
 
 def _download_file(
@@ -406,52 +454,46 @@ def _download_file(
     ``HCLI_KE_MAX_DOWNLOAD_MB`` cap, and — even without that cap — refuses to fill the
     disk: it aborts if free space would drop below ``_MIN_FREE_BYTES``, so a malicious
     server can't stream until the disk is full after one approval. When an IP won't
-    accept a connection it tries the next validated IP.
+    accept a connection it tries the next validated IP, and redirects are followed
+    (re-validated and re-pinned per hop).
 
     Downloads to a temporary ``.part`` file and atomically renames on success, so a
     failed re-download never destroys a previously-cached copy at *resource_path*.
     """
     max_bytes = ENV.HCLI_KE_MAX_DOWNLOAD_MB * 1024 * 1024 if ENV.HCLI_KE_MAX_DOWNLOAD_MB > 0 else None
-    attempts = _pinned_attempts(pinned_ips)
     tmp_path = resource_path.with_name(resource_path.name + ".part")
 
-    for index, pinned_ip in enumerate(attempts):
-        url, kwargs = _pinned_request_args(download_url, pinned_ip)
-        try:
-            with client.stream("GET", url, **kwargs) as response:
-                if response.status_code != 200:
-                    raise click.ClickException(f"Download failed: HTTP {response.status_code}")
-                written = 0
-                next_space_check = 0
-                with open(tmp_path, "wb") as f:
-                    for chunk in response.iter_bytes():
-                        written += len(chunk)
-                        if max_bytes is not None and written > max_bytes:
-                            raise click.ClickException(f"Download exceeded the {ENV.HCLI_KE_MAX_DOWNLOAD_MB} MB limit")
-                        # Periodically (and up front) ensure the download isn't filling
-                        # the disk — bounds disk use regardless of any configured cap.
-                        if written >= next_space_check:
-                            if shutil.disk_usage(resource_path.parent).free < _MIN_FREE_BYTES:
-                                raise click.ClickException("Download aborted: insufficient free disk space")
-                            next_space_check = written + _SPACE_CHECK_INTERVAL
-                        f.write(chunk)
-            # Only now replace any existing cached copy — atomic on the same filesystem.
-            os.replace(tmp_path, resource_path)
-            return
-        except _RETRYABLE_CONNECT as e:
-            _unlink_quiet(tmp_path)
-            if index < len(attempts) - 1:
-                continue  # this IP wouldn't connect — try the next validated one
-            raise click.ClickException(f"Download failed: {e}")
-        except httpx.TimeoutException:
-            _unlink_quiet(tmp_path)
-            raise click.ClickException("Download timed out")
-        except (httpx.RequestError, OSError) as e:
-            _unlink_quiet(tmp_path)
-            raise click.ClickException(f"Download failed: {e}")
-        except click.ClickException:
-            _unlink_quiet(tmp_path)
-            raise
+    try:
+        with _open_validated_stream(client, download_url, pinned_ips) as response:
+            if response.status_code != 200:
+                raise click.ClickException(f"Download failed: HTTP {response.status_code}")
+            written = 0
+            next_space_check = 0
+            with open(tmp_path, "wb") as f:
+                for chunk in response.iter_bytes():
+                    written += len(chunk)
+                    if max_bytes is not None and written > max_bytes:
+                        raise click.ClickException(f"Download exceeded the {ENV.HCLI_KE_MAX_DOWNLOAD_MB} MB limit")
+                    # Periodically (and up front) ensure the download isn't filling
+                    # the disk — bounds disk use regardless of any configured cap.
+                    if written >= next_space_check:
+                        if shutil.disk_usage(resource_path.parent).free < _MIN_FREE_BYTES:
+                            raise click.ClickException("Download aborted: insufficient free disk space")
+                        next_space_check = written + _SPACE_CHECK_INTERVAL
+                    f.write(chunk)
+        # Only now replace any existing cached copy — atomic on the same filesystem.
+        os.replace(tmp_path, resource_path)
+    except httpx.TimeoutException:
+        _unlink_quiet(tmp_path)
+        raise click.ClickException("Download timed out")
+    except (httpx.RequestError, OSError) as e:
+        _unlink_quiet(tmp_path)
+        raise click.ClickException(f"Download failed: {e}")
+    except click.ClickException:
+        # Non-200, size/disk limit, too-many-redirects, all pinned IPs unreachable, or
+        # an SSRF reject on a redirect — drop the partial and surface the reason.
+        _unlink_quiet(tmp_path)
+        raise
 
 
 def _unlink_quiet(path: Path) -> None:

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -50,14 +50,16 @@ class KEURLHandler(URLHandler):
 
     def matches(self, parsed: ParseResult) -> bool:
         # KE deep links have the documented shape ``ida://ke/<idb>/<resource>?…&url=``:
-        # the ``ida`` scheme, the ``ke`` host, an ``<idb>/<resource>`` path, AND a
+        # the ``ida`` scheme, the ``ke`` host, at least an ``<idb>`` path segment, AND a
         # ``url=`` download parameter. Requiring all of them keeps the download path
         # from being reached by any other ``ida://...?url=`` link — those (and plain
         # navigation links) fall through to DefaultURLHandler.
         if parsed.scheme != "ida" or parsed.hostname != "ke":
             return False
+        # At least the <idb> segment (handle() needs it); a missing resource is tolerated
+        # so open-only links (ida://ke/<idb>?...&url=) still route here.
         segments = [s for s in parsed.path.split("/") if s]
-        if len(segments) < 2:
+        if len(segments) < 1:
             return False
         return "url" in dict(parse_qsl(parsed.query, keep_blank_values=True))
 
@@ -79,16 +81,6 @@ class KEURLHandler(URLHandler):
         idb_name = _idb_name_from_path(parsed.path)
         if not idb_name:
             _reject("KE URL has no valid <idb> path segment")
-
-        # Validate url= and (when pinning is enabled) get the validated IPs to connect
-        # to, so the download can't re-resolve to a blocked address after the check
-        # (DNS rebinding). Surface rejections through the native dialog too — this
-        # handler is normally launched from a browser with no visible console.
-        try:
-            pinned_ips = _validate_asset_url(asset_url)
-        except click.ClickException as e:
-            _show_error_dialog(e.message or "Invalid KE link")
-            raise
 
         # Compute the cache paths (under a hash of the asset URL so two assets that
         # share a basename don't collide). No filesystem writes happen yet — these are
@@ -119,7 +111,18 @@ class KEURLHandler(URLHandler):
             console.print("[dim]Set HCLI_KE_SKIP_CONFIRM=1 to skip this prompt.[/dim]")
             return
 
-        # Consent given (or explicit CLI): now it's safe to touch the filesystem.
+        # Consent given (or explicit CLI). Only NOW validate url= and resolve/pin the
+        # host — doing the DNS lookup earlier would let a passive, never-consented click
+        # beacon out to the attacker-controlled host. Pinning the resolved IP(s) still
+        # defeats DNS rebinding between this check and the fetch. Rejections surface via
+        # the native dialog (browser-launched: no visible console).
+        try:
+            pinned_ips = _validate_asset_url(asset_url)
+        except click.ClickException as e:
+            _show_error_dialog(e.message or "Invalid KE link")
+            raise
+
+        # Safe to touch the filesystem now.
         _cleanup_old_downloads()
         resource_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -394,11 +397,14 @@ def _download_file(
     ``HCLI_KE_MAX_DOWNLOAD_MB`` cap, and — even without that cap — refuses to fill the
     disk: it aborts if free space would drop below ``_MIN_FREE_BYTES``, so a malicious
     server can't stream until the disk is full after one approval. When an IP won't
-    accept a connection it tries the next validated IP. A partial file is removed on
-    failure.
+    accept a connection it tries the next validated IP.
+
+    Downloads to a temporary ``.part`` file and atomically renames on success, so a
+    failed re-download never destroys a previously-cached copy at *resource_path*.
     """
     max_bytes = ENV.HCLI_KE_MAX_DOWNLOAD_MB * 1024 * 1024 if ENV.HCLI_KE_MAX_DOWNLOAD_MB > 0 else None
     attempts = _pinned_attempts(pinned_ips)
+    tmp_path = resource_path.with_name(resource_path.name + ".part")
 
     for index, pinned_ip in enumerate(attempts):
         url, kwargs = _pinned_request_args(download_url, pinned_ip)
@@ -408,7 +414,7 @@ def _download_file(
                     raise click.ClickException(f"Download failed: HTTP {response.status_code}")
                 written = 0
                 next_space_check = 0
-                with open(resource_path, "wb") as f:
+                with open(tmp_path, "wb") as f:
                     for chunk in response.iter_bytes():
                         written += len(chunk)
                         if max_bytes is not None and written > max_bytes:
@@ -420,20 +426,22 @@ def _download_file(
                                 raise click.ClickException("Download aborted: insufficient free disk space")
                             next_space_check = written + _SPACE_CHECK_INTERVAL
                         f.write(chunk)
+            # Only now replace any existing cached copy — atomic on the same filesystem.
+            os.replace(tmp_path, resource_path)
             return
         except _RETRYABLE_CONNECT as e:
-            _unlink_quiet(resource_path)
+            _unlink_quiet(tmp_path)
             if index < len(attempts) - 1:
                 continue  # this IP wouldn't connect — try the next validated one
             raise click.ClickException(f"Download failed: {e}")
         except httpx.TimeoutException:
-            _unlink_quiet(resource_path)
+            _unlink_quiet(tmp_path)
             raise click.ClickException("Download timed out")
         except (httpx.RequestError, OSError) as e:
-            _unlink_quiet(resource_path)
+            _unlink_quiet(tmp_path)
             raise click.ClickException(f"Download failed: {e}")
         except click.ClickException:
-            _unlink_quiet(resource_path)
+            _unlink_quiet(tmp_path)
             raise
 
 

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -16,8 +16,11 @@ See the KE ``docs/deep-links.md``.
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import logging
+import os
 import platform
+import socket
 import subprocess
 import time
 from pathlib import Path
@@ -61,10 +64,11 @@ class KEURLHandler(URLHandler):
         if not asset_url:
             console.print("[red]Error: KE URL is missing the 'url' download parameter[/red]")
             raise click.Abort()
+        _validate_asset_url(asset_url)
 
         idb_name = _idb_name_from_path(parsed.path)
         if not idb_name:
-            console.print("[red]Error: KE URL has no <idb> path segment[/red]")
+            console.print("[red]Error: KE URL has no valid <idb> path segment[/red]")
             raise click.Abort()
 
         # Cleanup old downloads (best-effort)
@@ -75,6 +79,14 @@ class KEURLHandler(URLHandler):
         downloads_dir = Path(ENV.HCLI_KE_DOWNLOADS_DIR or _default_downloads_dir())
         resource_path = downloads_dir / _ns(asset_url) / idb_name
         sidecar_path = resource_path.parent / f"{resource_path.name}.ke.json"
+
+        # Defense in depth: never write outside the downloads directory, even if
+        # idb_name somehow carried traversal/absolute-path components.
+        downloads_root = downloads_dir.resolve()
+        if not resource_path.resolve().is_relative_to(downloads_root):
+            console.print("[red]Error: refusing to write outside the downloads directory[/red]")
+            raise click.Abort()
+
         resource_path.parent.mkdir(parents=True, exist_ok=True)
 
         console.print(f"[blue]Downloading {idb_name} from KE...[/blue]")
@@ -127,9 +139,50 @@ def _default_downloads_dir() -> str:
 
 def _idb_name_from_path(path: str) -> str:
     """Return the ``<idb>`` segment (the first path segment) of an
-    ``ida://ke/<idb>/<resource>`` link — the IDB filename IDA reports."""
+    ``ida://ke/<idb>/<resource>`` link — the IDB filename IDA reports.
+
+    The decoded segment MUST be a bare filename. An attacker controls the deep
+    link and can percent-encode separators (``%2F``, ``%5C``) or ``..`` to smuggle
+    traversal/absolute paths that would escape the downloads directory once used
+    in a path join, so reject anything that isn't a plain filename here.
+    """
     segments = [seg for seg in path.split("/") if seg]
-    return unquote(segments[0]) if segments else ""
+    if not segments:
+        return ""
+    name = unquote(segments[0])
+    if "/" in name or "\\" in name or name in (".", ".."):
+        return ""
+    return name
+
+
+def _validate_asset_url(asset_url: str) -> None:
+    """Reject asset URLs that aren't safe to fetch from a clicked deep link.
+
+    KE links are attacker-reachable (any web page can launch ``ida://...``), so an
+    unrestricted ``url=`` would let a page make hcli fetch arbitrary internal or
+    loopback services. Allow only http(s), and block non-public address space
+    unless the operator opts in for an internal KE deployment.
+    """
+    parsed = urlparse(asset_url)
+    if parsed.scheme not in ("http", "https"):
+        raise click.ClickException(f"Refusing non-HTTP(S) asset URL: {parsed.scheme or 'missing'}://")
+
+    host = parsed.hostname
+    if not host:
+        raise click.ClickException("Asset URL has no host")
+
+    if ENV.HCLI_KE_ALLOW_PRIVATE_HOSTS:
+        return
+
+    try:
+        infos = socket.getaddrinfo(host, parsed.port or (443 if parsed.scheme == "https" else 80))
+    except socket.gaierror as e:
+        raise click.ClickException(f"Cannot resolve asset host: {e}")
+
+    for *_, sockaddr in infos:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
+            raise click.ClickException(f"Refusing to download from non-public address: {ip}")
 
 
 def _ns(url: str) -> str:
@@ -201,19 +254,25 @@ def _cleanup_old_downloads() -> None:
 def _show_download_dialog(filename: str) -> subprocess.Popen[bytes] | None:
     """Show a platform-native dialog during download."""
     system = platform.system().lower()
+    # The filename comes from an attacker-reachable deep link, so pass it as data
+    # via the environment — never inline it into osascript/PowerShell source, where
+    # quotes/newlines would let it break out and execute arbitrary commands.
+    env = {**os.environ, "KE_DLG_FILE": filename}
     try:
         if system == "darwin":
             return subprocess.Popen(
                 [
                     "osascript",
                     "-e",
-                    f'display dialog "Downloading {filename}\\n\\nPlease wait..." '
-                    f'with title "KE" buttons {{}} giving up after 600',
+                    'display dialog ("Downloading " & (system attribute "KE_DLG_FILE") '
+                    '& "\\n\\nPlease wait...") with title "KE" buttons {} giving up after 600',
                 ],
+                env=env,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
         if system == "linux":
+            # notify-send receives the name as a separate argv element — already safe.
             return subprocess.Popen(
                 ["notify-send", "-t", "0", "KE", f"Downloading {filename}..."],
                 stdout=subprocess.DEVNULL,
@@ -226,10 +285,11 @@ def _show_download_dialog(filename: str) -> subprocess.Popen[bytes] | None:
                     "-WindowStyle",
                     "Hidden",
                     "-Command",
-                    f"Add-Type -AssemblyName System.Windows.Forms; "
-                    f"[System.Windows.Forms.MessageBox]::Show("
-                    f'"Downloading {filename}...\\n\\nPlease wait...", "KE")',
+                    "Add-Type -AssemblyName System.Windows.Forms; "
+                    "[System.Windows.Forms.MessageBox]::Show("
+                    '"Downloading " + $env:KE_DLG_FILE + "...`n`nPlease wait...", "KE")',
                 ],
+                env=env,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
@@ -252,14 +312,20 @@ def _dismiss_dialog(proc: subprocess.Popen[bytes] | None) -> None:
 def _show_error_dialog(message: str) -> None:
     """Show a platform-native error dialog (blocking)."""
     system = platform.system().lower()
+    # message may embed attacker-controlled text (e.g. a URL or server response in
+    # an exception), so pass it as data via the environment rather than inlining it
+    # into osascript/PowerShell source.
+    env = {**os.environ, "KE_DLG_MSG": message}
     try:
         if system == "darwin":
             subprocess.run(
                 [
                     "osascript",
                     "-e",
-                    f'display dialog "{message}" with title "KE" buttons {{"OK"}} default button "OK" with icon stop',
+                    'display dialog (system attribute "KE_DLG_MSG") with title "KE" '
+                    'buttons {"OK"} default button "OK" with icon stop',
                 ],
+                env=env,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 check=False,
@@ -278,10 +344,10 @@ def _show_error_dialog(message: str) -> None:
                     "-WindowStyle",
                     "Hidden",
                     "-Command",
-                    f"Add-Type -AssemblyName System.Windows.Forms; "
-                    f"[System.Windows.Forms.MessageBox]::Show("
-                    f'"{message}", "KE", "OK", "Error")',
+                    "Add-Type -AssemblyName System.Windows.Forms; "
+                    '[System.Windows.Forms.MessageBox]::Show($env:KE_DLG_MSG, "KE", "OK", "Error")',
                 ],
+                env=env,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 check=False,

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -64,7 +64,9 @@ class KEURLHandler(URLHandler):
         if not asset_url:
             console.print("[red]Error: KE URL is missing the 'url' download parameter[/red]")
             raise click.Abort()
-        _validate_asset_url(asset_url)
+        # Validate and (when pinning is enabled) get the exact IP to connect to, so the
+        # download can't re-resolve to a blocked address after the check (DNS rebinding).
+        pinned_ip = _validate_asset_url(asset_url)
 
         idb_name = _idb_name_from_path(parsed.path)
         if not idb_name:
@@ -81,9 +83,14 @@ class KEURLHandler(URLHandler):
         sidecar_path = resource_path.parent / f"{resource_path.name}.ke.json"
 
         # Defense in depth: never write outside the downloads directory, even if
-        # idb_name somehow carried traversal/absolute-path components.
+        # idb_name somehow carried traversal/absolute-path components. Any resolve
+        # error (e.g. an unexpected invalid path byte) is treated as "outside".
         downloads_root = downloads_dir.resolve()
-        if not resource_path.resolve().is_relative_to(downloads_root):
+        try:
+            outside = not resource_path.resolve().is_relative_to(downloads_root)
+        except (ValueError, OSError):
+            outside = True
+        if outside:
             console.print("[red]Error: refusing to write outside the downloads directory[/red]")
             raise click.Abort()
 
@@ -95,8 +102,8 @@ class KEURLHandler(URLHandler):
 
         try:
             with httpx.Client(timeout=300.0) as client:
-                _download_metadata(client, asset_url, sidecar_path)
-                _download_file(client, f"{asset_url}/download", resource_path)
+                _download_metadata(client, asset_url, sidecar_path, pinned_ip)
+                _download_file(client, f"{asset_url}/download", resource_path, pinned_ip)
         except click.ClickException:
             _dismiss_dialog(dialog)
             _show_error_dialog("Download failed")
@@ -150,20 +157,53 @@ def _idb_name_from_path(path: str) -> str:
     if not segments:
         return ""
     name = unquote(segments[0])
+    # Reject separators, traversal, and NUL/control bytes (a NUL makes the later
+    # Path.resolve() raise ValueError and would bypass the clean error path).
     if "/" in name or "\\" in name or name in (".", ".."):
+        return ""
+    if any(ord(ch) < 0x20 or ch == "\x7f" for ch in name):
         return ""
     return name
 
 
-def _validate_asset_url(asset_url: str) -> None:
-    """Reject asset URLs that aren't safe to fetch from a clicked deep link.
+# RFC 6598 carrier-grade NAT shared address space — not flagged by any of the
+# ipaddress is_* properties, but must be treated as non-public for SSRF.
+_CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """True for addresses an attacker-supplied download must never reach."""
+    if ip.version == 4 and ip in _CGNAT_NET:
+        return True
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def _validate_asset_url(asset_url: str) -> str | None:
+    """Validate ``url=`` and return the IP to pin the download connection to.
 
     KE links are attacker-reachable (any web page can launch ``ida://...``), so an
     unrestricted ``url=`` would let a page make hcli fetch arbitrary internal or
-    loopback services. Allow only http(s), and block non-public address space
-    unless the operator opts in for an internal KE deployment.
+    loopback services. Allow only http(s), and — unless the operator opted into
+    private hosts — resolve the host once, reject non-public addresses, and return
+    the validated IP. The caller pins the connection to that IP so the host cannot
+    re-resolve to a blocked address between this check and the fetch (DNS rebinding).
+
+    Returns the IP literal to connect to, or ``None`` when pinning is disabled
+    (private hosts allowed), leaving normal hostname resolution in place.
     """
-    parsed = urlparse(asset_url)
+    try:
+        parsed = urlparse(asset_url)
+        port = parsed.port  # property access parses (and may reject) the port
+    except ValueError as e:
+        raise click.ClickException(f"Invalid asset URL: {e}")
+
     if parsed.scheme not in ("http", "https"):
         raise click.ClickException(f"Refusing non-HTTP(S) asset URL: {parsed.scheme or 'missing'}://")
 
@@ -172,17 +212,45 @@ def _validate_asset_url(asset_url: str) -> None:
         raise click.ClickException("Asset URL has no host")
 
     if ENV.HCLI_KE_ALLOW_PRIVATE_HOSTS:
-        return
+        return None
 
+    resolve_port = port or (443 if parsed.scheme == "https" else 80)
     try:
-        infos = socket.getaddrinfo(host, parsed.port or (443 if parsed.scheme == "https" else 80))
+        infos = socket.getaddrinfo(host, resolve_port, type=socket.SOCK_STREAM)
     except socket.gaierror as e:
         raise click.ClickException(f"Cannot resolve asset host: {e}")
 
+    pinned_ip: str | None = None
     for *_, sockaddr in infos:
         ip = ipaddress.ip_address(sockaddr[0])
-        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
+        if _is_blocked_ip(ip):
             raise click.ClickException(f"Refusing to download from non-public address: {ip}")
+        if pinned_ip is None:
+            pinned_ip = str(ip)
+
+    if pinned_ip is None:
+        raise click.ClickException("Asset host did not resolve to any address")
+    return pinned_ip
+
+
+def _pinned_request_args(url: str, pinned_ip: str | None) -> tuple[str, dict]:
+    """Rewrite *url* to connect to *pinned_ip* while preserving Host/SNI.
+
+    Connecting to the validated IP literal stops httpx from re-resolving the host
+    at fetch time. The original hostname is carried in the ``Host`` header and the
+    ``sni_hostname`` extension so virtual hosting and (for https) TLS SNI plus
+    certificate verification still work against the real name. With *pinned_ip*
+    ``None`` the URL is returned unchanged.
+    """
+    if pinned_ip is None:
+        return url, {}
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+    netloc = f"{ip_host}:{parsed.port}" if parsed.port else ip_host
+    pinned_url = urlunparse(parsed._replace(netloc=netloc))
+    host_header = f"{host}:{parsed.port}" if parsed.port else host
+    return pinned_url, {"headers": {"Host": host_header}, "extensions": {"sni_hostname": host}}
 
 
 def _ns(url: str) -> str:
@@ -205,10 +273,13 @@ def _strip_query_param(uri: str, param: str) -> str:
     return urlunparse(parsed._replace(query="&".join(kept)))
 
 
-def _download_metadata(client: httpx.Client, asset_url: str, sidecar_path: Path) -> None:
+def _download_metadata(
+    client: httpx.Client, asset_url: str, sidecar_path: Path, pinned_ip: str | None = None
+) -> None:
     """Download asset metadata and save as ``.ke.json`` sidecar."""
+    url, kwargs = _pinned_request_args(asset_url, pinned_ip)
     try:
-        response = client.get(asset_url)
+        response = client.get(url, **kwargs)
         if response.status_code == 200:
             sidecar_path.write_bytes(response.content)
         else:
@@ -217,10 +288,13 @@ def _download_metadata(client: httpx.Client, asset_url: str, sidecar_path: Path)
         _print(f"[yellow]Warning: Metadata fetch failed: {e}[/yellow]")
 
 
-def _download_file(client: httpx.Client, download_url: str, resource_path: Path) -> None:
+def _download_file(
+    client: httpx.Client, download_url: str, resource_path: Path, pinned_ip: str | None = None
+) -> None:
     """Download the resource file."""
+    url, kwargs = _pinned_request_args(download_url, pinned_ip)
     try:
-        response = client.get(download_url)
+        response = client.get(url, **kwargs)
         if response.status_code != 200:
             raise click.ClickException(f"Download failed: HTTP {response.status_code}")
         resource_path.write_bytes(response.content)

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -124,7 +124,7 @@ class KEURLHandler(URLHandler):
             raise
 
         # Safe to touch the filesystem now.
-        _cleanup_old_downloads()
+        _cleanup_old_downloads(downloads_dir)
         resource_path.parent.mkdir(parents=True, exist_ok=True)
 
         console.print(f"[blue]Downloading {idb_name} from KE...[/blue]")
@@ -215,10 +215,17 @@ def _idb_name_from_path(path: str) -> str:
 # ipaddress is_* properties, but must be treated as non-public for SSRF.
 _CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
 
+# RFC 4380 Teredo prefix. A Teredo address embeds a server/client IPv4 and the OS can
+# tunnel to it, but is_reserved/is_private don't classify the whole 2001::/32 range
+# before Python 3.11. Block the entire prefix — no public asset is served from it.
+_TEREDO_NET = ipaddress.ip_network("2001::/32")
+
 
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """True for addresses an attacker-supplied download must never reach."""
     if isinstance(ip, ipaddress.IPv6Address):
+        if ip in _TEREDO_NET:
+            return True
         # IPv6 forms that embed an IPv4 address (e.g. "::ffff:127.0.0.1") are NOT
         # flagged by is_private/is_loopback on Python <= 3.10 — the ::ffff:0:0/96
         # range was only classified in 3.11 — yet the OS connects them to the
@@ -441,7 +448,9 @@ def _download_metadata(
         # Connect failure, too-many-redirects, or an SSRF reject on a redirect: the
         # sidecar is best-effort, so warn rather than abort the whole download.
         _print(f"[yellow]Warning: Metadata fetch failed: {e.message}[/yellow]")
-    except (httpx.RequestError, httpx.TimeoutException) as e:
+    except (httpx.RequestError, httpx.TimeoutException, OSError) as e:
+        # OSError covers a failed sidecar write (ENOSPC, permissions, path length):
+        # the sidecar is best-effort, so it must never abort the actual IDB download.
         _print(f"[yellow]Warning: Metadata fetch failed: {e}[/yellow]")
 
 
@@ -503,6 +512,16 @@ def _unlink_quiet(path: Path) -> None:
         pass
 
 
+def _escape_dialog_markup(text: str) -> str:
+    """Neutralize Pango (zenity) / Qt rich-text (kdialog) markup in dialog text.
+
+    Escapes the three markup-significant characters so attacker-controlled values
+    embedded in a prompt render literally instead of as styled markup. ``&`` must be
+    replaced first so the introduced entities are not themselves re-escaped.
+    """
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
 def _confirm_open_dialog(filename: str, host: str) -> bool:
     """Native yes/no confirmation before opening downloaded content in IDA.
 
@@ -516,7 +535,10 @@ def _confirm_open_dialog(filename: str, host: str) -> bool:
         return True
 
     system = platform.system().lower()
-    prompt = f"Download and open IDB '{filename}' from {host} in IDA?"
+    # The download follows redirects (KE typically redirects to object storage), so the
+    # bytes may ultimately come from a different host than this one. Say so rather than
+    # implying {host} is the sole source — each hop is still SSRF-re-validated.
+    prompt = f"Download and open IDB '{filename}' from {host} (or where it redirects) in IDA?"
 
     if system == "darwin":
         try:
@@ -553,9 +575,15 @@ def _confirm_open_dialog(filename: str, host: str) -> bool:
     # available (or it errors), fail CLOSED — we cannot get consent, so we must not
     # open. The file is left on disk; the user can open it manually or set
     # HCLI_KE_SKIP_CONFIRM=1 for one-click flows.
+    #
+    # zenity renders --text as Pango markup and kdialog renders Qt rich text, so the
+    # attacker-controlled host/filename in the prompt must be escaped — otherwise a
+    # url= host like "evil.com<span ...>" injects styled text / fake labels into the
+    # consent dialog. (macOS/Windows above pass the prompt via env as plain text.)
+    safe_prompt = _escape_dialog_markup(prompt)
     for cmd in (
-        ["zenity", "--question", "--title=KE", f"--text={prompt}"],
-        ["kdialog", "--yesno", prompt, "--title", "KE"],
+        ["zenity", "--question", "--title=KE", f"--text={safe_prompt}"],
+        ["kdialog", "--yesno", safe_prompt, "--title", "KE"],
     ):
         if shutil.which(cmd[0]):
             try:
@@ -581,23 +609,22 @@ def _run_confirm(cmd: list[str], prompt: str) -> bool:
     )
 
 
-def _cleanup_old_downloads() -> None:
+def _cleanup_old_downloads(downloads_dir: Path) -> None:
     """Clean up downloads older than retention period (best-effort)."""
-    downloads_dir = Path(ENV.HCLI_KE_DOWNLOADS_DIR or _default_downloads_dir())
     if not downloads_dir.exists():
         return
 
     cutoff_time = time.time() - (ENV.HCLI_KE_DOWNLOADS_RETENTION_DAYS * 24 * 60 * 60)
 
     try:
-        for file_path in downloads_dir.rglob("*"):
-            if file_path.is_file() and file_path.stat().st_mtime < cutoff_time:
-                file_path.unlink()
-
-        # Remove empty directories
-        for dir_path in sorted(downloads_dir.rglob("*"), reverse=True):
-            if dir_path.is_dir() and not any(dir_path.iterdir()):
-                dir_path.rmdir()
+        # Walk the tree once; deepest paths first so directories are emptied bottom-up.
+        entries = sorted(downloads_dir.rglob("*"), reverse=True)
+        for path in entries:
+            if path.is_file() and path.stat().st_mtime < cutoff_time:
+                path.unlink()
+        for path in entries:
+            if path.is_dir() and not any(path.iterdir()):
+                path.rmdir()
     except Exception:
         pass
 

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -67,16 +67,23 @@ class KEURLHandler(URLHandler):
         params = dict(parse_qsl(parsed.query, keep_blank_values=True))
         asset_url = params.get("url", "")
         if not asset_url:
-            console.print("[red]Error: KE URL is missing the 'url' download parameter[/red]")
-            raise click.Abort()
-        # Validate and (when pinning is enabled) get the exact IP to connect to, so the
-        # download can't re-resolve to a blocked address after the check (DNS rebinding).
-        pinned_ip = _validate_asset_url(asset_url)
+            _reject("KE URL is missing the 'url' download parameter")
 
+        # Validate the idb segment FIRST (cheap, no network) so a malformed link does
+        # not trigger a DNS lookup of the attacker-controlled url= host.
         idb_name = _idb_name_from_path(parsed.path)
         if not idb_name:
-            console.print("[red]Error: KE URL has no valid <idb> path segment[/red]")
-            raise click.Abort()
+            _reject("KE URL has no valid <idb> path segment")
+
+        # Validate url= and (when pinning is enabled) get the validated IPs to connect
+        # to, so the download can't re-resolve to a blocked address after the check
+        # (DNS rebinding). Surface rejections through the native dialog too — this
+        # handler is normally launched from a browser with no visible console.
+        try:
+            pinned_ips = _validate_asset_url(asset_url)
+        except click.ClickException as e:
+            _show_error_dialog(e.message or "Invalid KE link")
+            raise
 
         # Cleanup old downloads (best-effort)
         _cleanup_old_downloads()
@@ -96,8 +103,7 @@ class KEURLHandler(URLHandler):
         except (ValueError, OSError):
             outside = True
         if outside:
-            console.print("[red]Error: refusing to write outside the downloads directory[/red]")
-            raise click.Abort()
+            _reject("refusing to write outside the downloads directory")
 
         resource_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -107,8 +113,8 @@ class KEURLHandler(URLHandler):
 
         try:
             with httpx.Client(timeout=300.0) as client:
-                _download_metadata(client, asset_url, sidecar_path, pinned_ip)
-                _download_file(client, _download_url(asset_url), resource_path, pinned_ip)
+                _download_metadata(client, asset_url, sidecar_path, pinned_ips)
+                _download_file(client, _download_url(asset_url), resource_path, pinned_ips)
         except click.ClickException:
             _dismiss_dialog(dialog)
             _show_error_dialog("Download failed")
@@ -131,6 +137,7 @@ class KEURLHandler(URLHandler):
         host = urlparse(asset_url).hostname or "an unknown host"
         if not _confirm_open_dialog(resource_path.name, host):
             console.print("[yellow]Cancelled — not opening in IDA.[/yellow]")
+            console.print("[dim]Set HCLI_KE_SKIP_CONFIRM=1 to skip this prompt.[/dim]")
             console.print(f"[green]Downloaded file: {resource_path}[/green]")
             return
 
@@ -151,6 +158,18 @@ class KEURLHandler(URLHandler):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _reject(message: str) -> None:
+    """Print and surface (via the native dialog) a rejection, then abort.
+
+    Used for the pre-download validation failures: this handler is normally
+    launched from a browser with no visible console, so the dialog is the only
+    feedback the user gets.
+    """
+    console.print(f"[red]Error: {message}[/red]")
+    _show_error_dialog(message)
+    raise click.Abort()
 
 
 def _default_downloads_dir() -> str:
@@ -198,17 +217,18 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     )
 
 
-def _validate_asset_url(asset_url: str) -> str | None:
-    """Validate ``url=`` and return the IP to pin the download connection to.
+def _validate_asset_url(asset_url: str) -> list[str] | None:
+    """Validate ``url=`` and return the IPs to pin the download connection to.
 
     KE links are attacker-reachable (any web page can launch ``ida://...``), so an
     unrestricted ``url=`` would let a page make hcli fetch arbitrary internal or
     loopback services. Allow only http(s), and — unless the operator opted into
-    private hosts — resolve the host once, reject non-public addresses, and return
-    the validated IP. The caller pins the connection to that IP so the host cannot
-    re-resolve to a blocked address between this check and the fetch (DNS rebinding).
+    private hosts — resolve the host once, reject if ANY resolved address is
+    non-public, and return ALL of the validated addresses. The caller connects only
+    to these IPs, so the host cannot re-resolve to a blocked address between this
+    check and the fetch (DNS rebinding), while still preserving multi-IP failover.
 
-    Returns the IP literal to connect to, or ``None`` when pinning is disabled
+    Returns the validated IP literals, or ``None`` when pinning is disabled
     (private hosts allowed), leaving normal hostname resolution in place.
     """
     try:
@@ -233,17 +253,18 @@ def _validate_asset_url(asset_url: str) -> str | None:
     except socket.gaierror as e:
         raise click.ClickException(f"Cannot resolve asset host: {e}")
 
-    pinned_ip: str | None = None
+    pinned_ips: list[str] = []
     for *_, sockaddr in infos:
         ip = ipaddress.ip_address(sockaddr[0])
         if _is_blocked_ip(ip):
             raise click.ClickException(f"Refusing to download from non-public address: {ip}")
-        if pinned_ip is None:
-            pinned_ip = str(ip)
+        ip_str = str(ip)
+        if ip_str not in pinned_ips:
+            pinned_ips.append(ip_str)
 
-    if pinned_ip is None:
+    if not pinned_ips:
         raise click.ClickException("Asset host did not resolve to any address")
-    return pinned_ip
+    return pinned_ips
 
 
 def _pinned_request_args(url: str, pinned_ip: str | None) -> tuple[str, dict]:
@@ -298,53 +319,95 @@ def _download_url(asset_url: str) -> str:
     return urlunparse(parsed._replace(path=new_path))
 
 
+# Hard ceiling on the metadata sidecar regardless of HCLI_KE_MAX_DOWNLOAD_MB: it is
+# small JSON, but the body comes from the attacker-controlled url= host, so bound it
+# so a huge response can't exhaust memory/disk via the (otherwise uncapped) sidecar.
+_METADATA_MAX_BYTES = 16 * 1024 * 1024
+
+
+def _pinned_attempts(pinned_ips: list[str] | None) -> list[str | None]:
+    """The list of IPs to try in order, or ``[None]`` when pinning is disabled."""
+    return list(pinned_ips) if pinned_ips else [None]
+
+
 def _download_metadata(
-    client: httpx.Client, asset_url: str, sidecar_path: Path, pinned_ip: str | None = None
+    client: httpx.Client, asset_url: str, sidecar_path: Path, pinned_ips: list[str] | None = None
 ) -> None:
-    """Download asset metadata and save as ``.ke.json`` sidecar."""
-    url, kwargs = _pinned_request_args(asset_url, pinned_ip)
-    try:
-        response = client.get(url, **kwargs)
-        if response.status_code == 200:
-            sidecar_path.write_bytes(response.content)
-        else:
-            _print(f"[yellow]Warning: Metadata fetch failed (HTTP {response.status_code})[/yellow]")
-    except (httpx.RequestError, httpx.TimeoutException) as e:
-        _print(f"[yellow]Warning: Metadata fetch failed: {e}[/yellow]")
+    """Download asset metadata and save as ``.ke.json`` sidecar (best-effort, bounded)."""
+    last_error: Exception | None = None
+    for pinned_ip in _pinned_attempts(pinned_ips):
+        url, kwargs = _pinned_request_args(asset_url, pinned_ip)
+        try:
+            with client.stream("GET", url, **kwargs) as response:
+                if response.status_code != 200:
+                    _print(f"[yellow]Warning: Metadata fetch failed (HTTP {response.status_code})[/yellow]")
+                    return
+                data = bytearray()
+                for chunk in response.iter_bytes():
+                    data += chunk
+                    if len(data) > _METADATA_MAX_BYTES:
+                        _print("[yellow]Warning: Metadata exceeded size limit; skipping sidecar[/yellow]")
+                        return
+                sidecar_path.write_bytes(bytes(data))
+                return
+        except httpx.ConnectError as e:
+            last_error = e  # try the next validated IP
+            continue
+        except (httpx.RequestError, httpx.TimeoutException) as e:
+            _print(f"[yellow]Warning: Metadata fetch failed: {e}[/yellow]")
+            return
+    if last_error is not None:
+        _print(f"[yellow]Warning: Metadata fetch failed: {last_error}[/yellow]")
 
 
 def _download_file(
-    client: httpx.Client, download_url: str, resource_path: Path, pinned_ip: str | None = None
+    client: httpx.Client, download_url: str, resource_path: Path, pinned_ips: list[str] | None = None
 ) -> None:
     """Stream the resource file to disk.
 
-    Streams rather than buffering the whole body in memory, and enforces the
-    optional ``HCLI_KE_MAX_DOWNLOAD_MB`` cap. A partial file is removed on failure.
+    Streams rather than buffering the whole body in memory, enforces the optional
+    ``HCLI_KE_MAX_DOWNLOAD_MB`` cap, and tries each validated IP in turn so a single
+    down address among several does not fail an otherwise-healthy host. A partial
+    file is removed on failure.
     """
-    url, kwargs = _pinned_request_args(download_url, pinned_ip)
     max_bytes = ENV.HCLI_KE_MAX_DOWNLOAD_MB * 1024 * 1024 if ENV.HCLI_KE_MAX_DOWNLOAD_MB > 0 else None
-    try:
-        with client.stream("GET", url, **kwargs) as response:
-            if response.status_code != 200:
-                raise click.ClickException(f"Download failed: HTTP {response.status_code}")
-            written = 0
-            with open(resource_path, "wb") as f:
-                for chunk in response.iter_bytes():
-                    written += len(chunk)
-                    if max_bytes is not None and written > max_bytes:
-                        raise click.ClickException(
-                            f"Download exceeded the {ENV.HCLI_KE_MAX_DOWNLOAD_MB} MB limit"
-                        )
-                    f.write(chunk)
-    except httpx.TimeoutException:
-        _unlink_quiet(resource_path)
-        raise click.ClickException("Download timed out")
-    except httpx.RequestError as e:
-        _unlink_quiet(resource_path)
-        raise click.ClickException(f"Download failed: {e}")
-    except click.ClickException:
-        _unlink_quiet(resource_path)
-        raise
+    attempts = _pinned_attempts(pinned_ips)
+    last_connect_error: Exception | None = None
+
+    for index, pinned_ip in enumerate(attempts):
+        url, kwargs = _pinned_request_args(download_url, pinned_ip)
+        try:
+            with client.stream("GET", url, **kwargs) as response:
+                if response.status_code != 200:
+                    raise click.ClickException(f"Download failed: HTTP {response.status_code}")
+                written = 0
+                with open(resource_path, "wb") as f:
+                    for chunk in response.iter_bytes():
+                        written += len(chunk)
+                        if max_bytes is not None and written > max_bytes:
+                            raise click.ClickException(
+                                f"Download exceeded the {ENV.HCLI_KE_MAX_DOWNLOAD_MB} MB limit"
+                            )
+                        f.write(chunk)
+            return
+        except httpx.ConnectError as e:
+            # Only a failure to connect is worth retrying on the next validated IP.
+            _unlink_quiet(resource_path)
+            last_connect_error = e
+            if index < len(attempts) - 1:
+                continue
+            raise click.ClickException(f"Download failed: {e}")
+        except httpx.TimeoutException:
+            _unlink_quiet(resource_path)
+            raise click.ClickException("Download timed out")
+        except (httpx.RequestError, OSError) as e:
+            _unlink_quiet(resource_path)
+            raise click.ClickException(f"Download failed: {e}")
+        except click.ClickException:
+            _unlink_quiet(resource_path)
+            raise
+    # Unreachable in practice (the loop returns or raises), but keeps types honest.
+    raise click.ClickException(f"Download failed: {last_connect_error}")
 
 
 def _unlink_quiet(path: Path) -> None:
@@ -357,34 +420,36 @@ def _unlink_quiet(path: Path) -> None:
 def _confirm_open_dialog(filename: str, host: str) -> bool:
     """Native yes/no confirmation before opening downloaded content in IDA.
 
-    Returns True if the user approved (or confirmation is suppressed via
-    ``HCLI_KE_SKIP_CONFIRM``). On macOS/Windows a dialog is always available, so an
-    error there fails closed (deny). Linux uses zenity/kdialog when present and
-    otherwise proceeds — the desktop launcher click is itself the user's consent.
+    Returns True only if the user approved (or confirmation is suppressed via
+    ``HCLI_KE_SKIP_CONFIRM``). macOS/Windows always have a dialog, so any error
+    there fails CLOSED (deny). Platforms without a guaranteed dialog (Linux and any
+    other) use zenity/kdialog when present and otherwise proceed — the desktop
+    launcher click is itself the user's consent, and failing closed would break the
+    feature where no scriptable prompt exists.
     """
     if ENV.HCLI_KE_SKIP_CONFIRM:
         return True
 
     system = platform.system().lower()
     prompt = f"Open downloaded IDB '{filename}' from {host} in IDA?"
-    try:
-        if system == "darwin":
-            env = {**os.environ, "KE_DLG_MSG": prompt}
-            result = subprocess.run(
+
+    if system == "darwin":
+        try:
+            return _run_confirm(
                 [
                     "osascript",
                     "-e",
                     'display dialog (system attribute "KE_DLG_MSG") with title "KE" '
                     'buttons {"Cancel", "Open"} default button "Open" cancel button "Cancel"',
                 ],
-                env=env,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                prompt,
             )
-            return result.returncode == 0  # osascript exits non-zero when Cancel is pressed
-        if system == "windows":
-            env = {**os.environ, "KE_DLG_MSG": prompt}
-            result = subprocess.run(
+        except Exception:
+            return False  # fail closed — a dialog is always available on macOS
+
+    if system == "windows":
+        try:
+            return _run_confirm(
                 [
                     "powershell",
                     "-WindowStyle",
@@ -394,24 +459,33 @@ def _confirm_open_dialog(filename: str, host: str) -> bool:
                     "if ([System.Windows.Forms.MessageBox]::Show("
                     '$env:KE_DLG_MSG, "KE", "YesNo", "Warning") -eq "Yes") { exit 0 } else { exit 1 }',
                 ],
-                env=env,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                prompt,
             )
-            return result.returncode == 0
-        if system == "linux":
-            for cmd in (
-                ["zenity", "--question", "--title=KE", f"--text={prompt}"],
-                ["kdialog", "--yesno", prompt, "--title", "KE"],
-            ):
-                if shutil.which(cmd[0]):
-                    return subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
-            _print("[yellow]No GUI prompt available (install zenity/kdialog to confirm); proceeding.[/yellow]")
-            return True
-    except Exception:
-        # Fail closed where a dialog is expected; don't hard-break Linux.
-        return system == "linux"
+        except Exception:
+            return False  # fail closed — a dialog is always available on Windows
+
+    # Linux and any other platform: best-effort GUI prompt; proceed if none works.
+    for cmd in (
+        ["zenity", "--question", "--title=KE", f"--text={prompt}"],
+        ["kdialog", "--yesno", prompt, "--title", "KE"],
+    ):
+        if shutil.which(cmd[0]):
+            try:
+                return subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+            except Exception:
+                break
+    _print("[yellow]No GUI prompt available (install zenity/kdialog to confirm); proceeding.[/yellow]")
     return True
+
+
+def _run_confirm(cmd: list[str], prompt: str) -> bool:
+    """Run a confirmation subprocess that returns exit 0 for "yes"/approve.
+
+    The prompt text is passed as data via the environment (read by the script as
+    ``system attribute``/``$env:``), never interpolated into interpreter source.
+    """
+    env = {**os.environ, "KE_DLG_MSG": prompt}
+    return subprocess.run(cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
 
 
 def _cleanup_old_downloads() -> None:

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import hashlib
 import ipaddress
+import json
 import logging
 import os
 import platform
@@ -48,11 +49,15 @@ class KEURLHandler(URLHandler):
     """
 
     def matches(self, parsed: ParseResult) -> bool:
-        # KE deep links have the documented shape ``ida://ke/<idb>/...?...&url=<asset>``:
-        # the ``ke`` host AND a ``url=`` download parameter. Requiring both keeps the
-        # download path from being reached by any other ``ida://...?url=`` link — those
-        # (and plain navigation links) fall through to DefaultURLHandler.
-        if parsed.hostname != "ke":
+        # KE deep links have the documented shape ``ida://ke/<idb>/<resource>?…&url=``:
+        # the ``ida`` scheme, the ``ke`` host, an ``<idb>/<resource>`` path, AND a
+        # ``url=`` download parameter. Requiring all of them keeps the download path
+        # from being reached by any other ``ida://...?url=`` link — those (and plain
+        # navigation links) fall through to DefaultURLHandler.
+        if parsed.scheme != "ida" or parsed.hostname != "ke":
+            return False
+        segments = [s for s in parsed.path.split("/") if s]
+        if len(segments) < 2:
             return False
         return "url" in dict(parse_qsl(parsed.query, keep_blank_values=True))
 
@@ -107,6 +112,16 @@ class KEURLHandler(URLHandler):
 
         resource_path.parent.mkdir(parents=True, exist_ok=True)
 
+        # Confirm BEFORE downloading. The handler is reachable from any web page, so a
+        # passive ida://ke/... click must not stream attacker content to disk (let alone
+        # hand it to IDA) without the user's consent. Skipped only for --no-launch (an
+        # explicit local CLI invocation, not the drive-by surface).
+        host = urlparse(asset_url).hostname or "an unknown host"
+        if not no_launch and not _confirm_open_dialog(idb_name, host):
+            console.print("[yellow]Cancelled — nothing downloaded.[/yellow]")
+            console.print("[dim]Set HCLI_KE_SKIP_CONFIRM=1 to skip this prompt.[/dim]")
+            return
+
         console.print(f"[blue]Downloading {idb_name} from KE...[/blue]")
 
         dialog = _show_download_dialog(idb_name)
@@ -131,15 +146,6 @@ class KEURLHandler(URLHandler):
         _dismiss_dialog(dialog)
 
         if no_launch:
-            console.print(f"[green]Downloaded file: {resource_path}[/green]")
-            return
-
-        # The download path is reachable from any web page, so confirm before handing
-        # attacker-influenced content to IDA (loaders/IDBs can auto-run scripts).
-        host = urlparse(asset_url).hostname or "an unknown host"
-        if not _confirm_open_dialog(resource_path.name, host):
-            console.print("[yellow]Cancelled — not opening in IDA.[/yellow]")
-            console.print("[dim]Set HCLI_KE_SKIP_CONFIRM=1 to skip this prompt.[/dim]")
             console.print(f"[green]Downloaded file: {resource_path}[/green]")
             return
 
@@ -354,6 +360,14 @@ def _download_metadata(
                     if len(data) > _METADATA_MAX_BYTES:
                         _print("[yellow]Warning: Metadata exceeded size limit; skipping sidecar[/yellow]")
                         return
+                # The body is attacker-influenced; only persist it as the .ke.json
+                # sidecar if it's actually JSON, so the sidecar can't become an
+                # arbitrary-content write primitive.
+                try:
+                    json.loads(bytes(data))
+                except ValueError:
+                    _print("[yellow]Warning: Metadata is not valid JSON; skipping sidecar[/yellow]")
+                    return
                 sidecar_path.write_bytes(bytes(data))
                 return
         except _RETRYABLE_CONNECT as e:
@@ -418,18 +432,17 @@ def _unlink_quiet(path: Path) -> None:
 def _confirm_open_dialog(filename: str, host: str) -> bool:
     """Native yes/no confirmation before opening downloaded content in IDA.
 
-    Returns True only if the user approved (or confirmation is suppressed via
-    ``HCLI_KE_SKIP_CONFIRM``). macOS/Windows always have a dialog, so any error
-    there fails CLOSED (deny). Platforms without a guaranteed dialog (Linux and any
-    other) use zenity/kdialog when present and otherwise proceed — the desktop
-    launcher click is itself the user's consent, and failing closed would break the
-    feature where no scriptable prompt exists.
+    Returns True only if the user explicitly approved (or confirmation is suppressed
+    via ``HCLI_KE_SKIP_CONFIRM``). Every platform fails CLOSED: if no prompt can be
+    shown (no dialog tool, or the dialog errors), it returns False rather than
+    auto-opening attacker-influenced content. The handler is browser-launched with no
+    usable console, so "no prompt" cannot count as consent.
     """
     if ENV.HCLI_KE_SKIP_CONFIRM:
         return True
 
     system = platform.system().lower()
-    prompt = f"Open downloaded IDB '{filename}' from {host} in IDA?"
+    prompt = f"Download and open IDB '{filename}' from {host} in IDA?"
 
     if system == "darwin":
         try:
@@ -462,7 +475,10 @@ def _confirm_open_dialog(filename: str, host: str) -> bool:
         except Exception:
             return False  # fail closed — a dialog is always available on Windows
 
-    # Linux and any other platform: best-effort GUI prompt; proceed if none works.
+    # Linux and any other platform: use zenity/kdialog when present. If neither is
+    # available (or it errors), fail CLOSED — we cannot get consent, so we must not
+    # open. The file is left on disk; the user can open it manually or set
+    # HCLI_KE_SKIP_CONFIRM=1 for one-click flows.
     for cmd in (
         ["zenity", "--question", "--title=KE", f"--text={prompt}"],
         ["kdialog", "--yesno", prompt, "--title", "KE"],
@@ -474,9 +490,9 @@ def _confirm_open_dialog(filename: str, host: str) -> bool:
                     == 0
                 )
             except Exception:
-                break
-    _print("[yellow]No GUI prompt available (install zenity/kdialog to confirm); proceeding.[/yellow]")
-    return True
+                return False
+    _print("[yellow]No confirmation prompt available (install zenity/kdialog, or set HCLI_KE_SKIP_CONFIRM=1).[/yellow]")
+    return False
 
 
 def _run_confirm(cmd: list[str], prompt: str) -> bool:

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -115,9 +115,11 @@ class KEURLHandler(URLHandler):
             with httpx.Client(timeout=300.0) as client:
                 _download_metadata(client, asset_url, sidecar_path, pinned_ips)
                 _download_file(client, _download_url(asset_url), resource_path, pinned_ips)
-        except click.ClickException:
+        except click.ClickException as e:
             _dismiss_dialog(dialog)
-            _show_error_dialog("Download failed")
+            # Surface the specific reason (HTTP status, size limit, SSRF reject) in the
+            # native dialog — the handler is browser-launched with no visible console.
+            _show_error_dialog(e.message or "Download failed")
             raise
         except Exception as e:
             _dismiss_dialog(dialog)
@@ -318,6 +320,12 @@ def _download_url(asset_url: str) -> str:
 _METADATA_MAX_BYTES = 16 * 1024 * 1024
 
 
+# Failures that mean "this validated IP wouldn't accept a connection" — worth
+# retrying on the next pinned IP. Mid-stream resets, read timeouts, and non-200
+# responses are treated as terminal (a server that answered is "up").
+_RETRYABLE_CONNECT = (httpx.ConnectError, httpx.ConnectTimeout)
+
+
 def _pinned_attempts(pinned_ips: list[str] | None) -> list[str | None]:
     """The list of IPs to try in order, or ``[None]`` when pinning is disabled."""
     return list(pinned_ips) if pinned_ips else [None]
@@ -326,9 +334,14 @@ def _pinned_attempts(pinned_ips: list[str] | None) -> list[str | None]:
 def _download_metadata(
     client: httpx.Client, asset_url: str, sidecar_path: Path, pinned_ips: list[str] | None = None
 ) -> None:
-    """Download asset metadata and save as ``.ke.json`` sidecar (best-effort, bounded)."""
-    last_error: Exception | None = None
-    for pinned_ip in _pinned_attempts(pinned_ips):
+    """Download asset metadata and save as ``.ke.json`` sidecar (best-effort, bounded).
+
+    Tries each validated IP in turn when an IP won't accept a connection; any other
+    failure (non-200, read error, timeout) is reported as a warning — the sidecar is
+    optional, so a missing one never blocks the download.
+    """
+    attempts = _pinned_attempts(pinned_ips)
+    for index, pinned_ip in enumerate(attempts):
         url, kwargs = _pinned_request_args(asset_url, pinned_ip)
         try:
             with client.stream("GET", url, **kwargs) as response:
@@ -343,14 +356,13 @@ def _download_metadata(
                         return
                 sidecar_path.write_bytes(bytes(data))
                 return
-        except httpx.ConnectError as e:
-            last_error = e  # try the next validated IP
-            continue
+        except _RETRYABLE_CONNECT as e:
+            if index < len(attempts) - 1:
+                continue  # this IP wouldn't connect — try the next validated one
+            _print(f"[yellow]Warning: Metadata fetch failed: {e}[/yellow]")
         except (httpx.RequestError, httpx.TimeoutException) as e:
             _print(f"[yellow]Warning: Metadata fetch failed: {e}[/yellow]")
             return
-    if last_error is not None:
-        _print(f"[yellow]Warning: Metadata fetch failed: {last_error}[/yellow]")
 
 
 def _download_file(
@@ -359,13 +371,12 @@ def _download_file(
     """Stream the resource file to disk.
 
     Streams rather than buffering the whole body in memory, enforces the optional
-    ``HCLI_KE_MAX_DOWNLOAD_MB`` cap, and tries each validated IP in turn so a single
-    down address among several does not fail an otherwise-healthy host. A partial
-    file is removed on failure.
+    ``HCLI_KE_MAX_DOWNLOAD_MB`` cap, and — when an IP won't accept a connection —
+    tries the next validated IP so a single dead address doesn't fail a host that
+    has other healthy ones. A partial file is removed on failure.
     """
     max_bytes = ENV.HCLI_KE_MAX_DOWNLOAD_MB * 1024 * 1024 if ENV.HCLI_KE_MAX_DOWNLOAD_MB > 0 else None
     attempts = _pinned_attempts(pinned_ips)
-    last_connect_error: Exception | None = None
 
     for index, pinned_ip in enumerate(attempts):
         url, kwargs = _pinned_request_args(download_url, pinned_ip)
@@ -381,12 +392,10 @@ def _download_file(
                             raise click.ClickException(f"Download exceeded the {ENV.HCLI_KE_MAX_DOWNLOAD_MB} MB limit")
                         f.write(chunk)
             return
-        except httpx.ConnectError as e:
-            # Only a failure to connect is worth retrying on the next validated IP.
+        except _RETRYABLE_CONNECT as e:
             _unlink_quiet(resource_path)
-            last_connect_error = e
             if index < len(attempts) - 1:
-                continue
+                continue  # this IP wouldn't connect — try the next validated one
             raise click.ClickException(f"Download failed: {e}")
         except httpx.TimeoutException:
             _unlink_quiet(resource_path)
@@ -397,8 +406,6 @@ def _download_file(
         except click.ClickException:
             _unlink_quiet(resource_path)
             raise
-    # Unreachable in practice (the loop returns or raises), but keeps types honest.
-    raise click.ClickException(f"Download failed: {last_connect_error}")
 
 
 def _unlink_quiet(path: Path) -> None:

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -90,11 +90,9 @@ class KEURLHandler(URLHandler):
             _show_error_dialog(e.message or "Invalid KE link")
             raise
 
-        # Cleanup old downloads (best-effort)
-        _cleanup_old_downloads()
-
-        # Cache under a hash of the asset URL so two assets that share a basename
-        # (e.g. both "chall.i64") don't collide in the downloads dir.
+        # Compute the cache paths (under a hash of the asset URL so two assets that
+        # share a basename don't collide). No filesystem writes happen yet — these are
+        # pure path ops, and resolve() does not create anything.
         downloads_dir = Path(ENV.HCLI_KE_DOWNLOADS_DIR or _default_downloads_dir())
         resource_path = downloads_dir / _ns(asset_url) / idb_name
         sidecar_path = resource_path.parent / f"{resource_path.name}.ke.json"
@@ -110,17 +108,20 @@ class KEURLHandler(URLHandler):
         if outside:
             _reject("refusing to write outside the downloads directory")
 
-        resource_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Confirm BEFORE downloading. The handler is reachable from any web page, so a
-        # passive ida://ke/... click must not stream attacker content to disk (let alone
-        # hand it to IDA) without the user's consent. Skipped only for --no-launch (an
-        # explicit local CLI invocation, not the drive-by surface).
+        # Confirm BEFORE any filesystem side effect. The handler is reachable from any
+        # web page, so a passive ida://ke/... click must not touch disk at all (no
+        # cleanup, no dir creation, no download) without the user's consent. Skipped
+        # only for --no-launch (an explicit local CLI invocation, not the drive-by
+        # surface).
         host = urlparse(asset_url).hostname or "an unknown host"
         if not no_launch and not _confirm_open_dialog(idb_name, host):
             console.print("[yellow]Cancelled — nothing downloaded.[/yellow]")
             console.print("[dim]Set HCLI_KE_SKIP_CONFIRM=1 to skip this prompt.[/dim]")
             return
+
+        # Consent given (or explicit CLI): now it's safe to touch the filesystem.
+        _cleanup_old_downloads()
+        resource_path.parent.mkdir(parents=True, exist_ok=True)
 
         console.print(f"[blue]Downloading {idb_name} from KE...[/blue]")
 
@@ -325,6 +326,11 @@ def _download_url(asset_url: str) -> str:
 # so a huge response can't exhaust memory/disk via the (otherwise uncapped) sidecar.
 _METADATA_MAX_BYTES = 16 * 1024 * 1024
 
+# Always keep at least this much free disk during a download, so a server can't fill
+# the disk even after the user approves the download (independent of any size cap).
+_MIN_FREE_BYTES = 512 * 1024 * 1024
+_SPACE_CHECK_INTERVAL = 32 * 1024 * 1024
+
 
 # Failures that mean "this validated IP wouldn't accept a connection" — worth
 # retrying on the next pinned IP. Mid-stream resets, read timeouts, and non-200
@@ -385,9 +391,11 @@ def _download_file(
     """Stream the resource file to disk.
 
     Streams rather than buffering the whole body in memory, enforces the optional
-    ``HCLI_KE_MAX_DOWNLOAD_MB`` cap, and — when an IP won't accept a connection —
-    tries the next validated IP so a single dead address doesn't fail a host that
-    has other healthy ones. A partial file is removed on failure.
+    ``HCLI_KE_MAX_DOWNLOAD_MB`` cap, and — even without that cap — refuses to fill the
+    disk: it aborts if free space would drop below ``_MIN_FREE_BYTES``, so a malicious
+    server can't stream until the disk is full after one approval. When an IP won't
+    accept a connection it tries the next validated IP. A partial file is removed on
+    failure.
     """
     max_bytes = ENV.HCLI_KE_MAX_DOWNLOAD_MB * 1024 * 1024 if ENV.HCLI_KE_MAX_DOWNLOAD_MB > 0 else None
     attempts = _pinned_attempts(pinned_ips)
@@ -399,11 +407,18 @@ def _download_file(
                 if response.status_code != 200:
                     raise click.ClickException(f"Download failed: HTTP {response.status_code}")
                 written = 0
+                next_space_check = 0
                 with open(resource_path, "wb") as f:
                     for chunk in response.iter_bytes():
                         written += len(chunk)
                         if max_bytes is not None and written > max_bytes:
                             raise click.ClickException(f"Download exceeded the {ENV.HCLI_KE_MAX_DOWNLOAD_MB} MB limit")
+                        # Periodically (and up front) ensure the download isn't filling
+                        # the disk — bounds disk use regardless of any configured cap.
+                        if written >= next_space_check:
+                            if shutil.disk_usage(resource_path.parent).free < _MIN_FREE_BYTES:
+                                raise click.ClickException("Download aborted: insufficient free disk space")
+                            next_space_check = written + _SPACE_CHECK_INTERVAL
                         f.write(chunk)
             return
         except _RETRYABLE_CONNECT as e:

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -20,6 +20,7 @@ import ipaddress
 import logging
 import os
 import platform
+import shutil
 import socket
 import subprocess
 import time
@@ -47,8 +48,12 @@ class KEURLHandler(URLHandler):
     """
 
     def matches(self, parsed: ParseResult) -> bool:
-        # KE deep links carry the asset download location as a ``url=`` parameter.
-        # Plain navigation links (rva/ea/name/view only) fall through to DefaultURLHandler.
+        # KE deep links have the documented shape ``ida://ke/<idb>/...?...&url=<asset>``:
+        # the ``ke`` host AND a ``url=`` download parameter. Requiring both keeps the
+        # download path from being reached by any other ``ida://...?url=`` link — those
+        # (and plain navigation links) fall through to DefaultURLHandler.
+        if parsed.hostname != "ke":
+            return False
         return "url" in dict(parse_qsl(parsed.query, keep_blank_values=True))
 
     def handle(
@@ -103,7 +108,7 @@ class KEURLHandler(URLHandler):
         try:
             with httpx.Client(timeout=300.0) as client:
                 _download_metadata(client, asset_url, sidecar_path, pinned_ip)
-                _download_file(client, f"{asset_url}/download", resource_path, pinned_ip)
+                _download_file(client, _download_url(asset_url), resource_path, pinned_ip)
         except click.ClickException:
             _dismiss_dialog(dialog)
             _show_error_dialog("Download failed")
@@ -118,6 +123,14 @@ class KEURLHandler(URLHandler):
         _dismiss_dialog(dialog)
 
         if no_launch:
+            console.print(f"[green]Downloaded file: {resource_path}[/green]")
+            return
+
+        # The download path is reachable from any web page, so confirm before handing
+        # attacker-influenced content to IDA (loaders/IDBs can auto-run scripts).
+        host = urlparse(asset_url).hostname or "an unknown host"
+        if not _confirm_open_dialog(resource_path.name, host):
+            console.print("[yellow]Cancelled — not opening in IDA.[/yellow]")
             console.print(f"[green]Downloaded file: {resource_path}[/green]")
             return
 
@@ -273,6 +286,18 @@ def _strip_query_param(uri: str, param: str) -> str:
     return urlunparse(parsed._replace(query="&".join(kept)))
 
 
+def _download_url(asset_url: str) -> str:
+    """Append the ``/download`` path segment to *asset_url*, preserving query/fragment.
+
+    KE serves the file at ``<asset>/download``. Plain ``f"{asset_url}/download"`` is
+    wrong when the asset URL carries a query or fragment (the segment would land in
+    the query string), so splice it into the path component instead.
+    """
+    parsed = urlparse(asset_url)
+    new_path = parsed.path.rstrip("/") + "/download"
+    return urlunparse(parsed._replace(path=new_path))
+
+
 def _download_metadata(
     client: httpx.Client, asset_url: str, sidecar_path: Path, pinned_ip: str | None = None
 ) -> None:
@@ -291,17 +316,102 @@ def _download_metadata(
 def _download_file(
     client: httpx.Client, download_url: str, resource_path: Path, pinned_ip: str | None = None
 ) -> None:
-    """Download the resource file."""
+    """Stream the resource file to disk.
+
+    Streams rather than buffering the whole body in memory, and enforces the
+    optional ``HCLI_KE_MAX_DOWNLOAD_MB`` cap. A partial file is removed on failure.
+    """
     url, kwargs = _pinned_request_args(download_url, pinned_ip)
+    max_bytes = ENV.HCLI_KE_MAX_DOWNLOAD_MB * 1024 * 1024 if ENV.HCLI_KE_MAX_DOWNLOAD_MB > 0 else None
     try:
-        response = client.get(url, **kwargs)
-        if response.status_code != 200:
-            raise click.ClickException(f"Download failed: HTTP {response.status_code}")
-        resource_path.write_bytes(response.content)
+        with client.stream("GET", url, **kwargs) as response:
+            if response.status_code != 200:
+                raise click.ClickException(f"Download failed: HTTP {response.status_code}")
+            written = 0
+            with open(resource_path, "wb") as f:
+                for chunk in response.iter_bytes():
+                    written += len(chunk)
+                    if max_bytes is not None and written > max_bytes:
+                        raise click.ClickException(
+                            f"Download exceeded the {ENV.HCLI_KE_MAX_DOWNLOAD_MB} MB limit"
+                        )
+                    f.write(chunk)
     except httpx.TimeoutException:
+        _unlink_quiet(resource_path)
         raise click.ClickException("Download timed out")
     except httpx.RequestError as e:
+        _unlink_quiet(resource_path)
         raise click.ClickException(f"Download failed: {e}")
+    except click.ClickException:
+        _unlink_quiet(resource_path)
+        raise
+
+
+def _unlink_quiet(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _confirm_open_dialog(filename: str, host: str) -> bool:
+    """Native yes/no confirmation before opening downloaded content in IDA.
+
+    Returns True if the user approved (or confirmation is suppressed via
+    ``HCLI_KE_SKIP_CONFIRM``). On macOS/Windows a dialog is always available, so an
+    error there fails closed (deny). Linux uses zenity/kdialog when present and
+    otherwise proceeds — the desktop launcher click is itself the user's consent.
+    """
+    if ENV.HCLI_KE_SKIP_CONFIRM:
+        return True
+
+    system = platform.system().lower()
+    prompt = f"Open downloaded IDB '{filename}' from {host} in IDA?"
+    try:
+        if system == "darwin":
+            env = {**os.environ, "KE_DLG_MSG": prompt}
+            result = subprocess.run(
+                [
+                    "osascript",
+                    "-e",
+                    'display dialog (system attribute "KE_DLG_MSG") with title "KE" '
+                    'buttons {"Cancel", "Open"} default button "Open" cancel button "Cancel"',
+                ],
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return result.returncode == 0  # osascript exits non-zero when Cancel is pressed
+        if system == "windows":
+            env = {**os.environ, "KE_DLG_MSG": prompt}
+            result = subprocess.run(
+                [
+                    "powershell",
+                    "-WindowStyle",
+                    "Hidden",
+                    "-Command",
+                    "Add-Type -AssemblyName System.Windows.Forms; "
+                    "if ([System.Windows.Forms.MessageBox]::Show("
+                    '$env:KE_DLG_MSG, "KE", "YesNo", "Warning") -eq "Yes") { exit 0 } else { exit 1 }',
+                ],
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return result.returncode == 0
+        if system == "linux":
+            for cmd in (
+                ["zenity", "--question", "--title=KE", f"--text={prompt}"],
+                ["kdialog", "--yesno", prompt, "--title", "KE"],
+            ):
+                if shutil.which(cmd[0]):
+                    return subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+            _print("[yellow]No GUI prompt available (install zenity/kdialog to confirm); proceeding.[/yellow]")
+            return True
+    except Exception:
+        # Fail closed where a dialog is expected; don't hard-break Linux.
+        return system == "linux"
+    return True
 
 
 def _cleanup_old_downloads() -> None:

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -207,14 +207,7 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """True for addresses an attacker-supplied download must never reach."""
     if ip.version == 4 and ip in _CGNAT_NET:
         return True
-    return (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
-    )
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
 
 
 def _validate_asset_url(asset_url: str) -> list[str] | None:
@@ -385,9 +378,7 @@ def _download_file(
                     for chunk in response.iter_bytes():
                         written += len(chunk)
                         if max_bytes is not None and written > max_bytes:
-                            raise click.ClickException(
-                                f"Download exceeded the {ENV.HCLI_KE_MAX_DOWNLOAD_MB} MB limit"
-                            )
+                            raise click.ClickException(f"Download exceeded the {ENV.HCLI_KE_MAX_DOWNLOAD_MB} MB limit")
                         f.write(chunk)
             return
         except httpx.ConnectError as e:
@@ -471,7 +462,10 @@ def _confirm_open_dialog(filename: str, host: str) -> bool:
     ):
         if shutil.which(cmd[0]):
             try:
-                return subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+                return (
+                    subprocess.run(cmd, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode
+                    == 0
+                )
             except Exception:
                 break
     _print("[yellow]No GUI prompt available (install zenity/kdialog to confirm); proceeding.[/yellow]")
@@ -485,7 +479,9 @@ def _run_confirm(cmd: list[str], prompt: str) -> bool:
     ``system attribute``/``$env:``), never interpolated into interpreter source.
     """
     env = {**os.environ, "KE_DLG_MSG": prompt}
-    return subprocess.run(cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+    return (
+        subprocess.run(cmd, check=False, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+    )
 
 
 def _cleanup_old_downloads() -> None:

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -12,7 +12,9 @@ from hcli.env import ENV as ENV_CLS
 from hcli.lib.ida.handler.ke_url_handler import (
     KEURLHandler,
     _cleanup_old_downloads,
+    _confirm_open_dialog,
     _default_downloads_dir,
+    _download_url,
     _has_nav_params,
     _idb_name_from_path,
     _ns,
@@ -49,6 +51,54 @@ class TestMatches:
         # The old download-locator form carried no url= param — it no longer matches.
         parsed = urlparse("ida://host:8080/api/v1/buckets/mybucket/assets/test.i64")
         assert KEURLHandler().matches(parsed) is False
+
+    def test_url_param_on_non_ke_host_not_detected(self):
+        # Only the documented ida://ke/... host gets the download path; a url= param
+        # on any other host must fall through to DefaultURLHandler.
+        parsed = urlparse("ida://evil/test.i64/functions?url=http://attacker/x")
+        assert KEURLHandler().matches(parsed) is False
+
+
+class TestDownloadUrl:
+    def test_appends_download_segment(self):
+        assert _download_url("https://host/a/b") == "https://host/a/b/download"
+
+    def test_preserves_query(self):
+        # Naive f"{url}/download" would put the segment inside the query string.
+        assert _download_url("https://host/a?token=x") == "https://host/a/download?token=x"
+
+    def test_handles_trailing_slash(self):
+        assert _download_url("https://host/a/") == "https://host/a/download"
+
+
+class TestConfirmOpenDialog:
+    def test_skip_confirm_returns_true_without_prompting(self):
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", True),
+            patch("hcli.lib.ida.handler.ke_url_handler.subprocess.run") as mock_run,
+        ):
+            assert _confirm_open_dialog("chall.i64", "ke.example.com") is True
+            mock_run.assert_not_called()
+
+    def test_linux_without_gui_tool_proceeds(self):
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", False),
+            patch("hcli.lib.ida.handler.ke_url_handler.platform.system", return_value="Linux"),
+            patch("hcli.lib.ida.handler.ke_url_handler.shutil.which", return_value=None),
+            patch("hcli.lib.ida.handler.ke_url_handler._print"),
+        ):
+            assert _confirm_open_dialog("chall.i64", "ke.example.com") is True
+
+    def test_linux_zenity_decline_denies(self):
+        completed = MagicMock()
+        completed.returncode = 1  # user clicked No / closed
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", False),
+            patch("hcli.lib.ida.handler.ke_url_handler.platform.system", return_value="Linux"),
+            patch("hcli.lib.ida.handler.ke_url_handler.shutil.which", side_effect=lambda c: "/usr/bin/zenity" if c == "zenity" else None),
+            patch("hcli.lib.ida.handler.ke_url_handler.subprocess.run", return_value=completed),
+        ):
+            assert _confirm_open_dialog("chall.i64", "ke.example.com") is False
 
 
 class TestIdbNameFromPath:
@@ -233,6 +283,34 @@ class TestCleanupOldDownloads:
             _cleanup_old_downloads()  # should not raise
 
 
+def _mock_httpx_client(content: bytes = b"file content", status: int = 200):
+    """Build a mock httpx client supporting both .get (metadata) and .stream (file)."""
+    mock_client = MagicMock()
+
+    meta_response = MagicMock()
+    meta_response.status_code = 200
+    meta_response.content = b"{}"
+    mock_client.get.return_value = meta_response
+
+    stream_response = MagicMock()
+    stream_response.status_code = status
+    stream_response.iter_bytes.return_value = [content]
+    stream_cm = MagicMock()
+    stream_cm.__enter__ = MagicMock(return_value=stream_response)
+    stream_cm.__exit__ = MagicMock(return_value=False)
+    mock_client.stream.return_value = stream_cm
+    return mock_client
+
+
+def _set_handler_env(mock_env, tmp_path):
+    """Populate the patched ENV with concrete (non-MagicMock) values the handler reads."""
+    mock_env.HCLI_KE_DOWNLOADS_DIR = str(tmp_path)
+    mock_env.HCLI_KE_DOWNLOADS_RETENTION_DAYS = 3
+    mock_env.HCLI_KE_MAX_DOWNLOAD_MB = 0
+    mock_env.HCLI_KE_SKIP_CONFIRM = True
+    mock_env.HCLI_KE_ALLOW_PRIVATE_HOSTS = True
+
+
 class TestHandleKeUrl:
     @patch("hcli.lib.ida.handler.ke_url_handler._show_download_dialog", return_value=None)
     @patch("hcli.lib.ida.handler.ke_url_handler._dismiss_dialog")
@@ -241,11 +319,7 @@ class TestHandleKeUrl:
     def test_no_launch_downloads_to_hashed_dir(
         self, mock_client_cls, mock_cleanup, mock_dismiss, mock_dialog, tmp_path
     ):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.content = b"file content"
-        mock_client.get.return_value = mock_response
+        mock_client = _mock_httpx_client(b"file content")
         mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -256,8 +330,7 @@ class TestHandleKeUrl:
             patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env,
             patch("hcli.lib.ida.handler.ke_url_handler.time.sleep"),
         ):
-            mock_env.HCLI_KE_DOWNLOADS_DIR = str(tmp_path)
-            mock_env.HCLI_KE_DOWNLOADS_RETENTION_DAYS = 3
+            _set_handler_env(mock_env, tmp_path)
             KEURLHandler().handle(uri, parsed, no_launch=True, timeout=120.0, skip_analysis=False)
 
         # File and its .ke.json sidecar land under the url-hash namespace dir.
@@ -282,11 +355,7 @@ class TestHandleKeUrl:
         mock_ipc.query_instance.return_value = running_instance
         mock_ipc.send_open_ida_link.return_value = (True, "OK")
 
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.content = b"file content"
-        mock_client.get.return_value = mock_response
+        mock_client = _mock_httpx_client(b"file content")
         mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -298,8 +367,7 @@ class TestHandleKeUrl:
             patch("hcli.lib.ida.handler.ke_url_handler.time.sleep"),
             patch("hcli.lib.ida.resolve._print"),
         ):
-            mock_env.HCLI_KE_DOWNLOADS_DIR = str(tmp_path)
-            mock_env.HCLI_KE_DOWNLOADS_RETENTION_DAYS = 3
+            _set_handler_env(mock_env, tmp_path)
             KEURLHandler().handle(uri, parsed, no_launch=False, timeout=120.0, skip_analysis=False)
 
         # Reuse the running instance and forward the nav link WITHOUT url=.

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -353,32 +353,35 @@ class TestCleanupOldDownloads:
             _cleanup_old_downloads()  # should not raise
 
 
-def _mock_httpx_client(content: bytes = b"file content", status: int = 200):
-    """Build a mock httpx client supporting both .get (metadata) and .stream (file)."""
+def _stream_cm(content: bytes, status: int = 200):
+    """A mock httpx streaming-response context manager yielding *content*."""
+    response = MagicMock()
+    response.status_code = status
+    response.iter_bytes.return_value = [content]
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=response)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+def _mock_httpx_client(content: bytes = b"file content", meta_content: bytes = b'{"meta":true}', status: int = 200):
+    """A mock httpx client whose .stream yields the metadata body then the file body.
+
+    handle() streams metadata first (asset_url) then the file (<asset_url>/download),
+    so distinct bodies let tests verify each independently.
+    """
     mock_client = MagicMock()
-
-    meta_response = MagicMock()
-    meta_response.status_code = 200
-    meta_response.content = b"{}"
-    mock_client.get.return_value = meta_response
-
-    stream_response = MagicMock()
-    stream_response.status_code = status
-    stream_response.iter_bytes.return_value = [content]
-    stream_cm = MagicMock()
-    stream_cm.__enter__ = MagicMock(return_value=stream_response)
-    stream_cm.__exit__ = MagicMock(return_value=False)
-    mock_client.stream.return_value = stream_cm
+    mock_client.stream.side_effect = [_stream_cm(meta_content, 200), _stream_cm(content, status)]
     return mock_client
 
 
-def _set_handler_env(mock_env, tmp_path):
+def _set_handler_env(mock_env, tmp_path, *, allow_private=True, skip_confirm=True):
     """Populate the patched ENV with concrete (non-MagicMock) values the handler reads."""
     mock_env.HCLI_KE_DOWNLOADS_DIR = str(tmp_path)
     mock_env.HCLI_KE_DOWNLOADS_RETENTION_DAYS = 3
     mock_env.HCLI_KE_MAX_DOWNLOAD_MB = 0
-    mock_env.HCLI_KE_SKIP_CONFIRM = True
-    mock_env.HCLI_KE_ALLOW_PRIVATE_HOSTS = True
+    mock_env.HCLI_KE_SKIP_CONFIRM = skip_confirm
+    mock_env.HCLI_KE_ALLOW_PRIVATE_HOSTS = allow_private
 
 
 class TestHandleKeUrl:
@@ -403,11 +406,12 @@ class TestHandleKeUrl:
             _set_handler_env(mock_env, tmp_path)
             KEURLHandler().handle(uri, parsed, no_launch=True, timeout=120.0, skip_analysis=False)
 
-        # File and its .ke.json sidecar land under the url-hash namespace dir.
+        # File and its .ke.json sidecar land under the url-hash namespace dir, each
+        # with its own body (so a broken metadata path can't masquerade as the file).
         downloaded = tmp_path / _ns(ASSET_URL) / "test.i64"
-        assert downloaded.exists()
+        sidecar = tmp_path / _ns(ASSET_URL) / "test.i64.ke.json"
         assert downloaded.read_bytes() == b"file content"
-        assert (tmp_path / _ns(ASSET_URL) / "test.i64.ke.json").exists()
+        assert sidecar.read_bytes() == b'{"meta":true}'
 
     @patch("hcli.lib.ida.handler.ke_url_handler._show_download_dialog", return_value=None)
     @patch("hcli.lib.ida.handler.ke_url_handler._dismiss_dialog")
@@ -444,6 +448,56 @@ class TestHandleKeUrl:
         mock_ipc.send_open_ida_link.assert_called_once_with(
             "/tmp/ida_ipc_1234", "ida://ke/test.i64/functions?ea=0x1000&view=pseudocode"
         )
+
+    @patch("hcli.lib.ida.handler.ke_url_handler._confirm_open_dialog", return_value=True)
+    @patch("hcli.lib.ida.handler.ke_url_handler._show_download_dialog", return_value=None)
+    @patch("hcli.lib.ida.handler.ke_url_handler._dismiss_dialog")
+    @patch("hcli.lib.ida.handler.ke_url_handler._cleanup_old_downloads")
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    @patch("hcli.lib.ida.handler.ke_url_handler.httpx.Client")
+    @patch("hcli.lib.ida.resolve.IDAIPCClient")
+    def test_default_path_pins_ip_and_confirms(
+        self, mock_ipc, mock_client_cls, mock_gai, mock_cleanup, mock_dismiss, mock_dialog, mock_confirm, tmp_path
+    ):
+        """Exercise the SECURITY-CRITICAL DEFAULT path: SSRF validation + IP pinning ON
+        and the confirm-before-open gate ON (not the relaxed test-only config)."""
+        from hcli.lib.ida.ipc import IDAInstance
+
+        # url= host resolves to a public IP, so the SSRF guard passes and pinning engages.
+        mock_gai.return_value = [(2, 1, 6, "", ("93.184.216.34", 443))]
+
+        running = IDAInstance(pid=1234, socket_path="/tmp/ida_ipc_1234", idb_name="test.i64", has_idb=True)
+        mock_ipc.discover_instances.return_value = [running]
+        mock_ipc.query_instance.return_value = running
+        mock_ipc.send_open_ida_link.return_value = (True, "OK")
+
+        mock_client = _mock_httpx_client(b"file content")
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        uri = _ke_link("test.i64", "functions", ASSET_URL, nav="ea=0x1000")
+        parsed = urlparse(uri)
+
+        with (
+            patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env,
+            patch("hcli.lib.ida.handler.ke_url_handler.time.sleep"),
+            patch("hcli.lib.ida.resolve._print"),
+        ):
+            _set_handler_env(mock_env, tmp_path, allow_private=False, skip_confirm=False)
+            KEURLHandler().handle(uri, parsed, no_launch=False, timeout=120.0, skip_analysis=False)
+
+        # The confirm-before-open gate actually ran.
+        mock_confirm.assert_called_once()
+
+        # The file download connected to the validated IP literal, carrying the real
+        # host in the Host header and TLS SNI (the DNS-rebinding pin).
+        file_call = mock_client.stream.call_args_list[-1]
+        assert "93.184.216.34:8080" in file_call.args[1]
+        assert file_call.kwargs["headers"]["Host"] == "host:8080"
+        assert file_call.kwargs["extensions"]["sni_hostname"] == "host"
+
+        # And it still downloaded to the hashed dir.
+        assert (tmp_path / _ns(ASSET_URL) / "test.i64").read_bytes() == b"file content"
 
     @patch("hcli.lib.ida.handler.ke_url_handler._show_error_dialog")
     def test_missing_url_param_aborts(self, mock_error_dialog):

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -8,6 +8,7 @@ from urllib.parse import quote, urlparse
 import click
 import pytest
 
+from hcli.env import ENV as ENV_CLS
 from hcli.lib.ida.handler.ke_url_handler import (
     KEURLHandler,
     _cleanup_old_downloads,
@@ -15,7 +16,9 @@ from hcli.lib.ida.handler.ke_url_handler import (
     _has_nav_params,
     _idb_name_from_path,
     _ns,
+    _pinned_request_args,
     _strip_query_param,
+    _validate_asset_url,
 )
 
 # A representative KE asset base — what KE percent-encodes into the ``url=`` parameter.
@@ -60,6 +63,105 @@ class TestIdbNameFromPath:
 
     def test_empty_path(self):
         assert _idb_name_from_path("") == ""
+
+    def test_rejects_encoded_traversal(self):
+        # %2F-encoded separators survive urlparse and would escape the downloads dir.
+        assert _idb_name_from_path("/..%2F..%2F..%2Fhome%2Fvictim%2F.bashrc/functions") == ""
+
+    def test_rejects_encoded_absolute_path(self):
+        assert _idb_name_from_path("/%2Fetc%2Fcron.d%2Fevil/functions") == ""
+
+    def test_rejects_dotdot(self):
+        assert _idb_name_from_path("/../functions") == ""
+
+    def test_rejects_backslash(self):
+        assert _idb_name_from_path("/a%5Cb/functions") == ""
+
+    def test_rejects_embedded_nul(self):
+        # A NUL would make the later Path.resolve() raise ValueError; reject up front.
+        assert _idb_name_from_path("/foo%00.i64/functions") == ""
+
+
+def _addrinfo(*ips: str):
+    """Build a getaddrinfo-style result list for the given IP strings."""
+    return [(2, 1, 6, "", (ip, 443)) for ip in ips]
+
+
+class TestValidateAssetUrl:
+    """Tests for the SSRF guard / DNS-rebinding pin in _validate_asset_url."""
+
+    def test_rejects_non_http_scheme(self):
+        with pytest.raises(click.ClickException, match="non-HTTP"):
+            _validate_asset_url("file:///etc/passwd")
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(click.ClickException, match="no host"):
+            _validate_asset_url("http:///path/only")
+
+    def test_rejects_malformed_port(self):
+        # parsed.port raises ValueError — must surface as a clean ClickException.
+        with pytest.raises(click.ClickException, match="Invalid asset URL"):
+            _validate_asset_url("http://host:notaport/x")
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_rejects_loopback(self, mock_gai):
+        mock_gai.return_value = _addrinfo("127.0.0.1")
+        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
+            with pytest.raises(click.ClickException, match="non-public"):
+                _validate_asset_url("http://evil.example/x")
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_rejects_link_local_metadata(self, mock_gai):
+        mock_gai.return_value = _addrinfo("169.254.169.254")
+        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
+            with pytest.raises(click.ClickException, match="non-public"):
+                _validate_asset_url("http://metadata.example/x")
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_rejects_cgnat(self, mock_gai):
+        mock_gai.return_value = _addrinfo("100.64.1.1")
+        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
+            with pytest.raises(click.ClickException, match="non-public"):
+                _validate_asset_url("http://cgnat.example/x")
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_rejects_when_any_resolved_ip_is_private(self, mock_gai):
+        # A host that returns one public + one private IP must be rejected (rebinding hedge).
+        mock_gai.return_value = _addrinfo("93.184.216.34", "10.0.0.5")
+        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
+            with pytest.raises(click.ClickException, match="non-public"):
+                _validate_asset_url("http://mixed.example/x")
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_returns_pinned_ip_for_public_host(self, mock_gai):
+        mock_gai.return_value = _addrinfo("93.184.216.34")
+        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
+            assert _validate_asset_url("https://public.example/x") == "93.184.216.34"
+
+    def test_returns_none_when_private_hosts_allowed(self):
+        # Opt-out: no resolution, no pinning — preserves self-hosted/internal KE.
+        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", True):
+            assert _validate_asset_url("http://internal-ke.lan:8080/x") is None
+
+
+class TestPinnedRequestArgs:
+    """Tests for the IP-pinning rewrite that defeats DNS rebinding at fetch time."""
+
+    def test_none_pin_passes_through(self):
+        url, kwargs = _pinned_request_args("https://host:8080/a/b", None)
+        assert url == "https://host:8080/a/b"
+        assert kwargs == {}
+
+    def test_pins_ip_and_preserves_host_and_sni(self):
+        url, kwargs = _pinned_request_args("https://host.example:8080/a/b", "93.184.216.34")
+        assert url == "https://93.184.216.34:8080/a/b"
+        assert kwargs["headers"]["Host"] == "host.example:8080"
+        assert kwargs["extensions"]["sni_hostname"] == "host.example"
+
+    def test_pins_ipv6_with_brackets(self):
+        url, kwargs = _pinned_request_args("http://host.example/a", "2606:2800:220:1:248:1893:25c8:1946")
+        assert url == "http://[2606:2800:220:1:248:1893:25c8:1946]/a"
+        assert kwargs["extensions"]["sni_hostname"] == "host.example"
 
 
 class TestNs:

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -16,6 +16,7 @@ from hcli.lib.ida.handler.ke_url_handler import (
     _confirm_open_dialog,
     _default_downloads_dir,
     _download_url,
+    _escape_dialog_markup,
     _has_nav_params,
     _idb_name_from_path,
     _ns,
@@ -145,6 +146,36 @@ class TestConfirmOpenDialog:
             patch("hcli.lib.ida.handler.ke_url_handler.subprocess.run", side_effect=FileNotFoundError("no powershell")),
         ):
             assert _confirm_open_dialog("chall.i64", "ke.example.com") is False
+
+
+class TestConfirmDialogMarkupEscaping:
+    """zenity renders --text as Pango markup and kdialog renders Qt rich text, so the
+    attacker-controlled host/filename in the consent prompt must be escaped."""
+
+    def test_escape_helper_neutralizes_markup(self):
+        assert _escape_dialog_markup("a<b>&'c") == "a&lt;b&gt;&amp;'c"
+
+    def test_linux_confirm_escapes_attacker_host_and_filename(self):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return SimpleNamespace(returncode=0)
+
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", False),
+            patch("hcli.lib.ida.handler.ke_url_handler.platform.system", return_value="Linux"),
+            patch(
+                "hcli.lib.ida.handler.ke_url_handler.shutil.which",
+                side_effect=lambda c: "/usr/bin/zenity" if c == "zenity" else None,
+            ),
+            patch("hcli.lib.ida.handler.ke_url_handler.subprocess.run", side_effect=fake_run),
+        ):
+            _confirm_open_dialog("evil<b>.i64", "evil.com<span foreground='red'>SAFE</span>")
+
+        text_arg = next(a for a in captured["cmd"] if a.startswith("--text="))
+        assert "<span" not in text_arg and "<b>" not in text_arg  # raw markup neutralized
+        assert "&lt;span" in text_arg and "&lt;b&gt;" in text_arg  # escaped form present
 
 
 class TestDownloadMetadataCap:
@@ -362,6 +393,18 @@ class TestValidateAssetUrl:
             _validate_asset_url("http://metadata.example/x")
 
     @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_rejects_teredo(self, mock_gai):
+        # Teredo (2001::/32) can tunnel to an embedded IPv4 the OS will reach, and its
+        # is_reserved/is_private classification is incomplete before 3.11 — block the
+        # whole prefix. 2001:0:7f00:0001:: embeds server IPv4 127.0.0.1.
+        mock_gai.return_value = _addrinfo("2001:0:7f00:0001::")
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False),
+            pytest.raises(click.ClickException, match="non-public"),
+        ):
+            _validate_asset_url("http://teredo.example/x")
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
     def test_rejects_when_any_resolved_ip_is_private(self, mock_gai):
         # A host that returns one public + one private IP must be rejected (rebinding hedge).
         mock_gai.return_value = _addrinfo("93.184.216.34", "10.0.0.5")
@@ -466,17 +509,16 @@ class TestCleanupOldDownloads:
         new_file.write_text("new")
 
         with patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env:
-            mock_env.HCLI_KE_DOWNLOADS_DIR = str(tmp_path)
             mock_env.HCLI_KE_DOWNLOADS_RETENTION_DAYS = 3
-            _cleanup_old_downloads()
+            _cleanup_old_downloads(tmp_path)
 
         assert not old_file.exists()
         assert new_file.exists()
 
     def test_cleanup_nonexistent_dir(self, tmp_path):
         with patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env:
-            mock_env.HCLI_KE_DOWNLOADS_DIR = str(tmp_path / "nonexistent")
-            _cleanup_old_downloads()  # should not raise
+            mock_env.HCLI_KE_DOWNLOADS_RETENTION_DAYS = 3
+            _cleanup_old_downloads(tmp_path / "nonexistent")  # should not raise
 
 
 def _stream_cm(content: bytes, status: int = 200):

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -200,6 +200,38 @@ class TestDownloadMetadataCap:
         assert sidecar.read_bytes() == b'{"ok": true}'
 
 
+class TestDownloadFileDiskGuard:
+    def test_aborts_and_cleans_up_when_disk_nearly_full(self, tmp_path):
+        # Even with no size cap, the download must not fill the disk: when free space
+        # is below the reserve, it aborts and removes the partial file.
+        from types import SimpleNamespace
+
+        from hcli.lib.ida.handler import ke_url_handler
+
+        dest = tmp_path / "big.i64"
+        stream_response = MagicMock()
+        stream_response.status_code = 200
+        stream_response.iter_bytes.return_value = [b"x" * 4096]
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=stream_response)
+        cm.__exit__ = MagicMock(return_value=False)
+        client = MagicMock()
+        client.stream.return_value = cm
+
+        with (
+            patch(
+                "hcli.lib.ida.handler.ke_url_handler.shutil.disk_usage",
+                return_value=SimpleNamespace(total=0, used=0, free=1024),  # only 1 KB free
+            ),
+            patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env,
+            pytest.raises(click.ClickException, match="disk space"),
+        ):
+            mock_env.HCLI_KE_MAX_DOWNLOAD_MB = 0
+            ke_url_handler._download_file(client, "https://h/a/download", dest, None)
+
+        assert not dest.exists()  # partial file removed
+
+
 class TestIdbNameFromPath:
     def test_first_segment_is_the_idb(self):
         assert _idb_name_from_path("/test.i64/functions") == "test.i64"
@@ -568,9 +600,10 @@ class TestHandleKeUrl:
             KEURLHandler().handle(uri, parsed, no_launch=False, timeout=120.0, skip_analysis=False)
 
         mock_confirm.assert_called_once()
-        # No HTTP request was made and nothing landed under the downloads dir.
+        # No HTTP request, no cleanup, and no directory creation — zero FS side effects.
         mock_client.stream.assert_not_called()
-        assert not (tmp_path / _ns(ASSET_URL)).exists() or not any((tmp_path / _ns(ASSET_URL)).iterdir())
+        mock_cleanup.assert_not_called()
+        assert not (tmp_path / _ns(ASSET_URL)).exists()
 
     @patch("hcli.lib.ida.handler.ke_url_handler._show_error_dialog")
     def test_missing_url_param_aborts(self, mock_error_dialog):

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -2,6 +2,7 @@
 
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from urllib.parse import quote, urlparse
 
@@ -487,6 +488,78 @@ def _stream_cm(content: bytes, status: int = 200):
     cm.__enter__ = MagicMock(return_value=response)
     cm.__exit__ = MagicMock(return_value=False)
     return cm
+
+
+def _redirect_cm(location: str, status: int = 302):
+    """A mock streaming-response context manager for a 3xx redirect to *location*."""
+    response = MagicMock()
+    response.status_code = status
+    response.headers = {"location": location}  # real dict so the "location" lookup works
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=response)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+class TestDownloadRedirects:
+    """A 3xx (e.g. KE -> object storage) must be followed, but every hop re-checked
+    through the SSRF guard so it can't be steered to a private/loopback address."""
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.shutil.disk_usage")
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_follows_redirect_to_public_host(self, mock_gai, mock_disk, tmp_path):
+        from hcli.lib.ida.handler import ke_url_handler
+
+        mock_gai.return_value = _addrinfo("93.184.216.34")  # redirect target resolves public
+        mock_disk.return_value = SimpleNamespace(total=0, used=0, free=10**12)
+        dest = tmp_path / "f.i64"
+        client = MagicMock()
+        client.stream.side_effect = [_redirect_cm("https://cdn.example/blob"), _stream_cm(b"REAL BODY", 200)]
+
+        with patch("hcli.lib.ida.handler.ke_url_handler.ENV") as env:
+            env.HCLI_KE_MAX_DOWNLOAD_MB = 0
+            env.HCLI_KE_ALLOW_PRIVATE_HOSTS = False
+            ke_url_handler._download_file(client, "https://host/a/download", dest, ["93.184.216.34"])
+
+        assert dest.read_bytes() == b"REAL BODY"
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_rejects_redirect_to_internal_host(self, mock_gai, tmp_path):
+        from hcli.lib.ida.handler import ke_url_handler
+
+        # The redirect target resolves to the cloud metadata service — must be blocked.
+        mock_gai.return_value = _addrinfo("169.254.169.254")
+        dest = tmp_path / "f.i64"
+        client = MagicMock()
+        client.stream.side_effect = [
+            _redirect_cm("http://evil.example/internal"),
+            _stream_cm(b"SHOULD NOT REACH", 200),
+        ]
+
+        with patch("hcli.lib.ida.handler.ke_url_handler.ENV") as env:
+            env.HCLI_KE_MAX_DOWNLOAD_MB = 0
+            env.HCLI_KE_ALLOW_PRIVATE_HOSTS = False
+            with pytest.raises(click.ClickException, match="non-public"):
+                ke_url_handler._download_file(client, "https://host/a/download", dest, ["93.184.216.34"])
+
+        assert not dest.exists()  # nothing written
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_aborts_on_redirect_loop(self, mock_gai, tmp_path):
+        from hcli.lib.ida.handler import ke_url_handler
+
+        mock_gai.return_value = _addrinfo("93.184.216.34")  # every hop is "public", just endless
+        dest = tmp_path / "f.i64"
+        client = MagicMock()
+        client.stream.side_effect = [
+            _redirect_cm("https://pub.example/x") for _ in range(ke_url_handler._MAX_REDIRECTS + 2)
+        ]
+
+        with patch("hcli.lib.ida.handler.ke_url_handler.ENV") as env:
+            env.HCLI_KE_MAX_DOWNLOAD_MB = 0
+            env.HCLI_KE_ALLOW_PRIVATE_HOSTS = False
+            with pytest.raises(click.ClickException, match="too many redirects"):
+                ke_url_handler._download_file(client, "https://host/a/download", dest, ["93.184.216.34"])
 
 
 def _mock_httpx_client(content: bytes = b"file content", meta_content: bytes = b'{"meta":true}', status: int = 200):

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -100,6 +100,58 @@ class TestConfirmOpenDialog:
         ):
             assert _confirm_open_dialog("chall.i64", "ke.example.com") is False
 
+    def test_unknown_platform_proceeds_without_silent_failopen(self):
+        # A platform with no scriptable dialog proceeds (consent = the launcher click)
+        # but emits a notice rather than silently auto-opening.
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", False),
+            patch("hcli.lib.ida.handler.ke_url_handler.platform.system", return_value="FreeBSD"),
+            patch("hcli.lib.ida.handler.ke_url_handler.shutil.which", return_value=None),
+            patch("hcli.lib.ida.handler.ke_url_handler._print") as mock_print,
+        ):
+            assert _confirm_open_dialog("chall.i64", "ke.example.com") is True
+            assert mock_print.called  # user was told confirmation was skipped
+
+    def test_macos_dialog_error_fails_closed(self):
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", False),
+            patch("hcli.lib.ida.handler.ke_url_handler.platform.system", return_value="Darwin"),
+            patch("hcli.lib.ida.handler.ke_url_handler.subprocess.run", side_effect=OSError("no osascript")),
+        ):
+            assert _confirm_open_dialog("chall.i64", "ke.example.com") is False
+
+    def test_windows_dialog_error_fails_closed(self):
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", False),
+            patch("hcli.lib.ida.handler.ke_url_handler.platform.system", return_value="Windows"),
+            patch("hcli.lib.ida.handler.ke_url_handler.subprocess.run", side_effect=FileNotFoundError("no powershell")),
+        ):
+            assert _confirm_open_dialog("chall.i64", "ke.example.com") is False
+
+
+class TestDownloadMetadataCap:
+    def test_oversized_metadata_skips_sidecar(self, tmp_path):
+        # The metadata fetch is bounded independently of HCLI_KE_MAX_DOWNLOAD_MB so a
+        # huge attacker body cannot exhaust memory/disk via the .ke.json sidecar.
+        from hcli.lib.ida.handler import ke_url_handler
+
+        sidecar = tmp_path / "x.ke.json"
+        huge = b"A" * (ke_url_handler._METADATA_MAX_BYTES + 1)
+
+        stream_response = MagicMock()
+        stream_response.status_code = 200
+        stream_response.iter_bytes.return_value = [huge]
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=stream_response)
+        cm.__exit__ = MagicMock(return_value=False)
+        client = MagicMock()
+        client.stream.return_value = cm
+
+        with patch("hcli.lib.ida.handler.ke_url_handler._print"):
+            ke_url_handler._download_metadata(client, "https://h/a", sidecar, None)
+
+        assert not sidecar.exists()  # refused to write the oversized body
+
 
 class TestIdbNameFromPath:
     def test_first_segment_is_the_idb(self):
@@ -186,7 +238,14 @@ class TestValidateAssetUrl:
     def test_returns_pinned_ip_for_public_host(self, mock_gai):
         mock_gai.return_value = _addrinfo("93.184.216.34")
         with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
-            assert _validate_asset_url("https://public.example/x") == "93.184.216.34"
+            assert _validate_asset_url("https://public.example/x") == ["93.184.216.34"]
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_returns_all_public_ips_deduped_for_failover(self, mock_gai):
+        # All validated IPs are returned (deduped) so the download can fail over.
+        mock_gai.return_value = _addrinfo("93.184.216.34", "93.184.216.35", "93.184.216.34")
+        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
+            assert _validate_asset_url("https://public.example/x") == ["93.184.216.34", "93.184.216.35"]
 
     def test_returns_none_when_private_hosts_allowed(self):
         # Opt-out: no resolution, no pinning — preserves self-hosted/internal KE.

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -58,6 +58,15 @@ class TestMatches:
         parsed = urlparse("ida://evil/test.i64/functions?url=http://attacker/x")
         assert KEURLHandler().matches(parsed) is False
 
+    def test_non_ida_scheme_not_detected(self):
+        parsed = urlparse("http://ke/test.i64/functions?url=http://attacker/x")
+        assert KEURLHandler().matches(parsed) is False
+
+    def test_too_few_path_segments_not_detected(self):
+        # Documented shape is ida://ke/<idb>/<resource>; fewer than two segments isn't it.
+        parsed = urlparse("ida://ke/test.i64?url=http://attacker/x")
+        assert KEURLHandler().matches(parsed) is False
+
 
 class TestDownloadUrl:
     def test_appends_download_segment(self):
@@ -80,14 +89,15 @@ class TestConfirmOpenDialog:
             assert _confirm_open_dialog("chall.i64", "ke.example.com") is True
             mock_run.assert_not_called()
 
-    def test_linux_without_gui_tool_proceeds(self):
+    def test_linux_without_gui_tool_fails_closed(self):
+        # No zenity/kdialog → cannot get consent → must NOT auto-open (fail closed).
         with (
             patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", False),
             patch("hcli.lib.ida.handler.ke_url_handler.platform.system", return_value="Linux"),
             patch("hcli.lib.ida.handler.ke_url_handler.shutil.which", return_value=None),
             patch("hcli.lib.ida.handler.ke_url_handler._print"),
         ):
-            assert _confirm_open_dialog("chall.i64", "ke.example.com") is True
+            assert _confirm_open_dialog("chall.i64", "ke.example.com") is False
 
     def test_linux_zenity_decline_denies(self):
         completed = MagicMock()
@@ -103,17 +113,16 @@ class TestConfirmOpenDialog:
         ):
             assert _confirm_open_dialog("chall.i64", "ke.example.com") is False
 
-    def test_unknown_platform_proceeds_without_silent_failopen(self):
-        # A platform with no scriptable dialog proceeds (consent = the launcher click)
-        # but emits a notice rather than silently auto-opening.
+    def test_unknown_platform_fails_closed(self):
+        # A platform with no scriptable dialog cannot get consent → fail closed.
         with (
             patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", False),
             patch("hcli.lib.ida.handler.ke_url_handler.platform.system", return_value="FreeBSD"),
             patch("hcli.lib.ida.handler.ke_url_handler.shutil.which", return_value=None),
             patch("hcli.lib.ida.handler.ke_url_handler._print") as mock_print,
         ):
-            assert _confirm_open_dialog("chall.i64", "ke.example.com") is True
-            assert mock_print.called  # user was told confirmation was skipped
+            assert _confirm_open_dialog("chall.i64", "ke.example.com") is False
+            assert mock_print.called  # user was told how to enable opening
 
     def test_macos_dialog_error_fails_closed(self):
         with (
@@ -154,6 +163,41 @@ class TestDownloadMetadataCap:
             ke_url_handler._download_metadata(client, "https://h/a", sidecar, None)
 
         assert not sidecar.exists()  # refused to write the oversized body
+
+    def test_non_json_metadata_skips_sidecar(self, tmp_path):
+        # The .ke.json sidecar must only persist valid JSON, not arbitrary 200 bodies.
+        from hcli.lib.ida.handler import ke_url_handler
+
+        sidecar = tmp_path / "x.ke.json"
+        stream_response = MagicMock()
+        stream_response.status_code = 200
+        stream_response.iter_bytes.return_value = [b"<html>not json</html>"]
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=stream_response)
+        cm.__exit__ = MagicMock(return_value=False)
+        client = MagicMock()
+        client.stream.return_value = cm
+
+        with patch("hcli.lib.ida.handler.ke_url_handler._print"):
+            ke_url_handler._download_metadata(client, "https://h/a", sidecar, None)
+
+        assert not sidecar.exists()  # non-JSON body rejected
+
+    def test_valid_json_metadata_is_written(self, tmp_path):
+        from hcli.lib.ida.handler import ke_url_handler
+
+        sidecar = tmp_path / "x.ke.json"
+        stream_response = MagicMock()
+        stream_response.status_code = 200
+        stream_response.iter_bytes.return_value = [b'{"ok": true}']
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=stream_response)
+        cm.__exit__ = MagicMock(return_value=False)
+        client = MagicMock()
+        client.stream.return_value = cm
+
+        ke_url_handler._download_metadata(client, "https://h/a", sidecar, None)
+        assert sidecar.read_bytes() == b'{"ok": true}'
 
 
 class TestIdbNameFromPath:
@@ -498,6 +542,35 @@ class TestHandleKeUrl:
 
         # And it still downloaded to the hashed dir.
         assert (tmp_path / _ns(ASSET_URL) / "test.i64").read_bytes() == b"file content"
+
+    @patch("hcli.lib.ida.handler.ke_url_handler._confirm_open_dialog", return_value=False)
+    @patch("hcli.lib.ida.handler.ke_url_handler._show_download_dialog", return_value=None)
+    @patch("hcli.lib.ida.handler.ke_url_handler._dismiss_dialog")
+    @patch("hcli.lib.ida.handler.ke_url_handler._cleanup_old_downloads")
+    @patch("hcli.lib.ida.handler.ke_url_handler.httpx.Client")
+    def test_declined_confirmation_downloads_nothing(
+        self, mock_client_cls, mock_cleanup, mock_dismiss, mock_dialog, mock_confirm, tmp_path
+    ):
+        """A passive (declined) ida://ke/... click must write NOTHING to disk — the
+        confirm gate runs before any download, killing the drive-by disk-fill."""
+        mock_client = _mock_httpx_client(b"file content")
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        uri = _ke_link("test.i64", "functions", ASSET_URL, nav="ea=0x1000")
+        parsed = urlparse(uri)
+
+        with (
+            patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env,
+            patch("hcli.lib.ida.handler.ke_url_handler.time.sleep"),
+        ):
+            _set_handler_env(mock_env, tmp_path, allow_private=True, skip_confirm=False)
+            KEURLHandler().handle(uri, parsed, no_launch=False, timeout=120.0, skip_analysis=False)
+
+        mock_confirm.assert_called_once()
+        # No HTTP request was made and nothing landed under the downloads dir.
+        mock_client.stream.assert_not_called()
+        assert not (tmp_path / _ns(ASSET_URL)).exists() or not any((tmp_path / _ns(ASSET_URL)).iterdir())
 
     @patch("hcli.lib.ida.handler.ke_url_handler._show_error_dialog")
     def test_missing_url_param_aborts(self, mock_error_dialog):

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -62,10 +62,15 @@ class TestMatches:
         parsed = urlparse("http://ke/test.i64/functions?url=http://attacker/x")
         assert KEURLHandler().matches(parsed) is False
 
-    def test_too_few_path_segments_not_detected(self):
-        # Documented shape is ida://ke/<idb>/<resource>; fewer than two segments isn't it.
-        parsed = urlparse("ida://ke/test.i64?url=http://attacker/x")
+    def test_no_path_segment_not_detected(self):
+        # No <idb> segment at all isn't a KE link.
+        parsed = urlparse("ida://ke/?url=http://attacker/x")
         assert KEURLHandler().matches(parsed) is False
+
+    def test_single_segment_open_only_link_detected(self):
+        # An open-only link with just the <idb> segment still routes to KE.
+        parsed = urlparse("ida://ke/test.i64?url=" + quote(ASSET_URL, safe=""))
+        assert KEURLHandler().matches(parsed) is True
 
 
 class TestDownloadUrl:
@@ -230,6 +235,29 @@ class TestDownloadFileDiskGuard:
             ke_url_handler._download_file(client, "https://h/a/download", dest, None)
 
         assert not dest.exists()  # partial file removed
+
+    def test_failed_redownload_preserves_cached_file(self, tmp_path):
+        # A re-download that fails must not destroy a previously-cached good copy:
+        # the download goes to a .part file and only atomically replaces on success.
+        from hcli.lib.ida.handler import ke_url_handler
+
+        dest = tmp_path / "cached.i64"
+        dest.write_bytes(b"GOOD CACHED COPY")
+
+        stream_response = MagicMock()
+        stream_response.status_code = 500  # transient server failure
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=stream_response)
+        cm.__exit__ = MagicMock(return_value=False)
+        client = MagicMock()
+        client.stream.return_value = cm
+
+        with patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env, pytest.raises(click.ClickException):
+            mock_env.HCLI_KE_MAX_DOWNLOAD_MB = 0
+            ke_url_handler._download_file(client, "https://h/a/download", dest, None)
+
+        assert dest.read_bytes() == b"GOOD CACHED COPY"  # untouched
+        assert not (tmp_path / "cached.i64.part").exists()  # partial cleaned up
 
 
 class TestIdbNameFromPath:
@@ -595,12 +623,16 @@ class TestHandleKeUrl:
         with (
             patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env,
             patch("hcli.lib.ida.handler.ke_url_handler.time.sleep"),
+            patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo") as mock_gai,
         ):
-            _set_handler_env(mock_env, tmp_path, allow_private=True, skip_confirm=False)
+            # allow_private=False so a reached _validate_asset_url WOULD resolve — proving
+            # the decline path never gets there (no DNS beacon to the attacker host).
+            _set_handler_env(mock_env, tmp_path, allow_private=False, skip_confirm=False)
             KEURLHandler().handle(uri, parsed, no_launch=False, timeout=120.0, skip_analysis=False)
 
         mock_confirm.assert_called_once()
-        # No HTTP request, no cleanup, and no directory creation — zero FS side effects.
+        # No DNS lookup, no HTTP request, no cleanup, no directory creation.
+        mock_gai.assert_not_called()
         mock_client.stream.assert_not_called()
         mock_cleanup.assert_not_called()
         assert not (tmp_path / _ns(ASSET_URL)).exists()

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -95,7 +95,10 @@ class TestConfirmOpenDialog:
         with (
             patch.object(ENV_CLS, "HCLI_KE_SKIP_CONFIRM", False),
             patch("hcli.lib.ida.handler.ke_url_handler.platform.system", return_value="Linux"),
-            patch("hcli.lib.ida.handler.ke_url_handler.shutil.which", side_effect=lambda c: "/usr/bin/zenity" if c == "zenity" else None),
+            patch(
+                "hcli.lib.ida.handler.ke_url_handler.shutil.which",
+                side_effect=lambda c: "/usr/bin/zenity" if c == "zenity" else None,
+            ),
             patch("hcli.lib.ida.handler.ke_url_handler.subprocess.run", return_value=completed),
         ):
             assert _confirm_open_dialog("chall.i64", "ke.example.com") is False
@@ -208,31 +211,39 @@ class TestValidateAssetUrl:
     @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
     def test_rejects_loopback(self, mock_gai):
         mock_gai.return_value = _addrinfo("127.0.0.1")
-        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
-            with pytest.raises(click.ClickException, match="non-public"):
-                _validate_asset_url("http://evil.example/x")
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False),
+            pytest.raises(click.ClickException, match="non-public"),
+        ):
+            _validate_asset_url("http://evil.example/x")
 
     @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
     def test_rejects_link_local_metadata(self, mock_gai):
         mock_gai.return_value = _addrinfo("169.254.169.254")
-        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
-            with pytest.raises(click.ClickException, match="non-public"):
-                _validate_asset_url("http://metadata.example/x")
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False),
+            pytest.raises(click.ClickException, match="non-public"),
+        ):
+            _validate_asset_url("http://metadata.example/x")
 
     @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
     def test_rejects_cgnat(self, mock_gai):
         mock_gai.return_value = _addrinfo("100.64.1.1")
-        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
-            with pytest.raises(click.ClickException, match="non-public"):
-                _validate_asset_url("http://cgnat.example/x")
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False),
+            pytest.raises(click.ClickException, match="non-public"),
+        ):
+            _validate_asset_url("http://cgnat.example/x")
 
     @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
     def test_rejects_when_any_resolved_ip_is_private(self, mock_gai):
         # A host that returns one public + one private IP must be rejected (rebinding hedge).
         mock_gai.return_value = _addrinfo("93.184.216.34", "10.0.0.5")
-        with patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False):
-            with pytest.raises(click.ClickException, match="non-public"):
-                _validate_asset_url("http://mixed.example/x")
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False),
+            pytest.raises(click.ClickException, match="non-public"),
+        ):
+            _validate_asset_url("http://mixed.example/x")
 
     @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
     def test_returns_pinned_ip_for_public_host(self, mock_gai):
@@ -434,8 +445,12 @@ class TestHandleKeUrl:
             "/tmp/ida_ipc_1234", "ida://ke/test.i64/functions?ea=0x1000&view=pseudocode"
         )
 
-    def test_missing_url_param_aborts(self):
+    @patch("hcli.lib.ida.handler.ke_url_handler._show_error_dialog")
+    def test_missing_url_param_aborts(self, mock_error_dialog):
+        # Patch the native dialog so the rejection path doesn't spawn a real
+        # notify-send/osascript/PowerShell during the test run.
         uri = "ida://ke/test.i64/functions?ea=0x1000"
         parsed = urlparse(uri)
         with pytest.raises(click.Abort):
             KEURLHandler().handle(uri, parsed, False, 120.0, False)
+        mock_error_dialog.assert_called_once()

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -340,6 +340,27 @@ class TestValidateAssetUrl:
             _validate_asset_url("http://cgnat.example/x")
 
     @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_rejects_ipv4_mapped_ipv6_loopback(self, mock_gai):
+        # "::ffff:127.0.0.1" maps to loopback, but ipaddress.is_loopback/is_private
+        # don't flag the ::ffff:0:0/96 range before Python 3.11 — the guard must
+        # recurse into the embedded IPv4 so the bypass is blocked on every version.
+        mock_gai.return_value = _addrinfo("::ffff:127.0.0.1")
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False),
+            pytest.raises(click.ClickException, match="non-public"),
+        ):
+            _validate_asset_url("http://evil.example/x")
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
+    def test_rejects_ipv4_mapped_ipv6_private(self, mock_gai):
+        mock_gai.return_value = _addrinfo("::ffff:169.254.169.254")
+        with (
+            patch.object(ENV_CLS, "HCLI_KE_ALLOW_PRIVATE_HOSTS", False),
+            pytest.raises(click.ClickException, match="non-public"),
+        ):
+            _validate_asset_url("http://metadata.example/x")
+
+    @patch("hcli.lib.ida.handler.ke_url_handler.socket.getaddrinfo")
     def test_rejects_when_any_resolved_ip_is_private(self, mock_gai):
         # A host that returns one public + one private IP must be rejected (rebinding hedge).
         mock_gai.return_value = _addrinfo("93.184.216.34", "10.0.0.5")


### PR DESCRIPTION
Security hardening for the KE "open in IDA" deep-link handler. `ida://` is a system-registered protocol handler, so any web page can launch `hcli ida open <attacker-uri>` — `parsed.path`, `parsed.query`, and the `url=` parameter are fully untrusted.

Addresses the deep-link findings from the protocol-handler security review:

- **Dialog string injection → RCE (CRITICAL):** the untrusted `<idb>` name / error text was interpolated into osascript/PowerShell source. Now passed as data via environment variables (`KE_DLG_FILE`/`KE_DLG_MSG`).
- **Path traversal → arbitrary file write (CRITICAL):** `_idb_name_from_path` now rejects separators, `..`, and NUL/control bytes; plus a containment check refuses any write resolving outside the downloads dir.
- **SSRF (CRITICAL):** `_validate_asset_url` enforces http(s) and blocks private/loopback/link-local/CGNAT addresses, then **pins the validated IP** into the download connection (preserving Host + SNI) so the host can't re-resolve to a blocked address (DNS rebinding).
- **Drive-by auto-open (CRITICAL):** a native confirmation dialog naming the source host is shown before handing downloaded content to IDA. Suppressed with `HCLI_KE_SKIP_CONFIRM`. macOS/Windows fail closed; Linux uses zenity/kdialog.
- **Naive download-URL concat:** `<asset>/download` is spliced into the path component (preserves query/fragment).
- **Unbounded download:** the file streams to disk instead of buffering; optional `HCLI_KE_MAX_DOWNLOAD_MB` cap; partial file removed on failure.
- **Lenient matcher:** requires the documented `ida://ke/...` host in addition to `url=`.

## Tests
`tests/lib/test_ke.py` — 57 passed (validation, IP-pinning, traversal/NUL rejection, confirm-dialog logic, streaming download).

## Notes
- Confirm-on-open defaults to enabled; flag with the KE product team if one-click is required (env opt-out provided).
- New env vars: `HCLI_KE_ALLOW_PRIVATE_HOSTS`, `HCLI_KE_SKIP_CONFIRM`, `HCLI_KE_MAX_DOWNLOAD_MB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)