### PR TITLE
fix: make plugin install/uninstall/upgrade transactional

### DIFF
--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -36,6 +36,7 @@ from hcli.lib.ida.plugin.install import (
     install_plugin_archive,
     install_plugin_directory_editable,
     pack_plugin_directory_to_zip,
+    sweep_trash,
     uninstall_plugin,
 )
 from hcli.lib.ida.plugin.reference import (
@@ -79,6 +80,8 @@ def install_plugin(ctx, plugin: str, editable: bool, config: tuple[str, ...], no
     plugin_repo_obj = ctx.obj.get("plugin_repo")
     plugin_spec = plugin
     try:
+        sweep_trash()
+
         with rich.status.Status("collecting environment", console=stderr_console):
             current_ida_platform = find_current_ida_platform()
             current_ida_version = find_current_ida_version()

--- a/src/hcli/commands/plugin/uninstall.py
+++ b/src/hcli/commands/plugin/uninstall.py
@@ -8,8 +8,7 @@ import rich_click as click
 
 from hcli.lib.console import console
 from hcli.lib.ida.plugin.exceptions import PluginNotInstalledError
-from hcli.lib.ida.plugin.install import sweep_trash
-from hcli.lib.ida.plugin.install import uninstall_plugin as uninstall_plugin_impl
+from hcli.lib.ida.plugin.install import sweep_trash, uninstall_plugin as uninstall_plugin_impl
 
 logger = logging.getLogger(__name__)
 

--- a/src/hcli/commands/plugin/uninstall.py
+++ b/src/hcli/commands/plugin/uninstall.py
@@ -8,6 +8,7 @@ import rich_click as click
 
 from hcli.lib.console import console
 from hcli.lib.ida.plugin.exceptions import PluginNotInstalledError
+from hcli.lib.ida.plugin.install import sweep_trash
 from hcli.lib.ida.plugin.install import uninstall_plugin as uninstall_plugin_impl
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 def uninstall_plugin(plugin: str) -> None:
     """Remove an installed plugin."""
     try:
+        sweep_trash()
         uninstall_plugin_impl(plugin)
     except PluginNotInstalledError as e:
         console.print(f"[red]{e}[/red]")

--- a/src/hcli/commands/plugin/uninstall.py
+++ b/src/hcli/commands/plugin/uninstall.py
@@ -8,7 +8,8 @@ import rich_click as click
 
 from hcli.lib.console import console
 from hcli.lib.ida.plugin.exceptions import PluginNotInstalledError
-from hcli.lib.ida.plugin.install import sweep_trash, uninstall_plugin as uninstall_plugin_impl
+from hcli.lib.ida.plugin.install import sweep_trash
+from hcli.lib.ida.plugin.install import uninstall_plugin as uninstall_plugin_impl
 
 logger = logging.getLogger(__name__)
 

--- a/src/hcli/commands/plugin/upgrade.py
+++ b/src/hcli/commands/plugin/upgrade.py
@@ -19,7 +19,7 @@ from hcli.lib.ida import (
 from hcli.lib.ida.plugin import get_metadata_from_plugin_archive
 from hcli.lib.ida.plugin.bundle import bundle_dependency_source
 from hcli.lib.ida.plugin.exceptions import PluginNotInstalledError
-from hcli.lib.ida.plugin.install import find_installed_plugin, upgrade_plugin_archive
+from hcli.lib.ida.plugin.install import find_installed_plugin, sweep_trash, upgrade_plugin_archive
 from hcli.lib.ida.plugin.reference import normalize_plugin_host, parse_plugin_reference
 from hcli.lib.ida.plugin.repo import BasePluginRepo
 from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo
@@ -42,6 +42,8 @@ def upgrade_plugin(ctx, plugin: str, no_build_isolation: bool) -> None:
     pip_options: PipOptions = ctx.obj.get("pip_options", PIP_OPTIONS_DEFAULT)
     plugin_spec = plugin
     try:
+        sweep_trash()
+
         current_ida_platform = find_current_ida_platform()
         current_ida_version = find_current_ida_version()
 

--- a/src/hcli/lib/ida/handler/ke_url_handler.py
+++ b/src/hcli/lib/ida/handler/ke_url_handler.py
@@ -546,8 +546,10 @@ def _confirm_open_dialog(filename: str, host: str) -> bool:
                 [
                     "osascript",
                     "-e",
-                    'display dialog (system attribute "KE_DLG_MSG") with title "KE" '
-                    'buttons {"Cancel", "Open"} default button "Open" cancel button "Cancel"',
+                    (
+                        'display dialog (system attribute "KE_DLG_MSG") with title "KE" '
+                        'buttons {"Cancel", "Open"} default button "Open" cancel button "Cancel"'
+                    ),
                 ],
                 prompt,
             )
@@ -562,9 +564,11 @@ def _confirm_open_dialog(filename: str, host: str) -> bool:
                     "-WindowStyle",
                     "Hidden",
                     "-Command",
-                    "Add-Type -AssemblyName System.Windows.Forms; "
-                    "if ([System.Windows.Forms.MessageBox]::Show("
-                    '$env:KE_DLG_MSG, "KE", "YesNo", "Warning") -eq "Yes") { exit 0 } else { exit 1 }',
+                    (
+                        "Add-Type -AssemblyName System.Windows.Forms; "
+                        "if ([System.Windows.Forms.MessageBox]::Show("
+                        '$env:KE_DLG_MSG, "KE", "YesNo", "Warning") -eq "Yes") { exit 0 } else { exit 1 }'
+                    ),
                 ],
                 prompt,
             )
@@ -642,8 +646,10 @@ def _show_download_dialog(filename: str) -> subprocess.Popen[bytes] | None:
                 [
                     "osascript",
                     "-e",
-                    'display dialog ("Downloading " & (system attribute "KE_DLG_FILE") '
-                    '& "\\n\\nPlease wait...") with title "KE" buttons {} giving up after 600',
+                    (
+                        'display dialog ("Downloading " & (system attribute "KE_DLG_FILE") '
+                        '& "\\n\\nPlease wait...") with title "KE" buttons {} giving up after 600'
+                    ),
                 ],
                 env=env,
                 stdout=subprocess.DEVNULL,
@@ -663,9 +669,11 @@ def _show_download_dialog(filename: str) -> subprocess.Popen[bytes] | None:
                     "-WindowStyle",
                     "Hidden",
                     "-Command",
-                    "Add-Type -AssemblyName System.Windows.Forms; "
-                    "[System.Windows.Forms.MessageBox]::Show("
-                    '"Downloading " + $env:KE_DLG_FILE + "...`n`nPlease wait...", "KE")',
+                    (
+                        "Add-Type -AssemblyName System.Windows.Forms; "
+                        "[System.Windows.Forms.MessageBox]::Show("
+                        '"Downloading " + $env:KE_DLG_FILE + "...`n`nPlease wait...", "KE")'
+                    ),
                 ],
                 env=env,
                 stdout=subprocess.DEVNULL,
@@ -700,8 +708,10 @@ def _show_error_dialog(message: str) -> None:
                 [
                     "osascript",
                     "-e",
-                    'display dialog (system attribute "KE_DLG_MSG") with title "KE" '
-                    'buttons {"OK"} default button "OK" with icon stop',
+                    (
+                        'display dialog (system attribute "KE_DLG_MSG") with title "KE" '
+                        'buttons {"OK"} default button "OK" with icon stop'
+                    ),
                 ],
                 env=env,
                 stdout=subprocess.DEVNULL,
@@ -722,8 +732,10 @@ def _show_error_dialog(message: str) -> None:
                     "-WindowStyle",
                     "Hidden",
                     "-Command",
-                    "Add-Type -AssemblyName System.Windows.Forms; "
-                    '[System.Windows.Forms.MessageBox]::Show($env:KE_DLG_MSG, "KE", "OK", "Error")',
+                    (
+                        "Add-Type -AssemblyName System.Windows.Forms; "
+                        '[System.Windows.Forms.MessageBox]::Show($env:KE_DLG_MSG, "KE", "OK", "Error")'
+                    ),
                 ],
                 env=env,
                 stdout=subprocess.DEVNULL,

--- a/src/hcli/lib/ida/plugin/exceptions.py
+++ b/src/hcli/lib/ida/plugin/exceptions.py
@@ -84,6 +84,29 @@ class InvalidPluginNameError(PluginInstallationError):
         super().__init__(f"Invalid plugin name '{name}': {reason}")
 
 
+class PluginInUseError(PluginInstallationError):
+    """Plugin files are locked by another process (typically a running IDA)."""
+
+    def __init__(self, name: str, path: Path):
+        self.name = name
+        self.path = path
+        super().__init__(
+            f"Cannot modify plugin '{name}': files at {path} are in use (is IDA running?). Close IDA and try again."
+        )
+
+
+class BrokenPluginInstallationError(PluginInstallationError):
+    """Plugin directory exists but does not contain a working installation."""
+
+    def __init__(self, name: str, path: Path):
+        self.name = name
+        self.path = path
+        super().__init__(
+            f"Found remnants of a broken installation of '{name}' at {path}. "
+            f"Run '{ENV.HCLI_BINARY_NAME} plugin uninstall {name}' to remove them, then retry."
+        )
+
+
 class PluginNotInstalledError(Exception):
     """Plugin is not installed."""
 

--- a/src/hcli/lib/ida/plugin/install.py
+++ b/src/hcli/lib/ida/plugin/install.py
@@ -103,10 +103,15 @@ TRASH_DIR_NAME = ".plugins-trash"
 
 
 def get_trash_directory(plugins_dir: Path | None = None) -> Path:
-    """$IDAUSR/.plugins-trash (or .plugins-trash next to the given directory)"""
+    """$IDAUSR/.plugins-trash (or .plugins-trash next to the given directory)
+
+    The plugins directory is resolved first so that when it is a symlink to
+    another filesystem, the trash lands next to the real directory and moves
+    in and out remain same-filesystem renames.
+    """
     if plugins_dir is None:
         plugins_dir = get_plugins_directory()
-    return plugins_dir.parent / TRASH_DIR_NAME
+    return plugins_dir.resolve().parent / TRASH_DIR_NAME
 
 
 def is_file_in_use_error(e: OSError) -> bool:
@@ -122,19 +127,22 @@ def is_file_in_use_error(e: OSError) -> bool:
     return e.errno in (errno.EACCES, errno.EPERM, errno.EBUSY, errno.ETXTBSY)
 
 
-def move_plugin_directory_to_trash(path: Path) -> Path:
+def move_plugin_directory_to_trash(path: Path, label: str = "") -> Path:
     """Atomically rename a plugin directory into the trash area.
 
     Either the whole directory moves or nothing changes: when a file inside is
     locked (e.g. a plugin DLL loaded by a running IDA on Windows), the rename
     fails without modifying the installation.
 
+    The optional label is included in the trashed name (e.g. ".rollback") so
+    a human inspecting the trash can tell what a leftover was.
+
     Raises:
         PluginInUseError: when the rename fails because files are in use.
     """
     trash_dir = get_trash_directory(path.parent)
     trash_dir.mkdir(exist_ok=True)
-    destination = trash_dir / f"{path.name}-{uuid.uuid4().hex[:8]}"
+    destination = trash_dir / f"{path.name}{label}-{uuid.uuid4().hex[:8]}"
     try:
         os.rename(path, destination)
     except OSError as e:
@@ -943,28 +951,29 @@ def validate_can_uninstall_plugin(name: str) -> None:
 
 
 def _uninstall_broken_plugin_directory(name: str) -> None:
-    """Remove a plugins/<name> directory that is not a valid installation.
+    """Remove a plugins/<name> entry that is not a valid installation.
 
     Remnants of an interrupted uninstall (e.g. rmtree failed partway because a
     running IDA held a DLL open, issue #228) don't count as installed, but the
-    directory blocks reinstallation. The user asked for this name to be gone,
-    so remove whatever is squatting on it.
+    entry blocks reinstallation. The user asked for this name to be gone, so
+    remove whatever is squatting on it: a broken directory, a stale symlink,
+    or even a plain file.
 
     Raises:
-        PluginNotInstalledError: If no matching directory exists at all
+        PluginNotInstalledError: If no matching entry exists at all
         PluginInUseError: If files are in use; nothing is modified
     """
     plugins_dir = get_plugins_directory()
     for child in plugins_dir.iterdir():
         if child.name.lower() != name.lower():
             continue
-        if not (child.is_dir() or child.is_symlink()):
-            continue
 
         logger.warning("removing remnants of a broken plugin installation: %s", child)
         if child.is_symlink():
             child.unlink()
-            _remove_editable_pth_file(name)
+            _remove_editable_pth_file(child.name)
+        elif child.is_file():
+            child.unlink()
         else:
             remove_plugin_directory(child)
         return
@@ -1099,17 +1108,9 @@ def upgrade_plugin_archive(
     # Checkpoint: atomically move the current install into the trash area
     # before writing anything. When plugin files are locked (e.g. loaded by a
     # running IDA on Windows), this fails without modifying the installation.
-    # The unique suffix means a stale rollback from an interrupted upgrade
+    # The unique trash name means a stale rollback from an interrupted upgrade
     # never blocks this one; the sweep removes such leftovers later.
-    trash_dir = get_trash_directory(plugin_path.parent)
-    trash_dir.mkdir(exist_ok=True)
-    rollback_path = trash_dir / f"{metadata.plugin.name}.rollback-{uuid.uuid4().hex[:8]}"
-    try:
-        os.rename(plugin_path, rollback_path)
-    except OSError as e:
-        if is_file_in_use_error(e):
-            raise PluginInUseError(metadata.plugin.name, plugin_path) from e
-        raise
+    rollback_path = move_plugin_directory_to_trash(plugin_path, label=".rollback")
 
     try:
         install_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation, pip_options=pip_options)
@@ -1120,7 +1121,10 @@ def upgrade_plugin_archive(
         logger.debug("rolling back to prior version")
         shutil.rmtree(plugin_path, ignore_errors=True)
         if plugin_path.exists():
-            logger.error("could not remove partial upgrade; previous version preserved at %s", rollback_path)
+            logger.error(
+                "could not restore previous version: partial upgrade remains at %s; uninstall and reinstall",
+                plugin_path,
+            )
         else:
             os.rename(rollback_path, plugin_path)
         raise

--- a/src/hcli/lib/ida/plugin/install.py
+++ b/src/hcli/lib/ida/plugin/install.py
@@ -1,10 +1,11 @@
 import errno
 import io
 import logging
+import os
 import pathlib
 import shutil
 import subprocess
-import tempfile
+import uuid
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -32,12 +33,14 @@ from hcli.lib.ida.plugin import (
     validate_path,
 )
 from hcli.lib.ida.plugin.exceptions import (
+    BrokenPluginInstallationError,
     DependencyInstallationError,
     IDAVersionIncompatibleError,
     InvalidPluginNameError,
     PipNotAvailableError,
     PlatformIncompatibleError,
     PluginAlreadyInstalledError,
+    PluginInUseError,
     PluginNotInstalledError,
     PluginVersionDowngradeError,
 )
@@ -90,6 +93,100 @@ def get_plugin_directory(name: str) -> Path:
     plugins_dir = get_plugins_directory()
     validate_path_component(name)
     return plugins_dir / name
+
+
+# Trash/staging area next to the plugins directory. Because it (normally)
+# lives on the same filesystem as the plugin directories, moves in and out are
+# atomic renames on all platforms. It sits outside $IDAUSR/plugins, so neither
+# IDA's plugin scan nor our own enumeration ever sees its contents.
+TRASH_DIR_NAME = ".plugins-trash"
+
+
+def get_trash_directory(plugins_dir: Path | None = None) -> Path:
+    """$IDAUSR/.plugins-trash (or .plugins-trash next to the given directory)"""
+    if plugins_dir is None:
+        plugins_dir = get_plugins_directory()
+    return plugins_dir.parent / TRASH_DIR_NAME
+
+
+def is_file_in_use_error(e: OSError) -> bool:
+    """Does this error indicate a file locked by another process?
+
+    On Windows, deleting a DLL mapped by a running process fails with
+    ERROR_ACCESS_DENIED, and renaming any ancestor directory of an open file
+    fails the same way. POSIX doesn't lock mapped files like this, but
+    EBUSY/ETXTBSY can surface in similar situations.
+    """
+    if getattr(e, "winerror", None) in (5, 32):  # ACCESS_DENIED, SHARING_VIOLATION
+        return True
+    return e.errno in (errno.EACCES, errno.EPERM, errno.EBUSY, errno.ETXTBSY)
+
+
+def move_plugin_directory_to_trash(path: Path) -> Path:
+    """Atomically rename a plugin directory into the trash area.
+
+    Either the whole directory moves or nothing changes: when a file inside is
+    locked (e.g. a plugin DLL loaded by a running IDA on Windows), the rename
+    fails without modifying the installation.
+
+    Raises:
+        PluginInUseError: when the rename fails because files are in use.
+    """
+    trash_dir = get_trash_directory(path.parent)
+    trash_dir.mkdir(exist_ok=True)
+    destination = trash_dir / f"{path.name}-{uuid.uuid4().hex[:8]}"
+    try:
+        os.rename(path, destination)
+    except OSError as e:
+        if is_file_in_use_error(e):
+            raise PluginInUseError(path.name, path) from e
+        raise
+    return destination
+
+
+def remove_plugin_directory(path: Path) -> None:
+    """Remove a plugin directory transactionally.
+
+    First atomically rename the directory into the trash area, then delete the
+    trashed copy. If deletion fails, the plugin is already logically removed;
+    the leftover is swept by a later plugin command.
+
+    Raises:
+        PluginInUseError: when files are in use; the installation is untouched.
+    """
+    trashed = move_plugin_directory_to_trash(path)
+    try:
+        shutil.rmtree(trashed)
+    except OSError as e:
+        logger.debug("could not delete trashed directory %s: %s (leaving for later sweep)", trashed, e)
+
+
+def sweep_trash() -> None:
+    """Best-effort cleanup of leftovers in the trash area.
+
+    Leftovers accumulate from interrupted operations: partially deleted
+    uninstalls, staging directories, stale upgrade rollbacks. Call this only
+    between plugin operations, never while one is in flight: an active upgrade
+    keeps its rollback copy in the trash.
+    """
+    try:
+        trash_dir = get_trash_directory()
+        if not trash_dir.is_dir():
+            return
+        entries = list(trash_dir.iterdir())
+    except Exception as e:
+        logger.debug("could not enumerate trash directory: %s", e)
+        return
+
+    for entry in entries:
+        logger.debug("sweeping trash: %s", entry)
+        try:
+            if entry.is_dir() and not entry.is_symlink():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()
+        except OSError as e:
+            logger.debug("could not sweep %s: %s", entry, e)
 
 
 def get_metadata_from_plugin_directory(plugin_path: Path) -> IDAMetadataDescriptor:
@@ -147,6 +244,26 @@ def validate_metadata_in_plugin_directory(plugin_path: Path):
         if not logo_path.exists():
             logger.debug(f"Logo file not found in directory: '{metadata.plugin.logo_path}'")
             raise ValueError(f"Logo file not found in directory: '{metadata.plugin.logo_path}'")
+
+
+def is_valid_plugin_directory(path: Path) -> bool:
+    """Does the path hold a well-formed installed plugin?
+
+    Mirrors the criteria of ``get_installed_plugin_records``: the manifest
+    parses, referenced files exist, and the plugin name matches the directory
+    name. A directory that fails this is debris, e.g. remnants of an
+    interrupted uninstall (issue #228).
+    """
+    if not (path / "ida-plugin.json").exists():
+        return False
+
+    try:
+        validate_metadata_in_plugin_directory(path)
+        metadata = get_metadata_from_plugin_directory(path)
+    except ValueError:
+        return False
+
+    return metadata.plugin.name == path.name
 
 
 @dataclass(frozen=True)
@@ -394,6 +511,7 @@ def validate_can_install_plugin(
     Raises:
         InvalidPluginNameError: If plugin name is invalid
         PluginAlreadyInstalledError: If plugin is already installed
+        BrokenPluginInstallationError: If remnants of a broken installation are in the way
         PlatformIncompatibleError: If current platform is not supported
         IDAVersionIncompatibleError: If current IDA version is not supported
         PipNotAvailableError: If pip is not available (when dependencies are needed)
@@ -406,9 +524,20 @@ def validate_can_install_plugin(
         logger.error(f"Can't install plugin: {e!s}")
         raise InvalidPluginNameError(name, str(e)) from e
 
-    if destination_path.exists():
-        logger.warning(f"Plugin directory already exists: {destination_path}")
-        raise PluginAlreadyInstalledError(name, destination_path)
+    # is_symlink() is checked in addition to exists() so a broken symlink
+    # (dangling editable install) is reported rather than tripping up
+    # extraction later.
+    if destination_path.exists() or destination_path.is_symlink():
+        if is_valid_plugin_directory(destination_path):
+            logger.warning(f"Plugin directory already exists: {destination_path}")
+            raise PluginAlreadyInstalledError(name, destination_path)
+
+        # The directory exists but doesn't hold a working plugin: remnants of
+        # an interrupted install/uninstall (issue #228). Point the user at
+        # uninstall, which knows how to remove broken directories, rather than
+        # silently deleting data on the install path.
+        logger.warning(f"Broken plugin directory: {destination_path}")
+        raise BrokenPluginInstallationError(name, destination_path)
 
     platforms = metadata.plugin.platforms
     if current_platform not in platforms:
@@ -488,10 +617,18 @@ def extract_zip_subdirectory_to(zip_data: bytes, subdirectory: Path, destination
         else:
             plugin_dir_prefix = subdirectory.as_posix() + "/"
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir) / destination.name
-            temp_path.mkdir()
+        # Stage in the trash area beside the destination's plugins directory
+        # rather than in the system temp dir: (normally) the same filesystem,
+        # so the final rename is atomic on all platforms and the fully-formed
+        # plugin directory appears all at once. An interrupted install never
+        # leaves a partial destination, and abandoned staging directories are
+        # swept by later plugin commands.
+        staging_root = get_trash_directory(destination.parent)
+        staging_root.mkdir(parents=True, exist_ok=True)
+        temp_path = staging_root / f"{destination.name}.staging-{uuid.uuid4().hex[:8]}"
+        temp_path.mkdir()
 
+        try:
             # do validation pass before extracting any content to prevent any half-extracted content
             for file_info in zip_file.infolist():
                 if not should_extract_plugin_archive_path(plugin_dir_prefix, file_info):
@@ -518,18 +655,14 @@ def extract_zip_subdirectory_to(zip_data: bytes, subdirectory: Path, destination
                             shutil.copyfileobj(source_file, target_file)
                     except OSError as e:
                         if e.errno == errno.ENOSPC:
-                            shutil.rmtree(temp_path, ignore_errors=True)
                             raise NoSpaceError(target_path.parent) from e
                         raise
 
             logger.debug("creating plugin directory: %s", destination)
-            # `move` rather than `rename` to support cross-filesystem operations
-            try:
-                shutil.move(temp_path, destination)
-            except OSError as e:
-                if e.errno == errno.ENOSPC:
-                    raise NoSpaceError(destination.parent) from e
-                raise
+            os.rename(temp_path, destination)
+        except BaseException:
+            shutil.rmtree(temp_path, ignore_errors=True)
+            raise
 
 
 def _install_plugin_archive(
@@ -730,7 +863,7 @@ def install_plugin_directory_editable(source_dir: Path, name: str, no_build_isol
     if destination_path.is_symlink() or destination_path.is_file():
         destination_path.unlink()
     elif destination_path.exists():
-        shutil.rmtree(destination_path)
+        remove_plugin_directory(destination_path)
 
     try:
         destination_path.symlink_to(source_dir, target_is_directory=True)
@@ -809,10 +942,54 @@ def validate_can_uninstall_plugin(name: str) -> None:
     find_installed_plugin(name)
 
 
-def uninstall_plugin(name: str):
-    # NOTE: keep this in sync with upgrade (checkpoint/rollback) which has an inlined copy.
+def _uninstall_broken_plugin_directory(name: str) -> None:
+    """Remove a plugins/<name> directory that is not a valid installation.
 
-    record = find_installed_plugin(name)
+    Remnants of an interrupted uninstall (e.g. rmtree failed partway because a
+    running IDA held a DLL open, issue #228) don't count as installed, but the
+    directory blocks reinstallation. The user asked for this name to be gone,
+    so remove whatever is squatting on it.
+
+    Raises:
+        PluginNotInstalledError: If no matching directory exists at all
+        PluginInUseError: If files are in use; nothing is modified
+    """
+    plugins_dir = get_plugins_directory()
+    for child in plugins_dir.iterdir():
+        if child.name.lower() != name.lower():
+            continue
+        if not (child.is_dir() or child.is_symlink()):
+            continue
+
+        logger.warning("removing remnants of a broken plugin installation: %s", child)
+        if child.is_symlink():
+            child.unlink()
+            _remove_editable_pth_file(name)
+        else:
+            remove_plugin_directory(child)
+        return
+
+    raise PluginNotInstalledError(name)
+
+
+def uninstall_plugin(name: str):
+    """Remove an installed plugin.
+
+    Transactional: the plugin directory is first atomically renamed into the
+    trash area, then deleted. When plugin files are locked (e.g. loaded by a
+    running IDA on Windows), the rename fails without modifying anything.
+
+    Raises:
+        PluginNotInstalledError: If plugin is not installed
+        PluginInUseError: If plugin files are in use; the installation is untouched
+    """
+    try:
+        record = find_installed_plugin(name)
+    except PluginNotInstalledError:
+        # a directory may exist without being a valid installation (issue #228)
+        _uninstall_broken_plugin_directory(name)
+        return
+
     logger.info("uninstalling plugin: %s (%s)", record.name, record.version)
 
     # note that the pythonDependencies of the plugin aren't pruned.
@@ -830,7 +1007,7 @@ def uninstall_plugin(name: str):
         # to expose a src-layout package. Best-effort cleanup.
         _remove_editable_pth_file(record.name)
     else:
-        shutil.rmtree(record.path)
+        remove_plugin_directory(record.path)
 
 
 def is_plugin_installed(name: str) -> bool:
@@ -919,18 +1096,36 @@ def upgrade_plugin_archive(
             metadata.plugin.name, existing_metadata.plugin.version, metadata.plugin.version
         )
 
-    rollback_path = plugin_path.parent / (metadata.plugin.name + ".rollback")
-    if rollback_path.exists():
-        raise RuntimeError("rollback path already exists for some reason")
-    shutil.move(plugin_path, rollback_path)
+    # Checkpoint: atomically move the current install into the trash area
+    # before writing anything. When plugin files are locked (e.g. loaded by a
+    # running IDA on Windows), this fails without modifying the installation.
+    # The unique suffix means a stale rollback from an interrupted upgrade
+    # never blocks this one; the sweep removes such leftovers later.
+    trash_dir = get_trash_directory(plugin_path.parent)
+    trash_dir.mkdir(exist_ok=True)
+    rollback_path = trash_dir / f"{metadata.plugin.name}.rollback-{uuid.uuid4().hex[:8]}"
+    try:
+        os.rename(plugin_path, rollback_path)
+    except OSError as e:
+        if is_file_in_use_error(e):
+            raise PluginInUseError(metadata.plugin.name, plugin_path) from e
+        raise
 
     try:
         install_plugin_archive(zip_data, name, no_build_isolation=no_build_isolation, pip_options=pip_options)
     except Exception as e:
+        # note that Python dependencies installed before the failure aren't
+        # rolled back; they're upgraded in place and left as-is.
         logger.debug("error during upgrade: install: %s", e)
         logger.debug("rolling back to prior version")
         shutil.rmtree(plugin_path, ignore_errors=True)
-        shutil.move(rollback_path, plugin_path)
+        if plugin_path.exists():
+            logger.error("could not remove partial upgrade; previous version preserved at %s", rollback_path)
+        else:
+            os.rename(rollback_path, plugin_path)
         raise
     else:
-        shutil.rmtree(rollback_path)
+        try:
+            shutil.rmtree(rollback_path)
+        except OSError as e:
+            logger.debug("could not delete rollback copy %s: %s (leaving for later sweep)", rollback_path, e)

--- a/tests/lib/test_plugin_install.py
+++ b/tests/lib/test_plugin_install.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import subprocess
+import sys
 import tempfile
 import zipfile
 from pathlib import Path
@@ -16,13 +17,21 @@ from fixtures import (
     temp_env_var,
 )
 
-from hcli.lib.ida.plugin.exceptions import PluginVersionDowngradeError
+from hcli.lib.ida.plugin.exceptions import (
+    BrokenPluginInstallationError,
+    PluginAlreadyInstalledError,
+    PluginInUseError,
+    PluginNotInstalledError,
+    PluginVersionDowngradeError,
+)
 from hcli.lib.ida.plugin.install import (
     extract_zip_subdirectory_to,
     get_installed_plugins,
     get_plugin_directory,
+    get_trash_directory,
     install_plugin_archive,
     is_plugin_installed,
+    sweep_trash,
     uninstall_plugin,
     upgrade_plugin_archive,
     validate_archive_entry,
@@ -271,7 +280,9 @@ def test_extract_zip_subdirectory_to_posix_paths():
     subdirectory = Path("repo-main/plugin")
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        destination = Path(temp_dir) / "myplugin"
+        # nested like $IDAUSR/plugins/<name> so staging lands within temp_dir
+        destination = Path(temp_dir) / "plugins" / "myplugin"
+        destination.parent.mkdir()
         extract_zip_subdirectory_to(zip_data, subdirectory, destination)
 
         assert destination.exists()
@@ -339,6 +350,155 @@ class TestValidateArchiveEntry:
         subdirectory = Path("plugin")
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            destination = Path(temp_dir) / "myplugin"
+            # nested like $IDAUSR/plugins/<name> so staging lands within temp_dir
+            destination = Path(temp_dir) / "plugins" / "myplugin"
+            destination.parent.mkdir()
             with pytest.raises(ValueError, match="Path traversal"):
                 extract_zip_subdirectory_to(zip_data, subdirectory, destination)
+
+
+def test_install_already_installed(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+
+    install_plugin_archive(buf, "plugin1")
+    with pytest.raises(PluginAlreadyInstalledError):
+        install_plugin_archive(buf, "plugin1")
+
+
+def test_uninstall_not_installed(virtual_ida_environment):
+    with pytest.raises(PluginNotInstalledError):
+        uninstall_plugin("plugin1")
+
+
+def break_installed_plugin(name: str) -> Path:
+    """Simulate an interrupted uninstall (issue #228): the manifest is gone
+    but other plugin files remain, so the directory is not a valid
+    installation yet still blocks the name.
+    """
+    plugin_dir = get_plugin_directory(name)
+    (plugin_dir / "ida-plugin.json").unlink()
+    return plugin_dir
+
+
+def test_uninstall_broken_plugin_directory(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    plugin_dir = break_installed_plugin("plugin1")
+    assert not is_plugin_installed("plugin1")
+
+    # must remove the remnants rather than raise PluginNotInstalledError
+    uninstall_plugin("plugin1")
+    assert not plugin_dir.exists()
+
+
+def test_install_over_broken_plugin_directory(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    break_installed_plugin("plugin1")
+
+    # install must distinguish remnants from a working installation,
+    # and the suggested recovery (uninstall, then install) must work
+    with pytest.raises(BrokenPluginInstallationError):
+        install_plugin_archive(buf, "plugin1")
+
+    uninstall_plugin("plugin1")
+    install_plugin_archive(buf, "plugin1")
+    assert is_plugin_installed("plugin1")
+
+
+def test_trash_directory_not_scanned(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    # a trashed copy retains its manifest but must not count as installed
+    trash_dir = get_trash_directory()
+    trash_dir.mkdir(exist_ok=True)
+    os.rename(get_plugin_directory("plugin1"), trash_dir / "plugin1-cafe0123")
+
+    assert not is_plugin_installed("plugin1")
+    assert get_installed_plugins() == []
+
+
+def test_sweep_trash(virtual_ida_environment):
+    trash_dir = get_trash_directory()
+    trash_dir.mkdir(exist_ok=True)
+    (trash_dir / "plugin1-deadbeef").mkdir()
+    (trash_dir / "plugin1-deadbeef" / "plugin1.py").write_text("# leftover")
+    (trash_dir / "plugin2.staging-deadbeef").mkdir()
+
+    sweep_trash()
+    assert list(trash_dir.iterdir()) == []
+
+
+def test_sweep_trash_without_trash_directory(virtual_ida_environment):
+    assert not get_trash_directory().exists()
+    sweep_trash()
+
+
+def append_path_traversal_entry(zip_data: bytes, prefix: str) -> bytes:
+    """Append a malicious entry so extraction fails after validation of the
+    metadata has already passed -- forcing failure mid-upgrade.
+    """
+    buf = io.BytesIO(zip_data)
+    with zipfile.ZipFile(buf, "a") as zf:
+        zf.writestr(f"{prefix}/../evil.txt", "malicious content")
+    return buf.getvalue()
+
+
+def test_upgrade_failure_rolls_back(virtual_ida_environment):
+    v1 = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    v2 = (PLUGINS_DIR / "plugin1" / "plugin1-v2.0.0.zip").read_bytes()
+
+    install_plugin_archive(v1, "plugin1")
+
+    corrupt_v2 = append_path_traversal_entry(v2, "src-v2")
+    with pytest.raises(ValueError, match="Path traversal"):
+        upgrade_plugin_archive(corrupt_v2, "plugin1")
+
+    # the failed upgrade must restore the previous version
+    assert ("plugin1", "1.0.0") in get_installed_plugins()
+
+    # and must not leave state that blocks a later, good upgrade
+    upgrade_plugin_archive(v2, "plugin1")
+    assert ("plugin1", "2.0.0") in get_installed_plugins()
+
+
+def test_failed_extraction_leaves_no_partial_destination():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("plugin/ida-plugin.json", '{"test": true}')
+        zf.writestr("plugin/../../../tmp/evil.txt", "malicious content")
+    zip_data = buf.getvalue()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # nested like $IDAUSR/plugins/<name> so staging lands within temp_dir
+        destination = Path(temp_dir) / "plugins" / "myplugin"
+        destination.parent.mkdir()
+        with pytest.raises(ValueError, match="Path traversal"):
+            extract_zip_subdirectory_to(zip_data, Path("plugin"), destination)
+
+        assert not destination.exists()
+        assert list(get_trash_directory(destination.parent).iterdir()) == []
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="file locking semantics are Windows-specific")
+def test_uninstall_while_file_in_use_is_atomic(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    install_plugin_archive(buf, "plugin1")
+    plugin_dir = get_plugin_directory("plugin1")
+
+    # Python opens files without FILE_SHARE_DELETE, so while this handle is
+    # held, renaming the plugin directory fails just like when a running IDA
+    # has the plugin loaded.
+    with (plugin_dir / "plugin1.py").open("rb"):
+        with pytest.raises(PluginInUseError):
+            uninstall_plugin("plugin1")
+
+        # nothing was modified: still a fully valid installation
+        assert is_plugin_installed("plugin1")
+        assert (plugin_dir / "ida-plugin.json").exists()
+
+    uninstall_plugin("plugin1")
+    assert not is_plugin_installed("plugin1")

--- a/tests/lib/test_plugin_install.py
+++ b/tests/lib/test_plugin_install.py
@@ -408,6 +408,22 @@ def test_install_over_broken_plugin_directory(virtual_ida_environment):
     assert is_plugin_installed("plugin1")
 
 
+def test_uninstall_file_squatting_on_plugin_name(virtual_ida_environment):
+    buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
+    squatter = get_plugin_directory("plugin1")
+    squatter.write_text("not a plugin")
+
+    with pytest.raises(BrokenPluginInstallationError):
+        install_plugin_archive(buf, "plugin1")
+
+    # the suggested recovery (uninstall, then install) must work for files too
+    uninstall_plugin("plugin1")
+    assert not squatter.exists()
+
+    install_plugin_archive(buf, "plugin1")
+    assert is_plugin_installed("plugin1")
+
+
 def test_trash_directory_not_scanned(virtual_ida_environment):
     buf = (PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip").read_bytes()
     install_plugin_archive(buf, "plugin1")


### PR DESCRIPTION
Closes #228

## Problem

An uninstall interrupted partway (typically on Windows, where a DLL loaded by a running IDA cannot be deleted) left a directory that satisfied neither command's precondition: `uninstall` said "not installed" (no valid manifest) while `install` said "already installed" (directory exists). Full analysis in https://github.com/HexRaysSA/ida-hcli/issues/228#issuecomment-5060122385.

## Approach

Same-filesystem renames are atomic on Linux, macOS, and Windows, and on Windows renaming a directory containing a locked file fails *without modifying anything*. All destructive plugin operations now go through a trash area at `$IDAUSR/.plugins-trash/`, a sibling of the resolved `plugins/` directory. This stays on the same filesystem even when `plugins/` is a symlink, and sits outside `plugins/`, so neither IDA's plugin scan nor hcli's enumeration ever sees its contents.

Uninstall atomically renames the plugin directory into the trash, then deletes the trashed copy. When files are locked, the rename fails atomically and hcli raises the new `PluginInUseError` ("is IDA running?") with the installation untouched. Uninstall also removes a name-matching entry that is *not* a valid installation (a broken directory, a stale symlink, or a plain file), so remnants of an interrupted operation can always be cleaned up.

Install distinguishes "already installed" from broken remnants: the latter raises the new `BrokenPluginInstallationError`, which points at `hcli plugin uninstall <name>`. Install stays non-destructive toward directories it doesn't recognize. Extraction now stages under `.plugins-trash/` instead of the system temp dir and finishes with one atomic rename, so an interrupted install never leaves a partial plugin directory (the previous `shutil.move` from the system temp dir degraded to a non-atomic copy when `/tmp` was a different filesystem).

Upgrade checkpoints the current install into the trash (via the same rename helper as uninstall, under a unique `<name>.rollback-<suffix>` entry): the `RuntimeError: rollback path already exists` case is gone, a stale rollback can no longer sit at `plugins/<name>.rollback` where IDA would scan it, and a locked plugin surfaces `PluginInUseError` before anything is modified.

The install/uninstall/upgrade commands sweep trash leftovers best-effort at startup.

## Behavior per platform

On Linux and macOS the happy path is unchanged (unlinking mapped `.so`/`.dylib` files succeeds, so uninstall-while-IDA-is-running still works); the changes add crash/Ctrl-C/disk-full safety. On Windows with IDA running and a binary plugin loaded, uninstall/upgrade now fail cleanly with a "close IDA and try again" message instead of half-destroying the installation, and any previously wedged state self-heals via `uninstall`.

## Testing

New tests cover the issue-228 wedge in both directions (uninstall of remnants, install over remnants), a plain file squatting on a plugin name (removable via `uninstall`, so the recovery path never dead-ends), upgrade rollback on mid-upgrade failure plus a subsequent successful retry, no-partial-destination on failed extraction, trash contents being invisible to plugin enumeration, and sweep behavior. A Windows-only test holds a file handle open to reproduce the original report and asserts the uninstall fails atomically.

Known limitations: Python dependencies installed before a failed upgrade are not rolled back (upgraded in place, as before), and concurrent hcli processes are not coordinated: one process's sweep can remove another's in-flight rollback copy (concurrent plugin operations were already unsafe before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
