### PR TITLE
fix: bundle python3.dll in the Windows binary

### DIFF
--- a/hcli.spec
+++ b/hcli.spec
@@ -1,17 +1,25 @@
 # -*- mode: python ; coding: utf-8 -*-
 from PyInstaller.utils.hooks import collect_submodules, copy_metadata
+from PyInstaller.depend.bindepend import get_python_library_path
 import os
+import sys
 
 artifact_name = os.environ.get("ARTIFACT_NAME", "hcli")
 
 datas = []
 datas += copy_metadata('ida-hcli')
 
+binaries = []
+if sys.platform == "win32":
+    python3_dll = os.path.join(os.path.dirname(get_python_library_path()), "python3.dll")
+    assert os.path.exists(python3_dll), f"python3.dll not found next to the interpreter: {python3_dll}"
+    binaries.append((python3_dll, "."))
+
 
 a = Analysis(
     ['src/hcli/main.py'],
     pathex=[],
-    binaries=[],
+    binaries=binaries,
     datas=datas,
     hiddenimports=collect_submodules('rich._unicode_data'),
     hookspath=[],


### PR DESCRIPTION
`accept_eula()` runs inside hcli's own bundled interpreter. Calling `import idapro` brings up `idalib`, which loads various `.pyd`s files

Those `.pyd`s references `python3.dll` in their import table, which is not shipped inside `hcli` binary, only `python313.dll` is. Windows couldn't resolve the missing dll, so loading every _ida_*.pyd failed with "The specified module could not be found," and EULA acceptance was skipped.