### PR TITLE
fix: skip repo fetch for plugin subcommands that don't use it

### DIFF
--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -85,8 +85,8 @@ def plugin(
     # fix #190: stale stdout/err handles due to click pytest integration
     hcli.lib.console._sync_console_streams()
 
-    # `schema` doesn't touch any plugin repository or IDA install, so skip the setup.
-    if ctx.invoked_subcommand in ("schema", "explain-environment"):
+    # These subcommands don't touch the plugin repository, so skip the setup.
+    if ctx.invoked_subcommand in ("schema", "explain-environment", "uninstall", "config", "lint"):
         return
 
     plugin_repo: hcli.lib.ida.plugin.repo.BasePluginRepo


### PR DESCRIPTION
## Summary
- Add `uninstall`, `config`, and `lint` to the set of plugin subcommands that skip the plugin repo setup, so they work offline without a network fetch.

Closes #257

## Test plan
- [ ] Run `hcli plugin uninstall`, `hcli plugin config`, and `hcli plugin lint` offline and verify they don't attempt a repo fetch
- [ ] Run `hcli plugin install` / `hcli plugin list` and verify they still fetch the repo as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)