### PR TITLE
ci: retry IDA install steps to ride out transient download 502s

### DIFF
--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Retry a command with linear backoff to ride out transient failures of the IDA
+# download backend (e.g. HTTP 502 / "no files downloaded") that intermittently
+# break the CI "Install IDA" steps. Keeps the command (and any secrets it carries)
+# inside our own code rather than handing it to a third-party retry action.
+#
+# Usage: retry.sh <max_attempts> <base_sleep_seconds> <command> [args...]
+#   sleeps base, 2*base, 3*base, ... between attempts.
+set -uo pipefail
+
+max="$1"
+base="$2"
+shift 2
+
+attempt=1
+while true; do
+  "$@" && exit 0
+  status=$?
+  if [ "$attempt" -ge "$max" ]; then
+    # Note: only the program name is printed, never the args, to avoid echoing secrets.
+    echo "::error::'$1' still failing after ${max} attempts (last exit ${status})."
+    exit "$status"
+  fi
+  wait=$((attempt * base))
+  echo "::warning::Attempt ${attempt}/${max} failed (exit ${status}); retrying in ${wait}s..."
+  sleep "$wait"
+  attempt=$((attempt + 1))
+done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,10 @@ jobs:
           uv sync --no-sources --extra dev --extra test
 
       - name: Install IDA Pro (latest)
+        shell: bash
         run: |
-          uv run hcli --disable-updates ida install --download-id "ida-pro:latest" --license-id ${{ secrets.IDA_LICENSE_ID }} --set-default --accept-eula --yes
+          bash .github/scripts/retry.sh 5 20 \
+            uv run hcli --disable-updates ida install --download-id "ida-pro:latest" --license-id "${{ secrets.IDA_LICENSE_ID }}" --set-default --accept-eula --yes
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
@@ -338,8 +340,10 @@ jobs:
           uv sync --no-sources --extra dev --extra test
 
       - name: Install IDA ${{ matrix.os_ida.ida_version }} (default location)
+        shell: bash
         run: |
-          uv run hcli --disable-updates ida install --download-id ${{ matrix.os_ida.slug }} --license-id ${{ secrets.IDA_LICENSE_ID }} --set-default --yes
+          bash .github/scripts/retry.sh 5 20 \
+            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${{ secrets.IDA_LICENSE_ID }}" --set-default --yes
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
@@ -361,8 +365,10 @@ jobs:
           }
 
       - name: Install IDA ${{ matrix.os_ida.ida_version }}
+        shell: bash
         run: |
-          uv run hcli --disable-updates ida install --download-id ${{ matrix.os_ida.slug }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida-${{ matrix.os_ida.ida_version }}/" --set-default --yes
+          bash .github/scripts/retry.sh 5 20 \
+            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${{ secrets.IDA_LICENSE_ID }}" --install-dir "${{ runner.temp }}/app/ida-${{ matrix.os_ida.ida_version }}/" --set-default --yes
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ site/
 # Local
 scratch/
 *.sh
+# CI helper scripts are tracked despite the *.sh ignore above
+!.github/scripts/*.sh
 .claude
 NOTES.md
 CLAUDE.md


### PR DESCRIPTION
## Problem

The `Install IDA …` steps in `test.yml` (both the `basic-test` gate and the IDA matrix) intermittently fail when the download backend returns **HTTP 502 / `no files downloaded`**. The step aborts and the job goes red **before any test runs** — a transient infra blip looks like a code failure and forces manual re-runs.

## Change

Wrap each of the three `hcli ida install` invocations in a small retry helper, `.github/scripts/retry.sh`:

- Retries up to **5 times** with **linear backoff** (20s → 40s → 60s → 80s) on any non-zero exit, so a transient 502 is ridden out automatically. A genuinely persistent failure (bad license, real outage) still fails — just after exhausting retries.
- **Keeps the install command — and the `IDA_LICENSE_ID` secret it carries — inside our own code**, rather than handing it to a third-party retry action. The helper never echoes the command args (only the program name) so the secret can't leak into logs.
- Steps now run under `shell: bash` so the retry loop is portable across the Linux / macOS / Windows matrix runners (Git Bash on Windows). The `uv run hcli …` invocation is unchanged otherwise.

`.gitignore` ignores `*.sh` globally; added a scoped negation (`!.github/scripts/*.sh`) so CI helper scripts are tracked.

## Notes

- Purely a CI/infra change — no product code touched.
- The helper was unit-tested locally: retries-then-succeeds, and propagates the final exit code on permanent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)