### PR TITLE
fix(security-review): post the report comment (automation mode doesn't auto-post)

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -75,9 +75,16 @@ jobs:
             nits. Environment variables and CLI flags are trusted inputs (an attacker
             cannot set them), so do not build findings on controlling them.
 
-            ALWAYS post a single PR comment, even when nothing is wrong, so there is a
-            visible record that the review ran and what it covered. Use this exact
-            structure:
+            You MUST post the report below as a PR comment — even when nothing is wrong
+            — so there is a visible record that the review ran and what it covered. Do
+            not rely on the action to post it; post it yourself with the GitHub CLI
+            (GITHUB_TOKEN is already in the environment):
+            - if you have already posted a report on this PR (a comment that starts with
+              "## 🔒 Automated security review"), UPDATE it:
+              `gh pr comment ${{ github.event.pull_request.number }} --edit-last --body "<report>"`
+            - otherwise create one:
+              `gh pr comment ${{ github.event.pull_request.number }} --body "<report>"`
+            Post exactly one comment, using this exact structure for `<report>`:
 
             ## 🔒 Automated security review
 
@@ -108,7 +115,10 @@ jobs:
 
             **Notes / limitations:** scope caveats, anything not assessable from the
             diff, and: "Advisory — does not block merge; a human still reviews this PR."
-          # Read-only review tools (no Edit/Write). To use a stronger model, append
-          # e.g. `--model <id>`; omitted here so the action's current default is used.
+          # Read-only analysis tools + the gh command used to post the report comment
+          # (automation mode does not auto-post the agent's prose, so it posts itself).
+          # To use a stronger model, append e.g. `--model <id>`; omitted so the action's
+          # current default is used.
           claude_args: |
-            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns 25
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"


### PR DESCRIPTION
## Why

After #232 merged, I ran the security review on the three open PRs (by rebasing them onto `main`). The job **ran** (the rebase made each branch's workflow match `main`, so the action's workflow-validation guard passed) — but it **posted no comment**.

Root cause: `anthropics/claude-code-action@v1` in **automation mode** (prompt on `pull_request`) does not auto-post the agent's prose output. `use_sticky_comment` only consolidates *inline review* comments, and our prompt produces a prose report — so the run logged "No buffered inline comments" and posted nothing. That defeats the "always write a report comment" requirement.

## Fix

Have the agent **post the report itself** via the GitHub CLI (`GITHUB_TOKEN` is already in the action env):
- `gh pr comment <n> --edit-last --body "<report>"` if it already posted one (keeps it sticky / no duplicates), else `gh pr comment <n> --body "<report>"`.
- Allow the `Bash(gh pr comment:*)` tool and bump `--max-turns`.

Deterministic — doesn't depend on the action's (absent) auto-post behavior.

## After this merges
The fix has to be on `main` for the action's validation guard to let it run on PRs, so once this is merged I'll re-rebase the three open PRs (#229/#230/#231) onto `main` and they'll post their reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)