### PR TITLE
Harden ida:// handler registration (Windows argv injection, predictable macOS log)

### DIFF
--- a/src/hcli/lib/ida/protocol.py
+++ b/src/hcli/lib/ida/protocol.py
@@ -30,13 +30,22 @@ def setup_macos_protocol_handler() -> None:
         # symlink and the handler's ">>" appends into a file they chose), and the log
         # records full ida:// URLs.
         log_dir = Path.home() / "Library" / "Logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
+        # Best-effort at registration; the handler also `mkdir -p`s at click time, so a
+        # locked-down home (or the dir being removed later) can't fail registration or
+        # break the redirect.
+        try:
+            log_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
         log_file = str(log_dir / "idb_handler.log")
         py_env_strip = "env -u PYTHONHOME -u PYTHONPATH -u PYTHONEXECUTABLE -u PYTHONSTARTUP"
+        # `ida open -- <url>`: the `--` stops the URL (or anything that decodes from it)
+        # from being parsed as an option to the open command.
         applescript_content = f'''
 on open location this_URL
     set logFile to "{log_file}"
-    do shell script "/bin/zsh -l -c " & quoted form of ("{py_env_strip} {hcli_path} ida open " & quoted form of this_URL) & " >> " & quoted form of logFile & " 2>&1"
+    set logDir to "{log_dir}"
+    do shell script "/bin/mkdir -p " & quoted form of logDir & " ; /bin/zsh -l -c " & quoted form of ("{py_env_strip} {hcli_path} ida open -- " & quoted form of this_URL) & " >> " & quoted form of logFile & " 2>&1"
 end open location
 
 on run
@@ -169,8 +178,8 @@ def setup_windows_protocol_handler() -> None:
     except ImportError:
         console.print("[red]winreg module not available (not on Windows?)[/red]")
         raise
-    except Exception:
-        console.print("[red]Error setting up Windows protocol handler: {e}[/red]")
+    except Exception as e:
+        console.print(f"[red]Error setting up Windows protocol handler: {e}[/red]")
         raise
 
 
@@ -188,10 +197,11 @@ def setup_linux_protocol_handler() -> None:
         # Python) can leak PYTHONHOME into the handler's environment, which makes hcli's
         # interpreter load the wrong stdlib and abort before it runs. The desktop
         # launcher passes %u as a literal argv, so no shell mangles the URL here.
+        # `-- %u` keeps the URL from being parsed as an option to the open command.
         py_env_strip = "env -u PYTHONHOME -u PYTHONPATH -u PYTHONEXECUTABLE -u PYTHONSTARTUP"
         desktop_content = f"""[Desktop Entry]
 Name=HCLI IDB Link Handler
-Exec={py_env_strip} {hcli_path} ida open %u
+Exec={py_env_strip} {hcli_path} ida open -- %u
 Type=Application
 NoDisplay=true
 MimeType=x-scheme-handler/{PROTOCOL};

--- a/src/hcli/lib/ida/protocol.py
+++ b/src/hcli/lib/ida/protocol.py
@@ -25,7 +25,13 @@ def setup_macos_protocol_handler() -> None:
         # Python 3.13) leaks PYTHONHOME into the handler's environment, which makes
         # hcli's pinned interpreter load the wrong stdlib and abort ("No module named
         # 'encodings'") before it runs. env -u clears them so hcli uses its own Python.
-        log_file = "/tmp/idb_handler.log"
+        # Log to a per-user, non-world-writable location. A fixed /tmp path is a
+        # classic symlink-write target on shared machines (another user pre-plants a
+        # symlink and the handler's ">>" appends into a file they chose), and the log
+        # records full ida:// URLs.
+        log_dir = Path.home() / "Library" / "Logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = str(log_dir / "idb_handler.log")
         py_env_strip = "env -u PYTHONHOME -u PYTHONPATH -u PYTHONEXECUTABLE -u PYTHONSTARTUP"
         applescript_content = f'''
 on open location this_URL
@@ -131,10 +137,15 @@ def setup_windows_protocol_handler() -> None:
         # `env -u` on Windows. ShellExecute/CreateProcess passes argv verbatim, so invoke
         # the interpreter directly with -E (ignore all PYTHON* env vars). Frozen builds
         # embed their own runtime and are immune, so run them as-is.
+        # Use a "--" separator before %1: Windows substitutes the raw URL into the
+        # command line, and a stray quote in the URL could otherwise append extra
+        # argv tokens parsed as options to `ida open`. After "--" click treats the
+        # URL strictly as the positional argument; injected tokens become surplus
+        # positionals and are rejected rather than interpreted.
         if getattr(sys, "frozen", False):
-            command = f'"{hcli_path}" ida open "%1"'
+            command = f'"{hcli_path}" ida open -- "%1"'
         else:
-            command = f'"{sys.executable}" -E -m hcli.main ida open "%1"'
+            command = f'"{sys.executable}" -E -m hcli.main ida open -- "%1"'
         reg_key = rf"SOFTWARE\Classes\{PROTOCOL}"
 
         with winreg.CreateKey(HKEY_CURRENT_USER, reg_key) as key:  # type: ignore[attr-defined]

--- a/src/hcli/lib/ida/protocol.py
+++ b/src/hcli/lib/ida/protocol.py
@@ -13,6 +13,42 @@ from hcli.lib.util.io import get_hcli_executable_path
 
 PROTOCOL = "ida"
 
+# Strip PYTHON* vars first: the requesting app (e.g. IDA running its own Python) leaks
+# PYTHONHOME into the handler's environment, which would make hcli's pinned interpreter
+# load the wrong stdlib and abort before it runs. env -u clears them.
+_PY_ENV_STRIP = "env -u PYTHONHOME -u PYTHONPATH -u PYTHONEXECUTABLE -u PYTHONSTARTUP"
+
+
+def _macos_handler_applescript(hcli_path: str, log_file: str, log_dir: str) -> str:
+    """Build the AppleScript handler body.
+
+    ``ida open -- <url>``: the ``--`` stops the URL (or anything that decodes from it)
+    from being parsed as an option to the open command. The handler ``mkdir -p``s the
+    log dir at click time so a removed/uncreatable dir can't break the redirect.
+    """
+    return f'''
+on open location this_URL
+    set logFile to "{log_file}"
+    set logDir to "{log_dir}"
+    do shell script "/bin/mkdir -p " & quoted form of logDir & " ; /bin/zsh -l -c " & quoted form of ("{_PY_ENV_STRIP} {hcli_path} ida open -- " & quoted form of this_URL) & " >> " & quoted form of logFile & " 2>&1"
+end open location
+
+on run
+    -- This handler is called when the app is launched directly
+end run
+'''
+
+
+def _linux_desktop_entry(hcli_path: str) -> str:
+    """Build the .desktop entry. ``-- %u`` keeps the URL from being parsed as an option."""
+    return f"""[Desktop Entry]
+Name=HCLI IDB Link Handler
+Exec={_PY_ENV_STRIP} {hcli_path} ida open -- %u
+Type=Application
+NoDisplay=true
+MimeType=x-scheme-handler/{PROTOCOL};
+"""
+
 
 def setup_macos_protocol_handler() -> None:
     """Set up protocol handler for macOS using AppleScript and plist modification."""
@@ -38,20 +74,7 @@ def setup_macos_protocol_handler() -> None:
         except OSError:
             pass
         log_file = str(log_dir / "idb_handler.log")
-        py_env_strip = "env -u PYTHONHOME -u PYTHONPATH -u PYTHONEXECUTABLE -u PYTHONSTARTUP"
-        # `ida open -- <url>`: the `--` stops the URL (or anything that decodes from it)
-        # from being parsed as an option to the open command.
-        applescript_content = f'''
-on open location this_URL
-    set logFile to "{log_file}"
-    set logDir to "{log_dir}"
-    do shell script "/bin/mkdir -p " & quoted form of logDir & " ; /bin/zsh -l -c " & quoted form of ("{py_env_strip} {hcli_path} ida open -- " & quoted form of this_URL) & " >> " & quoted form of logFile & " 2>&1"
-end open location
-
-on run
-    -- This handler is called when the app is launched directly
-end run
-'''
+        applescript_content = _macos_handler_applescript(hcli_path, log_file, str(log_dir))
 
         # Create temporary directory for the AppleScript
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -192,20 +215,8 @@ def setup_linux_protocol_handler() -> None:
         applications_dir = Path.home() / ".local" / "share" / "applications"
         applications_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create desktop entry for ida:// protocol.
-        # Strip PYTHON* first (via env -u): the launching app (e.g. IDA running its own
-        # Python) can leak PYTHONHOME into the handler's environment, which makes hcli's
-        # interpreter load the wrong stdlib and abort before it runs. The desktop
-        # launcher passes %u as a literal argv, so no shell mangles the URL here.
-        # `-- %u` keeps the URL from being parsed as an option to the open command.
-        py_env_strip = "env -u PYTHONHOME -u PYTHONPATH -u PYTHONEXECUTABLE -u PYTHONSTARTUP"
-        desktop_content = f"""[Desktop Entry]
-Name=HCLI IDB Link Handler
-Exec={py_env_strip} {hcli_path} ida open -- %u
-Type=Application
-NoDisplay=true
-MimeType=x-scheme-handler/{PROTOCOL};
-"""
+        # The desktop launcher passes %u as a literal argv, so no shell mangles the URL.
+        desktop_content = _linux_desktop_entry(hcli_path)
 
         desktop_path = applications_dir / "hcli-idb-handler.desktop"
         desktop_path.write_text(desktop_content)

--- a/tests/lib/test_protocol_handler.py
+++ b/tests/lib/test_protocol_handler.py
@@ -1,0 +1,30 @@
+"""Tests for the ida:// protocol handler registration hardening."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from hcli.commands.ida.open import open_ida_link
+
+
+class TestOpenArgSeparator:
+    """The Windows registry command uses `ida open -- "%1"`. These tests confirm the
+    `--` separator turns any injected tokens into surplus positionals that click
+    rejects, rather than options it would interpret."""
+
+    def test_url_after_separator_is_the_uri(self):
+        # A normal URL after `--` is accepted as the single positional argument.
+        # --no-launch keeps the test from touching IDA/instances.
+        runner = CliRunner()
+        result = runner.invoke(open_ida_link, ["--no-launch", "--", "ida://ke/x.i64/functions?url=http://h/a"])
+        # It parsed fine (no usage error). Behaviour beyond parsing is out of scope here.
+        assert "no such option" not in result.output.lower()
+        assert "Got unexpected extra argument" not in result.output
+
+    def test_injected_option_after_separator_is_rejected(self):
+        # Simulates %1 = `x" --no-launch "` → `ida open -- "x" --no-launch ""`.
+        # After `--`, the extra tokens are positionals; open takes only one → error.
+        runner = CliRunner()
+        result = runner.invoke(open_ida_link, ["--", "ida://ke/x.i64/f", "--no-launch", ""])
+        assert result.exit_code != 0
+        assert "Got unexpected extra argument" in result.output

--- a/tests/lib/test_protocol_handler.py
+++ b/tests/lib/test_protocol_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -37,3 +38,25 @@ class TestOpenArgSeparator:
         result = runner.invoke(open_ida_link, ["--", "ida://ke/x.i64/f", "--no-launch", ""])
         assert result.exit_code != 0
         assert "Got unexpected extra argument" in result.output
+
+
+class TestWindowsRegistration:
+    """Guard the actual registered artifact: the REG_SZ command string must carry the
+    `--` separator before %1 (a regression here wouldn't be caught by the click tests)."""
+
+    def test_registered_command_has_separator_before_percent1(self):
+        fake_winreg = MagicMock()
+        fake_winreg.HKEY_CURRENT_USER = 0
+        fake_winreg.REG_SZ = 1
+        # `with winreg.CreateKey(...) as key:` — MagicMock supports the context manager
+        # protocol out of the box.
+
+        with patch.dict(sys.modules, {"winreg": fake_winreg}):
+            from hcli.lib.ida.protocol import setup_windows_protocol_handler
+
+            setup_windows_protocol_handler()
+
+        # SetValueEx(key, name, reserved, type, value) — find the command value.
+        commands = [c.args[4] for c in fake_winreg.SetValueEx.call_args_list if "ida open" in str(c.args[4])]
+        assert commands, "no ida open command was registered"
+        assert commands[0].endswith('ida open -- "%1"'), commands[0]

--- a/tests/lib/test_protocol_handler.py
+++ b/tests/lib/test_protocol_handler.py
@@ -18,7 +18,7 @@ class TestOpenArgSeparator:
     def test_url_after_separator_is_dispatched_as_the_uri(self):
         # A normal URL after `--` is parsed as the single positional and dispatched
         # verbatim to the handler. A fake handler captures it so no real I/O happens.
-        captured = {}
+        captured: dict[str, str] = {}
         fake = MagicMock()
         fake.matches.return_value = True
         fake.handle.side_effect = lambda uri, *a, **k: captured.__setitem__("uri", uri)

--- a/tests/lib/test_protocol_handler.py
+++ b/tests/lib/test_protocol_handler.py
@@ -60,3 +60,39 @@ class TestWindowsRegistration:
         commands = [c.args[4] for c in fake_winreg.SetValueEx.call_args_list if "ida open" in str(c.args[4])]
         assert commands, "no ida open command was registered"
         assert commands[0].endswith('ida open -- "%1"'), commands[0]
+
+
+class TestPosixHandlerArtifacts:
+    """The macOS AppleScript and Linux desktop Exec= are the real registered artifacts;
+    assert each carries the `--` option terminator before the URL placeholder."""
+
+    def test_macos_applescript_has_separator(self):
+        from hcli.lib.ida.protocol import _macos_handler_applescript
+
+        script = _macos_handler_applescript(
+            "/path/hcli", "/home/u/Library/Logs/idb_handler.log", "/home/u/Library/Logs"
+        )
+        assert "ida open -- " in script
+        # and it ensures the log dir exists at click time so the redirect can't break
+        assert "mkdir -p" in script
+
+    def test_linux_desktop_exec_has_separator(self):
+        from hcli.lib.ida.protocol import _linux_desktop_entry
+
+        entry = _linux_desktop_entry("/path/hcli")
+        exec_line = next(ln for ln in entry.splitlines() if ln.startswith("Exec="))
+        assert exec_line.endswith("ida open -- %u"), exec_line
+
+    def test_linux_registration_writes_separator_to_desktop_file(self, tmp_path, monkeypatch):
+        # Real-artifact check: the written .desktop file must carry `-- %u`.
+        monkeypatch.setattr("hcli.lib.ida.protocol.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("hcli.lib.ida.protocol.get_hcli_executable_path", lambda: "/path/hcli")
+        monkeypatch.setattr("hcli.lib.ida.protocol.subprocess.run", lambda *a, **k: MagicMock())
+
+        from hcli.lib.ida.protocol import setup_linux_protocol_handler
+
+        setup_linux_protocol_handler()
+
+        desktop = tmp_path / ".local" / "share" / "applications" / "hcli-idb-handler.desktop"
+        exec_line = next(ln for ln in desktop.read_text().splitlines() if ln.startswith("Exec="))
+        assert exec_line.endswith("ida open -- %u"), exec_line

--- a/tests/lib/test_protocol_handler.py
+++ b/tests/lib/test_protocol_handler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 from click.testing import CliRunner
 
 from hcli.commands.ida.open import open_ida_link
@@ -10,16 +12,23 @@ from hcli.commands.ida.open import open_ida_link
 class TestOpenArgSeparator:
     """The Windows registry command uses `ida open -- "%1"`. These tests confirm the
     `--` separator turns any injected tokens into surplus positionals that click
-    rejects, rather than options it would interpret."""
+    rejects, rather than options it would interpret. The handler dispatch is mocked
+    so only argument parsing is exercised — no real download/IPC/dialog I/O runs."""
 
-    def test_url_after_separator_is_the_uri(self):
-        # A normal URL after `--` is accepted as the single positional argument.
-        # --no-launch keeps the test from touching IDA/instances.
+    def test_url_after_separator_is_dispatched_as_the_uri(self):
+        # A normal URL after `--` is parsed as the single positional and dispatched
+        # verbatim to the handler. A fake handler captures it so no real I/O happens.
+        captured = {}
+        fake = MagicMock()
+        fake.matches.return_value = True
+        fake.handle.side_effect = lambda uri, *a, **k: captured.__setitem__("uri", uri)
+
         runner = CliRunner()
-        result = runner.invoke(open_ida_link, ["--no-launch", "--", "ida://ke/x.i64/functions?url=http://h/a"])
-        # It parsed fine (no usage error). Behaviour beyond parsing is out of scope here.
-        assert "no such option" not in result.output.lower()
-        assert "Got unexpected extra argument" not in result.output
+        with patch("hcli.commands.ida.open.HANDLERS", [fake]):
+            result = runner.invoke(open_ida_link, ["--", "ida://ke/x.i64/functions?url=http://h/a"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("uri") == "ida://ke/x.i64/functions?url=http://h/a"
 
     def test_injected_option_after_separator_is_rejected(self):
         # Simulates %1 = `x" --no-launch "` → `ida open -- "x" --no-launch ""`.


### PR DESCRIPTION
Hardening for the `ida://` protocol-handler **registration** (separate concern from the handler logic in #229).

- **Windows `%1` argument injection (MEDIUM):** the registry command now registers `ida open -- "%1"`. Windows substitutes the raw URL into the command line, so a stray quote could append extra argv tokens parsed as options to `ida open`. The `--` separator makes click treat the URL strictly as the positional `uri` argument; injected tokens become surplus positionals and are rejected.
- **Predictable `/tmp` log on macOS (LOW):** the handler log moves from the world-writable `/tmp/idb_handler.log` to the per-user `~/Library/Logs/idb_handler.log`, removing a symlink-write target (the log also records full `ida://` URLs).

## Tests
`tests/lib/test_protocol_handler.py` — 2 passed (confirms `--` causes injected option tokens to be rejected rather than interpreted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)