### PR TITLE
Clean up macos runners at the start of a job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -339,6 +339,15 @@ jobs:
         run: |
           uv sync --no-sources --extra dev --extra test
 
+      - name: Clean stale IDA install (macOS runners occasionally retain state)
+        if: ${{ startsWith(matrix.os_ida.os, 'macos') }}
+        shell: bash
+        run: |
+          if [[ -d "${{ matrix.os_ida.default_path }}" ]]; then
+            echo "Removing stale installation: ${{ matrix.os_ida.default_path }}"
+            rm -rf "${{ matrix.os_ida.default_path }}"
+          fi
+
       - name: Install IDA ${{ matrix.os_ida.ida_version }} (default location)
         shell: bash
         run: |


### PR DESCRIPTION
Bunch of CI failures related to IDA already being installed, likely happening because `/Applications` was retained between runs or something.