### PR TITLE
ci: automatic AI security review on PRs + review guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -241,4 +241,23 @@ The project uses modern Python packaging:
 - **rich-click** for enhanced CLI interfaces
 - **pytest** with asyncio support for testing
 
+## Security Review
+
+Before opening or merging a PR, run a security review of your changes and address (or
+explicitly justify) any findings — e.g. via the `/security-review` command in Claude
+Code. Focus on whether the diff introduces command/code injection, path traversal,
+SSRF (host/protocol control), auth bypass, insecure deserialization, hardcoded
+secrets, unsafe subprocess/shell use, or unsafe handling of untrusted input.
+
+`hcli` registers an `ida://` protocol handler, so deep-link URLs are
+**attacker-reachable** (any web page can launch them) — treat parsed URL paths, query
+parameters, and `url=`-style values as fully untrusted. Review these areas with extra
+care: `src/hcli/lib/ida/handler/` (deep-link handlers), `src/hcli/lib/ida/protocol.py`
+(handler registration), `src/hcli/lib/ida/ipc.py` (local IPC), and auth/credential,
+subprocess, download, or file-write code.
+
+An automatic AI security review also runs on every PR to `main`
+(`.github/workflows/security-review.yml`) and posts findings as a PR comment — triage
+them, don't ignore them. See `CLAUDE.md` for the same guidance.
+
 Always use `uv run <command>` instead of activating virtual environments manually.

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -75,11 +75,39 @@ jobs:
             nits. Environment variables and CLI flags are trusted inputs (an attacker
             cannot set them), so do not build findings on controlling them.
 
-            Post a single PR comment. For each finding include: `file:line`, severity
-            (HIGH/MEDIUM), category, a one-line description, a brief exploit scenario,
-            and a concrete fix. If you find no high-confidence issues, say so in one
-            line. This review is ADVISORY — it does not block merge; a human still
-            reviews the PR.
+            ALWAYS post a single PR comment, even when nothing is wrong, so there is a
+            visible record that the review ran and what it covered. Use this exact
+            structure:
+
+            ## 🔒 Automated security review
+
+            **Verdict:** one line — either
+            `✅ Checked, all OK — no high-confidence security issues found.`
+            or `⚠️ N potential issue(s) found — see below.`
+
+            **Scope:** the diff of PR #${{ github.event.pull_request.number }}
+            (base…head) only.
+            **Files reviewed:** comma-separated changed files you assessed, or
+            "none security-relevant".
+
+            **Checked** — mark each category ✅ (reviewed, no concern), ⚠️ (finding
+            below), or — (n/a to this diff):
+            - Injection (command/code/template/shell)
+            - Path traversal / file write / insecure or world-writable paths & perms
+            - SSRF / DNS-rebinding / validate-then-fetch TOCTOU
+            - Authn/authz bypass / fail-open logic
+            - Attacker-driven resource exhaustion (memory/disk)
+            - Insecure deserialization (eval/pickle/yaml)
+            - Secrets / sensitive data in logs, errors, or dialogs
+            - Crypto / randomness / certificate validation
+            - Supply-chain (new/changed deps, unpinned refs, install hooks)
+
+            **Findings:** for each — `file:line` · SEVERITY (HIGH/MEDIUM) · category —
+            one-line description; brief exploit scenario; concrete fix. If none, write
+            "None."
+
+            **Notes / limitations:** scope caveats, anything not assessable from the
+            diff, and: "Advisory — does not block merge; a human still reviews this PR."
           # Read-only review tools (no Edit/Write). To use a stronger model, append
           # e.g. `--model <id>`; omitted here so the action's current default is used.
           claude_args: |

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -40,20 +40,40 @@ jobs:
             Review ONLY the diff of this PR against its base branch — the newly
             added/changed code — not the whole repository.
 
-            hcli registers an `ida://` protocol handler, so deep-link URLs are
-            attacker-reachable: treat parsed URL paths, query parameters, and any
-            `url=`-style values as fully untrusted input. Look hardest at changes under
-            `src/hcli/lib/ida/handler/` (the deep-link handlers), `src/hcli/lib/ida/protocol.py`
-            (handler registration), `src/hcli/lib/ida/ipc.py` (local IPC), and any
+            Threat model. hcli is a desktop CLI that registers an `ida://` protocol
+            handler, so deep-link URLs are attacker-reachable (any web page can launch
+            them): treat parsed URL paths, query parameters, and any `url=`-style values
+            as fully untrusted input. It also downloads assets and hands them to IDA,
+            and talks to running IDA instances over local IPC (a same-user trust
+            boundary). Look hardest at changes under `src/hcli/lib/ida/handler/` (the
+            deep-link handlers), `src/hcli/lib/ida/protocol.py` (OS handler
+            registration), `src/hcli/lib/ida/ipc.py` (local IPC), and any
             auth/credential, subprocess, download, or file-write code.
 
-            Report only HIGH/MEDIUM findings you are >80% confident are real and
-            exploitable: command/code injection, path traversal, SSRF (host/protocol
-            control), authn/authz bypass, insecure deserialization, hardcoded secrets,
-            unsafe subprocess/shell use, and unsafe handling of untrusted input.
-            Explicitly SKIP and do not report: denial-of-service / resource exhaustion,
-            secrets-at-rest, rate-limiting, pure style/quality, and purely theoretical
-            issues. Prefer missing a speculative issue over adding noise.
+            Report HIGH/MEDIUM findings you are >80% confident are real and have a
+            concrete attack path. Consider these categories (not exhaustive):
+            - command/code/template injection; unsafe subprocess or shell use
+            - path traversal / arbitrary file write; insecure, predictable, or
+              world-writable file/socket/registry paths and permissions
+            - SSRF (attacker control of host or protocol), and DNS-rebinding/TOCTOU
+              around validate-then-fetch
+            - authn/authz bypass; fail-OPEN security logic (a check that is skipped or
+              defaults to "allow" on error/unknown platform)
+            - resource exhaustion driven by ATTACKER-CONTROLLED input (e.g. unbounded
+              download/read/write that can fill memory or disk) — this IS in scope here
+            - concretely-exploitable race conditions / TOCTOU
+            - insecure deserialization; eval/pickle/yaml on untrusted data
+            - hardcoded or leaked secrets; sensitive data (tokens, credentials, PII)
+              written to logs, error text, or dialogs
+            - weak crypto, bad randomness, or certificate-validation bypass
+            - supply-chain: newly added/changed dependencies, unpinned action/refs, or
+              install/postinstall hooks
+
+            Noise control (important): prefer missing a speculative issue over adding
+            noise. Do NOT report pure style/quality or non-security correctness bugs,
+            theoretical issues with no concrete attack path, or generic "best practice"
+            nits. Environment variables and CLI flags are trusted inputs (an attacker
+            cannot set them), so do not build findings on controlling them.
 
             Post a single PR comment. For each finding include: `file:line`, severity
             (HIGH/MEDIUM), category, a one-line description, a brief exploit scenario,

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,0 +1,66 @@
+name: Security Review
+
+# Automatic AI security review on every PR to main. Advisory / non-blocking: it posts
+# its findings as a single PR comment and does not gate merge. To make it merge-blocking
+# later, add this job's check ("security-review") to the required status checks in the
+# branch-protection rule for `main` (see the PR description / repo docs).
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: security-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write # post the review comment
+  id-token: write
+
+jobs:
+  security-review:
+    name: security-review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so the base..head diff is available
+
+      - name: Claude security review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # One sticky comment per PR (updated on each push) instead of a new comment each run.
+          use_sticky_comment: true
+          prompt: |
+            You are a senior security engineer reviewing this pull request
+            (#${{ github.event.pull_request.number }}) in ${{ github.repository }}.
+            Review ONLY the diff of this PR against its base branch — the newly
+            added/changed code — not the whole repository.
+
+            hcli registers an `ida://` protocol handler, so deep-link URLs are
+            attacker-reachable: treat parsed URL paths, query parameters, and any
+            `url=`-style values as fully untrusted input. Look hardest at changes under
+            `src/hcli/lib/ida/handler/` (the deep-link handlers), `src/hcli/lib/ida/protocol.py`
+            (handler registration), `src/hcli/lib/ida/ipc.py` (local IPC), and any
+            auth/credential, subprocess, download, or file-write code.
+
+            Report only HIGH/MEDIUM findings you are >80% confident are real and
+            exploitable: command/code injection, path traversal, SSRF (host/protocol
+            control), authn/authz bypass, insecure deserialization, hardcoded secrets,
+            unsafe subprocess/shell use, and unsafe handling of untrusted input.
+            Explicitly SKIP and do not report: denial-of-service / resource exhaustion,
+            secrets-at-rest, rate-limiting, pure style/quality, and purely theoretical
+            issues. Prefer missing a speculative issue over adding noise.
+
+            Post a single PR comment. For each finding include: `file:line`, severity
+            (HIGH/MEDIUM), category, a one-line description, a brief exploit scenario,
+            and a concrete fix. If you find no high-confidence issues, say so in one
+            line. This review is ADVISORY — it does not block merge; a human still
+            reviews the PR.
+          # Read-only review tools (no Edit/Write). To use a stronger model, append
+          # e.g. `--model <id>`; omitted here so the action's current default is used.
+          claude_args: |
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## What this adds

An **automatic, advisory** AI security review on every PR to `main`, plus guidance so devs/AI self-review and know which areas are security-sensitive.

- **`.github/workflows/security-review.yml`** — runs `anthropics/claude-code-action@v1` in automation mode on `pull_request → main` (opened/synchronize/reopened), scoped to the PR diff, and posts findings as a **single sticky PR comment**.
  - **Non-blocking** (coverage, not enforcement) — it does not fail the build or gate merge.
  - **Reuses the existing `CLAUDE_CODE_OAUTH_TOKEN` secret** (same as `claude.yml`) — no new secret.
  - Read-only tools; the existing `@claude` on-demand workflow (`claude.yml`) is unchanged and complements this as a deeper, human-invoked review.
- **`.github/copilot-instructions.md`** — new "Security Review" section: run `/security-review` before PRs/merge; the security-sensitive paths (`ida://` handler, `protocol.py`, `ipc.py`, auth).

### Note on `CLAUDE.md`
The repo **intentionally gitignores `CLAUDE.md`** (`.gitignore:16`) and `.claude`, so the advisory guidance is committed in `.github/copilot-instructions.md` instead (the repo's tracked agent guide). If you'd prefer a committed root `CLAUDE.md` too, it can be force-added — say the word.

### Alternative engine (optional)
A purpose-built **`anthropics/claude-code-security-review`** action exists, but it requires a **`claude-api-key`** (an Anthropic API key) — a different credential than this repo's `CLAUDE_CODE_OAUTH_TOKEN`. If you add a `CLAUDE_API_KEY` secret, we can switch to it for inline severity-tagged findings + built-in false-positive filtering.

---

## Turning this into enforcement (repo-admin, one-time)

Coverage ≠ enforcement. To actually require review/approvals before merge, add a branch-protection rule on `main`. **To make this AI review merge-blocking, add `security-review` to the required status-check contexts below.**

**Classic branch protection** — write `protection.json`:
```json
{
  "required_status_checks": { "strict": true, "contexts": ["code_style", "initial test run"] },
  "enforce_admins": false,
  "required_pull_request_reviews": {
    "dismiss_stale_reviews": true,
    "required_approving_review_count": 1,
    "require_last_push_approval": true
  },
  "restrictions": null,
  "allow_force_pushes": false,
  "allow_deletions": false
}
```
then apply:
```bash
gh api -X PUT repos/HexRaysSA/ida-hcli/branches/main/protection \
  -H "Accept: application/vnd.github+json" --input protection.json
```

**Or a Ruleset** (Settings → Rules → Rulesets → New branch ruleset, target `main`): enable "Require a pull request before merging" (1 approval) and "Require status checks to pass" (add `code_style`, `initial test run`, and optionally `security-review`).

---

## Verification
1. Confirm GitHub parses the workflow (this PR triggers it — the run should appear and post a security-review comment).
2. The job should be **green regardless of findings** (non-blocking).
3. Confirm the run authenticates (token present) and can comment (`pull-requests: write`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)