### PR TITLE
Add `hcli plugin list` alias

### DIFF
--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -167,6 +167,16 @@ def plugin(
 
 
 plugin.add_command(get_plugin_status, name="status")
+
+
+@click.command(name="list", hidden=True)
+@click.pass_context
+def _plugin_status_alias(ctx) -> None:
+    """Show installed plugins and their upgrade status (alias for 'status')."""
+    ctx.forward(get_plugin_status)
+
+
+plugin.add_command(_plugin_status_alias)
 plugin.add_command(search_plugins, name="search")
 plugin.add_command(install_plugin, name="install")
 plugin.add_command(lint_plugin_directory, name="lint")

--- a/tests/integration/test_integration_plugin.py
+++ b/tests/integration/test_integration_plugin.py
@@ -12,6 +12,10 @@ class TestPluginCommands:
         success, _output = cli_tester.run_command("uv run hcli plugin status")
         assert success is not None, "plugin status command should run"
 
+    def test_plugin_list(self, cli_tester):
+        success, _output = cli_tester.run_command("uv run hcli plugin list")
+        assert success is not None, "plugin list command should run (alias for status)"
+
     def test_plugin_search_empty(self, cli_tester):
         success, _output = cli_tester.run_command("uv run hcli plugin search")
         assert success is not None, "`plugin search` command should run"


### PR DESCRIPTION
The `plugin status` command was inconsistent with all the other `list` commands and I kept doing it wrong so I decided to change it. There is a hidden `hcli plugin status` fallback