### PR TITLE
python: better detect IDAPython environment with VIRTUAL_ENV set

### DIFF
--- a/src/hcli/commands/plugin/explain_environment.py
+++ b/src/hcli/commands/plugin/explain_environment.py
@@ -30,6 +30,7 @@ from hcli.lib.ida.python import (
     detect_current_python_version,
     find_current_python_executable,
 )
+from hcli.lib.venv import find_candidate_virtual_envs, is_uv_cache_virtual_env, resolve_user_virtual_env
 
 
 def _path(p: object) -> str:
@@ -131,7 +132,26 @@ def explain_environment() -> None:
 
     # --- Python detection ---
 
-    console.print("[bold]Python executable[/bold]")
+    console.print("[bold]Python environment[/bold]")
+
+    process_virtual_env = os.environ.get("VIRTUAL_ENV")
+    is_uv_cache = process_virtual_env is not None and is_uv_cache_virtual_env(process_virtual_env)
+    if process_virtual_env and is_uv_cache:
+        _kv("$VIRTUAL_ENV", f"{_path(process_virtual_env)}  [dim](uv cache)[/dim]")
+    elif process_virtual_env:
+        _kv("$VIRTUAL_ENV", _path(process_virtual_env))
+    else:
+        _kv("$VIRTUAL_ENV", "not set")
+
+    user_venv = resolve_user_virtual_env()
+    if user_venv:
+        _kv("user virtualenv", _path(user_venv), "resolved from $PATH")
+
+    path_venvs = find_candidate_virtual_envs()
+    non_uv_candidates = [c for c in path_venvs if not is_uv_cache_virtual_env(c.path)]
+    if non_uv_candidates:
+        for candidate in non_uv_candidates:
+            _kv("  candidate venv", f"{_path(candidate.path)}  [dim](via {candidate.source})[/dim]")
 
     info: dict | None = None
     env_python = os.environ.get("HCLI_CURRENT_IDA_PYTHON_EXE") or ENV.HCLI_CURRENT_IDA_PYTHON_EXE
@@ -188,7 +208,7 @@ def explain_environment() -> None:
 
     try:
         python_exe = find_current_python_executable()
-        _kv("python exe", _path(python_exe))
+        _kv("final python exe", _path(python_exe))
 
         result = subprocess.run(
             [str(python_exe), "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
@@ -212,12 +232,36 @@ def explain_environment() -> None:
         _err("final version", f"{type(e).__name__}: {e}")
 
     console.print()
-    active_venv = os.environ.get("VIRTUAL_ENV")
-    if active_venv:
+    is_hcli_own_venv = process_virtual_env and os.path.normcase(
+        os.path.abspath(process_virtual_env)
+    ) == os.path.normcase(os.path.abspath(sys.prefix))
+
+    if is_uv_cache and user_venv:
         console.print(
-            f"[dim]Note: the active virtualenv ({escape(active_venv)}) "
+            f"[dim]Note: $VIRTUAL_ENV is a uv cache overlay. Resolved user virtualenv: {escape(str(user_venv))}[/dim]",
+            highlight=False,
+        )
+        console.print()
+    elif is_uv_cache:
+        console.print(
+            "[dim]Note: $VIRTUAL_ENV is a uv cache overlay, not your virtualenv. "
+            "No user virtualenvs were found on $PATH.[/dim]",
+            highlight=False,
+        )
+        console.print()
+    elif process_virtual_env and is_hcli_own_venv:
+        console.print(
+            f"[dim]Note: $VIRTUAL_ENV ({escape(process_virtual_env)}) "
             f"is the hcli process environment, not the IDA Python environment. "
             f"It is not used for plugin installation.[/dim]",
+            highlight=False,
+        )
+        console.print()
+    elif process_virtual_env and not ida_venv:
+        console.print(
+            f"[dim]Note: $VIRTUAL_ENV is set ({escape(process_virtual_env)}) "
+            f"but was not detected inside IDA. "
+            f"To use this virtualenv with IDA, activate it via idapythonrc.py.[/dim]",
             highlight=False,
         )
         console.print()
@@ -228,5 +272,5 @@ def explain_environment() -> None:
             "https://community.hex-rays.com/t/using-a-virtualenv-for-idapython/261/5[/dim]",
             highlight=False,
         )
-    if not active_venv and not ida_venv:
+    if not user_venv and not is_uv_cache and not ida_venv:
         console.print("[dim]To change IDA's Python, use idapyswitch to point at a different interpreter.[/dim]")

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from hcli.env import ENV
 from hcli.lib.ida.version import parse_version_from_ida_binary
 from hcli.lib.util.io import NoSpaceError, check_free_space, get_os
+from hcli.lib.venv import resolve_user_virtual_env
 
 logger = logging.getLogger(__name__)
 
@@ -1057,9 +1058,28 @@ def _run_ida_batch_script(idat_path: Path, src: str, env: dict[str, str] | None 
 
 
 def _clean_env_for_idat() -> dict[str, str]:
+    # When HCLI runs under `uv run --with ida-hcli`, uv replaces `$VIRTUAL_ENV`
+    #  with its own ephemeral virtual environment.
+    # So, we try to resolve the *real* virtual environment, if possible.
+    user_venv = resolve_user_virtual_env()
+
     env = os.environ.copy()
     for key in ("VIRTUAL_ENV", "PYTHONHOME", "PYTHONPATH", "PATH"):
         env.pop(key, None)
+
+    if user_venv is not None:
+        # we pass this along so idat can recognize the current virtualenv
+        # if VIRTUAL_ENV is set, such as users that run HCLI and IDA with
+        # a virtualenv activated.
+        #
+        # note that there can be false positives here:
+        # if the user runs HCLI when a venv is activated,
+        # but its not the venv that IDA would use,
+        # then it may install plugin dependencies into it.
+        #
+        # we don't have a good way of differentiating IDA's venv from a random venv.
+        env["VIRTUAL_ENV"] = str(user_venv)
+
     return env
 
 

--- a/src/hcli/lib/venv.py
+++ b/src/hcli/lib/venv.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def _parse_pyvenv_cfg(path: Path) -> dict[str, str]:
     """
-    fetch key-value pairs from a pyenv.cfg file, such as found in uv-created
+    Fetch key-value pairs from a pyvenv.cfg file, such as found in uv-created
     virtual environments.
     """
     result: dict[str, str] = {}

--- a/src/hcli/lib/venv.py
+++ b/src/hcli/lib/venv.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_pyvenv_cfg(path: Path) -> dict[str, str]:
+    """
+    fetch key-value pairs from a pyenv.cfg file, such as found in uv-created
+    virtual environments.
+    """
+    result: dict[str, str] = {}
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if "=" in line:
+                key, _, value = line.partition("=")
+                result[key.strip().lower()] = value.strip()
+    except OSError:
+        pass
+    return result
+
+
+def _get_uv_cache_dirs() -> list[Path]:
+    """
+    compute the file system path to the cache directory used by uv,
+    to store things like temporary virtual environments.
+    """
+    dirs: list[Path] = []
+
+    uv_cache = os.environ.get("UV_CACHE_DIR")
+    if uv_cache:
+        dirs.append(Path(uv_cache).resolve())
+
+    home = Path.home()
+    system = platform.system()
+    if system == "Darwin":
+        dirs.append(home / "Library" / "Caches" / "uv")
+        dirs.append(home / ".cache" / "uv")
+    elif system == "Windows":
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        if local_app_data:
+            dirs.append(Path(local_app_data) / "uv" / "cache")
+    else:
+        xdg = os.environ.get("XDG_CACHE_HOME")
+        if xdg:
+            dirs.append(Path(xdg) / "uv")
+        dirs.append(home / ".cache" / "uv")
+
+    return dirs
+
+
+def _is_under_uv_cache(path: Path) -> bool:
+    """
+    is the given path found under any uv cache directory,
+    such as, "is the given virtual environment found in the cache directory?"
+    """
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+
+    for cache_dir in _get_uv_cache_dirs():
+        try:
+            resolved.relative_to(cache_dir.resolve())
+            return True
+        except ValueError:
+            continue
+
+    return False
+
+
+_UV_INTERNAL_DIRS = frozenset({"archive-v0", "builds-v0"})
+
+
+def _has_uv_internal_parent(path: Path) -> bool:
+    """Check if any ancestor directory has a UV-internal name.
+
+    UV organizes its cache into directories like ``archive-v0/`` and
+    ``builds-v0/``.  These names are unique to UV's internal layout —
+    no user would name their project directories this way.  This catches
+    ephemeral environments regardless of where the cache root is
+    (``~/.cache/uv/``, ``$TMPDIR``, ``--no-cache`` temp dirs, etc.).
+    """
+    for parent in path.resolve().parents:
+        if parent.name in _UV_INTERNAL_DIRS:
+            return True
+    return False
+
+
+def is_uv_cache_virtual_env(virtual_env: str | Path) -> bool:
+    """Detect if a virtual environment is a UV ephemeral cache/overlay environment.
+
+    For example, if you run ``uv run --with ida-hcli hcli`` from a non-project
+    directory, then uv may create a temporary virtual environment to run this
+    command.  This routine detects if the given path is one of those cache
+    environments.
+
+    Three independent signals (any is sufficient):
+
+      1. Path is under a known UV cache directory (``~/.cache/uv/``, etc.).
+      2. Path has a UV-internal ancestor directory (``archive-v0/``,
+         ``builds-v0/``).  Catches ``--no-cache`` and ``$TMPDIR`` layouts.
+      3. pyvenv.cfg contains ``extends-environment`` — only written by
+         ``uv run --with`` overlay environments (uv 0.7.9+).
+    """
+    path = Path(virtual_env)
+
+    if _is_under_uv_cache(path):
+        return True
+
+    if _has_uv_internal_parent(path):
+        return True
+
+    cfg = _parse_pyvenv_cfg(path / "pyvenv.cfg")
+    return "extends-environment" in cfg
+
+
+@dataclass(frozen=True)
+class VenvCandidate:
+    path: Path
+    source: str
+    cfg: dict[str, str] = field(default_factory=dict)
+
+
+def find_candidate_virtual_envs() -> list[VenvCandidate]:
+    """Scan PATH for virtual environments that are not the current process venv.
+
+    When HCLI runs under `uv run --with ida-hcli`, uv replaces `$VIRTUAL_ENV`
+     with its own ephemeral virtual environment.
+    Based on our research, the user's real venv typically
+     remains on `$PATH` (the `activate` script prepends its `bin/`).
+
+    This function recovers those candidates.
+    """
+    excluded: set[Path] = set()
+    excluded.add(Path(sys.prefix).resolve())
+
+    seen: set[Path] = set()
+    candidates: list[VenvCandidate] = []
+
+    path_val = os.environ.get("PATH", "")
+    for entry in path_val.split(os.pathsep):
+        if not entry:
+            continue
+
+        entry_path = Path(entry)
+        if entry_path.name not in ("bin", "Scripts"):
+            continue
+
+        venv_root = entry_path.parent
+        cfg_path = venv_root / "pyvenv.cfg"
+        if not cfg_path.is_file():
+            continue
+
+        try:
+            resolved = venv_root.resolve()
+        except OSError:
+            continue
+
+        if resolved in excluded:
+            continue
+
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+
+        cfg = _parse_pyvenv_cfg(cfg_path)
+        candidates.append(VenvCandidate(path=venv_root, source="PATH", cfg=cfg))
+
+    return candidates
+
+
+def resolve_user_virtual_env() -> Path | None:
+    """Resolve the user's activated virtual environment.
+
+    If `$VIRTUAL_ENV` is set and is not a uv cache overlay, returns it
+    directly.  If it *is* a uv cache overlay, scans `$PATH` for the
+    first non-uv-cache candidate venv.  Returns None when no user venv
+    can be identified.
+
+    When HCLI runs under `uv run --with ida-hcli`, uv replaces `$VIRTUAL_ENV`
+     with its own ephemeral virtual environment.
+    Based on our research, the user's real venv typically
+     remains on `$PATH` (the `activate` script prepends its `bin/`).
+    """
+    virtual_env = os.environ.get("VIRTUAL_ENV")
+    if not virtual_env:
+        return None
+
+    if not is_uv_cache_virtual_env(virtual_env):
+        hcli_prefix = os.path.normcase(os.path.abspath(sys.prefix))
+        if os.path.normcase(os.path.abspath(virtual_env)) == hcli_prefix:
+            return None
+        return Path(virtual_env)
+
+    for candidate in find_candidate_virtual_envs():
+        if not is_uv_cache_virtual_env(candidate.path):
+            return candidate.path
+
+    return None

--- a/tests/lib/test_venv.py
+++ b/tests/lib/test_venv.py
@@ -1,0 +1,186 @@
+import os
+from pathlib import Path
+
+from hcli.lib.venv import (
+    find_candidate_virtual_envs,
+    is_uv_cache_virtual_env,
+    resolve_user_virtual_env,
+)
+
+
+def _write_pyvenv_cfg(venv_dir: Path, content: str) -> None:
+    venv_dir.mkdir(parents=True, exist_ok=True)
+    (venv_dir / "pyvenv.cfg").write_text(content, encoding="utf-8")
+    bin_dir = venv_dir / "bin"
+    bin_dir.mkdir(exist_ok=True)
+
+
+def test_is_uv_cache_detects_uv_overlay(tmp_path):
+    cache_dir = tmp_path / ".cache" / "uv" / "archive-v0" / "abc123"
+    _write_pyvenv_cfg(
+        cache_dir,
+        "home = /usr/bin\nuv = 0.7.16\nrelocatable = true\nextends-environment = /home/user/.venv\n",
+    )
+    assert is_uv_cache_virtual_env(cache_dir) is True
+
+
+def test_is_uv_cache_detects_extends_environment(tmp_path):
+    venv = tmp_path / "ephemeral"
+    _write_pyvenv_cfg(venv, "home = /usr/bin\nuv = 0.7.16\nextends-environment = /home/user/.venv\n")
+    assert is_uv_cache_virtual_env(venv) is True
+
+
+def test_is_uv_cache_rejects_relocatable_user_venv(tmp_path):
+    venv = tmp_path / ".venv"
+    _write_pyvenv_cfg(venv, "home = /usr/bin\nuv = 0.7.16\nrelocatable = true\n")
+    assert is_uv_cache_virtual_env(venv) is False
+
+
+def test_is_uv_cache_rejects_user_uv_venv(tmp_path):
+    venv = tmp_path / ".venv"
+    _write_pyvenv_cfg(venv, "home = /usr/bin\nuv = 0.7.16\n")
+    assert is_uv_cache_virtual_env(venv) is False
+
+
+def test_is_uv_cache_rejects_stdlib_venv(tmp_path):
+    venv = tmp_path / ".venv"
+    _write_pyvenv_cfg(venv, "home = /usr/bin\ninclude-system-site-packages = false\n")
+    assert is_uv_cache_virtual_env(venv) is False
+
+
+def test_is_uv_cache_rejects_missing_pyvenv_cfg(tmp_path):
+    venv = tmp_path / ".venv"
+    venv.mkdir()
+    assert is_uv_cache_virtual_env(venv) is False
+
+
+def test_is_uv_cache_detects_archive_v0_parent(tmp_path):
+    venv = tmp_path / "tmpXXXXXX" / "archive-v0" / "abc123" / "lib" / "python3.12"
+    _write_pyvenv_cfg(venv.parent.parent, "home = /usr/bin\nuv = 0.7.16\n")
+    assert is_uv_cache_virtual_env(venv.parent.parent) is True
+
+
+def test_is_uv_cache_detects_builds_v0_parent(tmp_path):
+    venv = tmp_path / "tmpXXXXXX" / "builds-v0" / "abc123"
+    _write_pyvenv_cfg(venv, "home = /usr/bin\nuv = 0.7.16\n")
+    assert is_uv_cache_virtual_env(venv) is True
+
+
+def test_is_uv_cache_rejects_nonexistent_path(tmp_path):
+    assert is_uv_cache_virtual_env(tmp_path / "does-not-exist") is False
+
+
+def test_find_candidates_discovers_venv_on_path(tmp_path, monkeypatch):
+    venv = tmp_path / "project" / ".venv"
+    _write_pyvenv_cfg(venv, "home = /usr/bin\n")
+
+    fake_prefix = tmp_path / "hcli-venv"
+    fake_prefix.mkdir()
+    monkeypatch.setattr("hcli.lib.venv.sys", type("FakeSys", (), {"prefix": str(fake_prefix)}))
+
+    monkeypatch.setenv("PATH", str(venv / "bin"))
+
+    candidates = find_candidate_virtual_envs()
+    assert len(candidates) == 1
+    assert candidates[0].path == venv
+    assert candidates[0].source == "PATH"
+
+
+def test_find_candidates_excludes_current_prefix(tmp_path, monkeypatch):
+    venv = tmp_path / ".venv"
+    _write_pyvenv_cfg(venv, "home = /usr/bin\n")
+
+    monkeypatch.setattr("hcli.lib.venv.sys", type("FakeSys", (), {"prefix": str(venv)}))
+    monkeypatch.setenv("PATH", str(venv / "bin"))
+
+    candidates = find_candidate_virtual_envs()
+    assert len(candidates) == 0
+
+
+def test_find_candidates_deduplicates(tmp_path, monkeypatch):
+    venv = tmp_path / ".venv"
+    _write_pyvenv_cfg(venv, "home = /usr/bin\n")
+
+    fake_prefix = tmp_path / "other"
+    fake_prefix.mkdir()
+    monkeypatch.setattr("hcli.lib.venv.sys", type("FakeSys", (), {"prefix": str(fake_prefix)}))
+
+    path = os.pathsep.join([str(venv / "bin"), str(venv / "bin")])
+    monkeypatch.setenv("PATH", path)
+
+    candidates = find_candidate_virtual_envs()
+    assert len(candidates) == 1
+
+
+def test_find_candidates_skips_non_venv_bin_dirs(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "just-a-bin" / "bin"
+    bin_dir.mkdir(parents=True)
+
+    fake_prefix = tmp_path / "other"
+    fake_prefix.mkdir()
+    monkeypatch.setattr("hcli.lib.venv.sys", type("FakeSys", (), {"prefix": str(fake_prefix)}))
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+    candidates = find_candidate_virtual_envs()
+    assert len(candidates) == 0
+
+
+def test_resolve_user_venv_returns_non_uv_virtual_env(tmp_path, monkeypatch):
+    user_venv = tmp_path / "project" / ".venv"
+    _write_pyvenv_cfg(user_venv, "home = /usr/bin\n")
+
+    monkeypatch.setenv("VIRTUAL_ENV", str(user_venv))
+    fake_prefix = tmp_path / "other"
+    fake_prefix.mkdir()
+    monkeypatch.setattr("hcli.lib.venv.sys", type("FakeSys", (), {"prefix": str(fake_prefix)}))
+
+    assert resolve_user_virtual_env() == user_venv
+
+
+def test_resolve_user_venv_returns_none_when_hcli_own(tmp_path, monkeypatch):
+    venv = tmp_path / ".venv"
+    _write_pyvenv_cfg(venv, "home = /usr/bin\n")
+
+    monkeypatch.setenv("VIRTUAL_ENV", str(venv))
+    monkeypatch.setattr("hcli.lib.venv.sys", type("FakeSys", (), {"prefix": str(venv)}))
+
+    assert resolve_user_virtual_env() is None
+
+
+def test_resolve_user_venv_recovers_from_uv_cache(tmp_path, monkeypatch):
+    uv_cache_venv = tmp_path / "uv-cache"
+    _write_pyvenv_cfg(uv_cache_venv, "home = /usr/bin\nuv = 0.7.16\nextends-environment = /somewhere\n")
+
+    user_venv = tmp_path / "project" / ".venv"
+    _write_pyvenv_cfg(user_venv, "home = /usr/bin\n")
+
+    monkeypatch.setenv("VIRTUAL_ENV", str(uv_cache_venv))
+    monkeypatch.setenv("PATH", os.pathsep.join([str(uv_cache_venv / "bin"), str(user_venv / "bin")]))
+
+    fake_prefix = tmp_path / "other"
+    fake_prefix.mkdir()
+    monkeypatch.setattr("hcli.lib.venv.sys", type("FakeSys", (), {"prefix": str(fake_prefix)}))
+
+    assert resolve_user_virtual_env() == user_venv
+
+
+def test_resolve_user_venv_skips_uv_cache_candidates(tmp_path, monkeypatch):
+    uv_cache_venv = tmp_path / "uv-cache"
+    _write_pyvenv_cfg(uv_cache_venv, "home = /usr/bin\nuv = 0.7.16\nextends-environment = /somewhere\n")
+
+    uv_archive = tmp_path / "uv-archive"
+    _write_pyvenv_cfg(uv_archive, "home = /usr/bin\nuv = 0.7.16\nextends-environment = /elsewhere\n")
+
+    monkeypatch.setenv("VIRTUAL_ENV", str(uv_cache_venv))
+    monkeypatch.setenv("PATH", str(uv_archive / "bin"))
+
+    fake_prefix = tmp_path / "other"
+    fake_prefix.mkdir()
+    monkeypatch.setattr("hcli.lib.venv.sys", type("FakeSys", (), {"prefix": str(fake_prefix)}))
+
+    assert resolve_user_virtual_env() is None
+
+
+def test_resolve_user_venv_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    assert resolve_user_virtual_env() is None


### PR DESCRIPTION
previously HCLI didn't handle the case where a user activates a virtual environment (share with IDA) before running HCLI (or IDA). now, we do pass `$VIRTUAL_ENV` to idat so it can resolve the environment. we also handle cases when the user is running HCLI via uv, like `uv run --with ida-hcli hcli ...` (this is how i run it), which is special because uv may create a temporary venv for the execution, and therefore stomps on `$VIRTUAL_ENV`. we recover the original `VIRTUAL_ENV` value by inspecting entries on the `$PATH`.