### PR TITLE
fix: split IDAUSR environment variable

### DIFF
--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -139,7 +139,7 @@ def get_ida_user_dir() -> Path:
         return Path(ENV.HCLI_IDAUSR)
 
     if ENV.IDAUSR is not None:
-        return Path(ENV.IDAUSR)
+        return Path(ENV.IDAUSR.split(os.pathsep)[0])
 
     os_ = get_os()
     if os_ == "windows":


### PR DESCRIPTION
This is what IDA does when parsing IDAUSR from the environment variable