### PR TITLE
Automatically detect installations configured in $IDAUSR/ida-config.json

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -66,11 +66,15 @@ The following envrionment variables can be used to override system/version/confi
 | HCLI_CURRENT_IDA_VERSION     | auto-detected                                | Override IDA version (e.g., "9.1", "9.2")                     |
 | HCLI_CURRENT_IDA_PYTHON_EXE  | auto-detected                                | Override Python executable path for IDA Pro                   |
 
-In particular, if you haven't registered a default IDA installation, such as with:
-- `hcli ida install ... --set-default`, or
-- `hcli ida set-default /path/to/ida`
+Native IDA installers register the active idalib installation in
+`$IDAUSR/ida-config.json`. HCLI automatically imports that installation into
+its multi-installation registry and selects it when the existing HCLI default
+is also idalib-capable. This keeps plugin management aligned with a newly
+installed IDA while preserving an intentionally selected GUI-only default.
 
-then you may need to set `HCLI_CURRENT_IDA_INSTALL_DIR` when using the plugin manager, so that HCLI can find IDA and its resources.
+You can select another registered installation with `hcli ida switch`. If no
+installation is registered or configured, set `HCLI_CURRENT_IDA_INSTALL_DIR`
+when using the plugin manager so HCLI can find IDA and its resources.
 
 
 ## Cache & Storage

--- a/src/hcli/commands/ida/list.py
+++ b/src/hcli/commands/ida/list.py
@@ -11,7 +11,11 @@ from rich.text import Text
 
 from hcli.env import ENV
 from hcli.lib.config import config_store
-from hcli.lib.ida import is_ida_dir, parse_instance_version
+from hcli.lib.ida import (
+    is_ida_dir,
+    parse_instance_version,
+    synchronize_idalib_installation_with_hcli,
+)
 
 console = Console()
 
@@ -34,6 +38,8 @@ def _sort_instance_rows(instance_rows: list[InstanceRow]) -> None:
 @click.command()
 def list_instances() -> None:
     """List all registered IDA Pro instances."""
+    synchronize_idalib_installation_with_hcli()
+
     # Get existing instances and default
     instances: dict[str, str] = config_store.get_object("ida.instances", {}) or {}
     default_instance = config_store.get_string("ida.default", "")

--- a/src/hcli/commands/ida/set_default.py
+++ b/src/hcli/commands/ida/set_default.py
@@ -10,6 +10,8 @@ from hcli.lib.ida import (
     find_standard_installations,
     get_ida_config_path,
     is_ida_dir,
+    register_ida_installation,
+    synchronize_idalib_installation_with_hcli,
 )
 
 
@@ -23,6 +25,7 @@ def set_default_ida(path: Path | None) -> None:
     config_path = get_ida_config_path()
 
     if path is None:
+        synchronize_idalib_installation_with_hcli()
         if not config_path.exists():
             console.print("[yellow]No default IDA installation set.[/yellow]")
         else:
@@ -60,6 +63,7 @@ def set_default_ida(path: Path | None) -> None:
             json.dumps({"Paths": {"ida-install-dir": str(install_dir.absolute())}}), encoding="utf-8"
         )
         console.print("[grey69]Wrote default ida-config.json[/grey69]")
+        register_ida_installation(install_dir, make_default=True)
         console.print(f"[green]Set default IDA installation: {install_dir.absolute()}[/green]")
     else:
         doc = json.loads(config_path.read_text(encoding="utf-8"))
@@ -69,6 +73,7 @@ def set_default_ida(path: Path | None) -> None:
         new = str(install_dir.absolute())
         doc["Paths"]["ida-install-dir"] = new
         _ = config_path.write_text(json.dumps(doc), encoding="utf-8")
+        register_ida_installation(install_dir, make_default=True)
         console.print("[grey69]Updated ida-config.json:[/grey69]")
         console.print(f"[grey69]  default install path: {existing}[/grey69]")
         console.print(f"[grey69]                     -> {new}[/grey69]")

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -27,6 +27,7 @@ from hcli.lib.util.io import NoSpaceError, check_free_space, get_os
 from hcli.lib.venv import resolve_user_virtual_env
 
 logger = logging.getLogger(__name__)
+_IDALIB_SYNC_PATH_KEY = "ida.idalib-observed-install-dir"
 
 
 class DownloadResource(NamedTuple):
@@ -884,6 +885,90 @@ def find_hcli_default_ida_install_directory() -> Path | None:
     return install_dir
 
 
+def register_ida_installation(path: Path, *, make_default: bool = False) -> str:
+    """Register an installation by path and optionally select it as default.
+
+    Existing registrations are reused by resolved path. Name collisions get a
+    numeric suffix, matching ``hcli ida install`` behavior.
+    """
+    from hcli.lib.config import config_store
+
+    install_dir = _normalize_install_dir(path).resolve()
+    instances: dict[str, str] = config_store.get_object("ida.instances", {}) or {}
+    for name, configured_path in instances.items():
+        try:
+            if _normalize_install_dir(Path(configured_path)).resolve() == install_dir:
+                if make_default:
+                    config_store.set_string("ida.default", name)
+                return name
+        except OSError:
+            continue
+
+    base_name = generate_instance_name(install_dir)
+    name = base_name
+    suffix = 2
+    while name in instances:
+        name = f"{base_name}-{suffix}"
+        suffix += 1
+    instances[name] = str(install_dir)
+    config_store.set_object("ida.instances", instances)
+    if make_default:
+        config_store.set_string("ida.default", name)
+    return name
+
+
+def synchronize_idalib_installation_with_hcli() -> Path | None:
+    """Import a newly installer-selected idalib path into hcli's registry.
+
+    The native IDA installer updates ``ida-config.json`` but does not know about
+    hcli's newer multi-installation registry. Reconcile each newly observed path
+    once, so a later explicit ``hcli ida remove`` or GUI-only selection is not
+    continually undone. If both defaults are idalib-capable, the newly selected
+    installer path is authoritative.
+    """
+    from hcli.lib.config import config_store
+
+    try:
+        config = get_ida_config()
+    except (OSError, ValueError) as exc:
+        logger.warning("could not read idalib configuration for hcli sync: %s", exc)
+        return None
+    configured_path = config.paths.installation_directory
+    if configured_path is None:
+        return None
+
+    install_dir = _normalize_install_dir(configured_path)
+    try:
+        usable = (
+            install_dir.exists()
+            and is_ida_dir(install_dir)
+            and is_idalib_capable_installation(install_dir)
+        )
+    except OSError:
+        usable = False
+    if not usable:
+        return None
+
+    resolved_install_dir = install_dir.resolve()
+    observed_path = config_store.get_string(_IDALIB_SYNC_PATH_KEY, "")
+    if observed_path:
+        try:
+            if _normalize_install_dir(Path(observed_path)).resolve() == resolved_install_dir:
+                return install_dir
+        except OSError:
+            pass
+
+    hcli_default = find_hcli_default_ida_install_directory()
+    make_default = (
+        hcli_default is None
+        or hcli_default.resolve() == resolved_install_dir
+        or is_idalib_capable_installation(hcli_default)
+    )
+    register_ida_installation(install_dir, make_default=make_default)
+    config_store.set_string(_IDALIB_SYNC_PATH_KEY, str(resolved_install_dir))
+    return install_dir
+
+
 def find_current_ida_install_directory() -> Path:
     # duplicate here, because we prefer access through ENV
     # but tests might update env vars for the current process.
@@ -895,6 +980,10 @@ def find_current_ida_install_directory() -> Path:
 
     if ENV.IDADIR is not None:
         return _normalize_install_dir(Path(ENV.IDADIR))
+
+    # A native installer can update ida-config.json without updating hcli's
+    # multi-installation registry. Reconcile that before choosing the default.
+    synchronize_idalib_installation_with_hcli()
 
     hcli_default = find_hcli_default_ida_install_directory()
     if hcli_default is not None:

--- a/src/hcli/main.py
+++ b/src/hcli/main.py
@@ -39,7 +39,13 @@ def _get_status_section() -> str:
             is_ida_dir,
             is_idalib_capable_installation,
             parse_instance_version,
+            synchronize_idalib_installation_with_hcli,
         )
+
+        # Native IDA installers update ida-config.json independently of hcli's
+        # instance registry. Keep the status summary and command resolution in
+        # agreement before displaying either default.
+        synchronize_idalib_installation_with_hcli()
 
         lines: list[str] = []
 

--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -29,6 +29,7 @@ from hcli.lib.ida import (
     parse_version_from_ida_pro_py,
     parse_version_from_windows_registry,
     select_default_ida_instance,
+    synchronize_idalib_installation_with_hcli,
 )
 from hcli.lib.ida.version import normalize_ida_binary_version, parse_version_from_ida_binary
 
@@ -51,6 +52,108 @@ def test_find_current_ida_install_directory():
     assert isinstance(result, Path)
     assert result.exists()
     assert result.is_dir()
+
+
+class _FakeConfigStore:
+    def __init__(self, instances, default):
+        self.data = {
+            "ida.instances": dict(instances),
+            "ida.default": default,
+        }
+
+    def get_string(self, key, default=""):
+        return self.data.get(key, default)
+
+    def get_object(self, key, default=None):
+        return self.data.get(key, default)
+
+    def set_string(self, key, value):
+        self.data[key] = value
+
+    def set_object(self, key, value):
+        self.data[key] = value
+
+
+def test_syncs_native_installer_idalib_path_to_hcli_default(monkeypatch, tmp_path):
+    ida93 = tmp_path / "IDA Professional 9.3"
+    ida94 = tmp_path / "IDA Professional 9.4"
+    ida93.mkdir()
+    ida94.mkdir()
+    store = _FakeConfigStore({"ida-pro-9.3": str(ida93)}, "ida-pro-9.3")
+    selected = [ida94]
+
+    monkeypatch.setattr("hcli.lib.config.config_store", store)
+    monkeypatch.setattr(
+        "hcli.lib.ida.get_ida_config",
+        lambda: types.SimpleNamespace(
+            paths=types.SimpleNamespace(installation_directory=selected[0])
+        ),
+    )
+    monkeypatch.setattr("hcli.lib.ida.is_ida_dir", lambda _path: True)
+    monkeypatch.setattr(
+        "hcli.lib.ida.is_idalib_capable_installation", lambda _path: True
+    )
+
+    assert synchronize_idalib_installation_with_hcli() == ida94
+    assert store.data["ida.instances"]["ida-pro-9.4"] == str(ida94)
+    assert store.data["ida.default"] == "ida-pro-9.4"
+    assert find_current_ida_install_directory() == ida94
+
+    # Reconciliation is edge-triggered. An explicit later registry change must
+    # not be undone until the native installer selects a different path.
+    del store.data["ida.instances"]["ida-pro-9.4"]
+    store.data["ida.default"] = "ida-pro-9.3"
+    assert synchronize_idalib_installation_with_hcli() == ida94
+    assert "ida-pro-9.4" not in store.data["ida.instances"]
+    assert store.data["ida.default"] == "ida-pro-9.3"
+
+    ida95 = tmp_path / "IDA Professional 9.5"
+    ida95.mkdir()
+    selected[0] = ida95
+    assert synchronize_idalib_installation_with_hcli() == ida95
+    assert store.data["ida.instances"]["ida-pro-9.5"] == str(ida95)
+    assert store.data["ida.default"] == "ida-pro-9.5"
+
+
+def test_malformed_idalib_config_preserves_hcli_default(monkeypatch, tmp_path):
+    ida94 = tmp_path / "IDA Professional 9.4"
+    ida94.mkdir()
+    store = _FakeConfigStore({"ida-pro-9.4": str(ida94)}, "ida-pro-9.4")
+
+    monkeypatch.setattr("hcli.lib.config.config_store", store)
+    monkeypatch.setattr(
+        "hcli.lib.ida.get_ida_config",
+        lambda: (_ for _ in ()).throw(ValueError("invalid config")),
+    )
+    monkeypatch.setattr("hcli.lib.ida.is_ida_dir", lambda _path: True)
+
+    assert find_current_ida_install_directory() == ida94
+    assert store.data["ida.default"] == "ida-pro-9.4"
+
+
+def test_sync_preserves_non_idalib_hcli_default(monkeypatch, tmp_path):
+    gui_only = tmp_path / "IDA Free 9.4"
+    idalib = tmp_path / "IDA Professional 9.4"
+    gui_only.mkdir()
+    idalib.mkdir()
+    store = _FakeConfigStore({"ida-free-9.4": str(gui_only)}, "ida-free-9.4")
+
+    monkeypatch.setattr("hcli.lib.config.config_store", store)
+    monkeypatch.setattr(
+        "hcli.lib.ida.get_ida_config",
+        lambda: types.SimpleNamespace(
+            paths=types.SimpleNamespace(installation_directory=idalib)
+        ),
+    )
+    monkeypatch.setattr("hcli.lib.ida.is_ida_dir", lambda _path: True)
+    monkeypatch.setattr(
+        "hcli.lib.ida.is_idalib_capable_installation",
+        lambda path: Path(path) == idalib,
+    )
+
+    assert synchronize_idalib_installation_with_hcli() == idalib
+    assert store.data["ida.instances"]["ida-pro-9.4"] == str(idalib)
+    assert store.data["ida.default"] == "ida-free-9.4"
 
 
 def has_idat():


### PR DESCRIPTION
My situation:
- IDA 9.3 was installed and set as default around the release
- I installed 9.4 through the installer, marking it as idalib default
- `hcli plugin install` fails on plugins requiring 9.4 because I didn't manually add 9.4 to hcli

This PR automatically imports IDA configured in `ida-config.json` for a better UX