### PR TITLE
--json output for plugin status/search/explain-environment

### DIFF
--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -171,10 +171,10 @@ plugin.add_command(get_plugin_status, name="status")
 
 @click.command(name="list", hidden=True)
 @click.argument("plugins", nargs=-1)
-@click.option("--offline", is_flag=True, default=False)
+@click.option("--skip-upgrade-check", is_flag=True, default=False)
 @click.option("--json", "json_output", is_flag=True, default=False)
 @click.pass_context
-def _plugin_status_alias(ctx, plugins: tuple[str, ...], offline: bool, json_output: bool) -> None:
+def _plugin_status_alias(ctx, plugins: tuple[str, ...], skip_upgrade_check: bool, json_output: bool) -> None:
     """Show installed plugins and their upgrade status (alias for 'status')."""
     ctx.forward(get_plugin_status)
 

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -171,8 +171,9 @@ plugin.add_command(get_plugin_status, name="status")
 
 @click.command(name="list", hidden=True)
 @click.argument("plugins", nargs=-1)
+@click.option("--offline", is_flag=True, default=False)
 @click.pass_context
-def _plugin_status_alias(ctx, plugins: tuple[str, ...]) -> None:
+def _plugin_status_alias(ctx, plugins: tuple[str, ...], offline: bool) -> None:
     """Show installed plugins and their upgrade status (alias for 'status')."""
     ctx.forward(get_plugin_status)
 

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -170,8 +170,9 @@ plugin.add_command(get_plugin_status, name="status")
 
 
 @click.command(name="list", hidden=True)
+@click.argument("plugins", nargs=-1)
 @click.pass_context
-def _plugin_status_alias(ctx) -> None:
+def _plugin_status_alias(ctx, plugins: tuple[str, ...]) -> None:
     """Show installed plugins and their upgrade status (alias for 'status')."""
     ctx.forward(get_plugin_status)
 

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -172,8 +172,9 @@ plugin.add_command(get_plugin_status, name="status")
 @click.command(name="list", hidden=True)
 @click.argument("plugins", nargs=-1)
 @click.option("--offline", is_flag=True, default=False)
+@click.option("--json", "json_output", is_flag=True, default=False)
 @click.pass_context
-def _plugin_status_alias(ctx, plugins: tuple[str, ...], offline: bool) -> None:
+def _plugin_status_alias(ctx, plugins: tuple[str, ...], offline: bool, json_output: bool) -> None:
     """Show installed plugins and their upgrade status (alias for 'status')."""
     ctx.forward(get_plugin_status)
 

--- a/src/hcli/commands/plugin/explain_environment.py
+++ b/src/hcli/commands/plugin/explain_environment.py
@@ -114,8 +114,7 @@ class PythonVersionReport(BaseModel):
 
 
 class EnvironmentNote(BaseModel):
-    # diagnostic notes describe the environment we found, hints suggest what to do about it.
-    kind: Literal["diagnostic", "hint"]
+    kind: Literal["diagnostic", "hint", "warning"]
     text: str
 
 
@@ -301,6 +300,7 @@ def collect_python_version() -> PythonVersionReport:
 def collect_notes(
     python_environment: PythonEnvironmentReport,
     idapython_virtualenv: IdaPythonVirtualEnvReport | None,
+    python_version: PythonVersionReport,
 ) -> list[EnvironmentNote]:
     notes: list[EnvironmentNote] = []
 
@@ -366,6 +366,24 @@ def collect_notes(
             )
         )
 
+    if python_version.final_version:
+        try:
+            parts = python_version.final_version.split(".")
+            major, minor = int(parts[0]), int(parts[1])
+            if (major, minor) <= (3, 9):
+                notes.append(
+                    EnvironmentNote(
+                        kind="warning",
+                        text=(
+                            f"Python {python_version.final_version} has reached end-of-life. "
+                            "Many IDA plugins may not support it. "
+                            "Consider upgrading to a newer Python and using idapyswitch to point IDA at it."
+                        ),
+                    )
+                )
+        except (ValueError, IndexError):
+            pass
+
     return notes
 
 
@@ -382,7 +400,7 @@ def collect_environment_report() -> EnvironmentReport:
     report.python_environment = collect_python_environment()
     report.idapython_virtualenv = collect_idapython_virtualenv(report.python_environment.idat_probe)
     report.python_version = collect_python_version()
-    report.notes = collect_notes(report.python_environment, report.idapython_virtualenv)
+    report.notes = collect_notes(report.python_environment, report.idapython_virtualenv, report.python_version)
 
     return report
 
@@ -534,7 +552,10 @@ def render_python_version_text(report: PythonVersionReport) -> None:
 
 def render_notes_text(notes: list[EnvironmentNote]) -> None:
     for note in notes:
-        if note.kind == "diagnostic":
+        if note.kind == "warning":
+            console.print(f"[bold yellow]Warning:[/bold yellow] {escape(note.text)}", highlight=False)
+            console.print()
+        elif note.kind == "diagnostic":
             console.print(f"[dim]Note: {escape(note.text)}[/dim]", highlight=False)
             console.print()
         else:
@@ -570,26 +591,6 @@ def render_environment_report_json(report: EnvironmentReport) -> None:
 def explain_environment(json_output: bool) -> None:
     """Show how the current IDA installation and Python version are detected. (experimental)"""
     report = collect_environment_report()
-
-    try:
-        final_version = detect_current_python_version()
-        parts = final_version.split(".")
-        major, minor = int(parts[0]), int(parts[1])
-        if (major, minor) <= (3, 9):
-            notes.append(
-                f"Python {final_version} has reached end-of-life. "
-                "Many IDA plugins may not support it. "
-                "Consider upgrading to a newer Python and using idapyswitch to point IDA at it."
-            )
-            if not json_output:
-                console.print()
-                console.print(
-                    f"[bold yellow]Warning:[/bold yellow] Python {final_version} has reached end-of-life. "
-                    "Many IDA plugins may not support it. "
-                    "Consider upgrading to a newer Python and using idapyswitch to point IDA at it.",
-                )
-    except Exception:
-        pass
 
     if json_output:
         render_environment_report_json(report)

--- a/src/hcli/commands/plugin/explain_environment.py
+++ b/src/hcli/commands/plugin/explain_environment.py
@@ -28,10 +28,8 @@ from hcli.lib.ida.python import (
     GET_PYTHON_INFO_PY,
     PythonNotFoundError,
     _derive_python_exe,
-    build_console_script_search_dirs,
     detect_current_python_version,
     find_current_python_executable,
-    probe_console_script_info,
 )
 from hcli.lib.venv import find_candidate_virtual_envs, is_uv_cache_virtual_env, resolve_user_virtual_env
 
@@ -370,52 +368,6 @@ def explain_environment(json_output: bool) -> None:
 
     emit("")
 
-    # --- Console scripts (e.g. locating a pip-installed script like `speakeasy`) ---
-
-    emit("[bold]Console scripts[/bold]")
-    console_scripts_report: dict[str, Any] = {
-        "python_exe": None,
-        "prefix": None,
-        "base_prefix": None,
-        "scripts_dir": None,
-        "os_name": None,
-        "search_dirs": [],
-        "error": None,
-    }
-    report["console_scripts"] = console_scripts_report
-
-    if python_exe is None:
-        console_scripts_report["error"] = "no final python exe was detected above"
-        if not json_output:
-            _err("search dirs", "no final python exe was detected above")
-    else:
-        try:
-            csi = probe_console_script_info(python_exe)
-            search_dirs = build_console_script_search_dirs(
-                csi["prefix"], csi["base_prefix"], csi["scripts_dir"], csi["os_name"]
-            )
-            console_scripts_report.update(
-                {
-                    "python_exe": str(python_exe),
-                    "prefix": csi["prefix"],
-                    "base_prefix": csi["base_prefix"],
-                    "scripts_dir": csi["scripts_dir"],
-                    "os_name": csi["os_name"],
-                    "search_dirs": search_dirs,
-                }
-            )
-            if not json_output:
-                _kv("prefix", _path(csi["prefix"]))
-                _kv("base_prefix", _path(csi["base_prefix"]))
-                _kv("scripts dir", _path(csi["scripts_dir"]))
-                for directory in search_dirs:
-                    _kv("  search dir", _path(directory))
-        except Exception as e:
-            console_scripts_report["error"] = f"{type(e).__name__}: {e}"
-            if not json_output:
-                _err("search dirs", f"{type(e).__name__}: {e}")
-
-    emit("")
     is_hcli_own_venv = process_virtual_env and os.path.normcase(
         os.path.abspath(process_virtual_env)
     ) == os.path.normcase(os.path.abspath(sys.prefix))

--- a/src/hcli/commands/plugin/explain_environment.py
+++ b/src/hcli/commands/plugin/explain_environment.py
@@ -4,9 +4,10 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Literal
 
 import rich_click as click
+from pydantic import BaseModel
 from rich.markup import escape
 
 from hcli.env import ENV
@@ -34,6 +35,357 @@ from hcli.lib.ida.python import (
 from hcli.lib.venv import find_candidate_virtual_envs, is_uv_cache_virtual_env, resolve_user_virtual_env
 
 
+class InstallationEntry(BaseModel):
+    path: str
+    version: str | None = None
+
+
+class KnownInstallationsReport(BaseModel):
+    installations: list[InstallationEntry] = []
+    error: str | None = None
+
+
+class SelectedInstallationReport(BaseModel):
+    install_dir: str | None = None
+    install_dir_source: str | None = None
+    install_dir_error: str | None = None
+    resolved_dir: str | None = None
+    resolved_dir_error: str | None = None
+
+
+class ArchitectureAndVersionReport(BaseModel):
+    ida_binary: str | None = None
+    ida_binary_error: str | None = None
+    binary_arch: str | None = None
+    binary_arch_error: str | None = None
+    platform: str | None = None
+    platform_error: str | None = None
+    ida_version: str | None = None
+    ida_version_source: str | None = None
+    ida_version_error: str | None = None
+
+
+class CandidateVirtualEnv(BaseModel):
+    path: str
+    source: str
+
+
+class IdatProbe(BaseModel):
+    """What IDA's embedded Python reports about itself, via GET_PYTHON_INFO_PY."""
+
+    frozen: bool = False
+    prefix: str
+    base_prefix: str
+    executable: str | None = None
+    virtual_env: str | None = None
+    idapython_venv_executable: str | None = None
+    version_major: int
+    version_minor: int
+
+
+class PythonEnvironmentReport(BaseModel):
+    virtual_env: str | None = None
+    virtual_env_is_uv_cache: bool = False
+    user_virtual_env: str | None = None
+    candidate_virtual_envs: list[CandidateVirtualEnv] = []
+    python_exe: str | None = None
+    python_exe_source: str | None = None
+    idat_probe: IdatProbe | None = None
+    idat_probe_error: str | None = None
+    derived_exe: str | None = None
+    derived_exe_error: str | None = None
+
+
+class IdaPythonVirtualEnvReport(BaseModel):
+    venv: str
+    home: str | None = None
+    system_site_packages: str | None = None
+
+
+class PythonVersionReport(BaseModel):
+    final_python_exe: str | None = None
+    final_python_exe_error: str | None = None
+    probed_version: str | None = None
+    probed_version_error: str | None = None
+    hcli_interpreter_version: str
+    hcli_interpreter_path: str
+    final_version: str | None = None
+    final_version_error: str | None = None
+
+
+class EnvironmentNote(BaseModel):
+    # diagnostic notes describe the environment we found, hints suggest what to do about it.
+    kind: Literal["diagnostic", "hint"]
+    text: str
+
+
+class EnvironmentReport(BaseModel):
+    known_installations: KnownInstallationsReport
+    selected_installation: SelectedInstallationReport
+    # the sections below need an installation directory, so they're absent when it can't be resolved.
+    architecture_and_version: ArchitectureAndVersionReport | None = None
+    python_environment: PythonEnvironmentReport | None = None
+    idapython_virtualenv: IdaPythonVirtualEnvReport | None = None
+    python_version: PythonVersionReport | None = None
+    notes: list[EnvironmentNote] = []
+
+
+def collect_known_installations() -> KnownInstallationsReport:
+    report = KnownInstallationsReport()
+
+    try:
+        for path in sorted(find_standard_installations()):
+            version = parse_version_from_ida_pro_py(path) or parse_version_from_dir_name(path) or None
+            report.installations.append(InstallationEntry(path=str(path), version=version))
+    except Exception as e:
+        report.error = str(e)
+
+    return report
+
+
+def collect_selected_installation() -> SelectedInstallationReport:
+    report = SelectedInstallationReport()
+
+    env_install_dir = os.environ.get("HCLI_CURRENT_IDA_INSTALL_DIR") or ENV.HCLI_CURRENT_IDA_INSTALL_DIR
+    if env_install_dir:
+        report.install_dir = str(env_install_dir)
+        report.install_dir_source = "$HCLI_CURRENT_IDA_INSTALL_DIR"
+    else:
+        config_path = get_ida_config_path()
+        try:
+            config = get_ida_config()
+            if config.paths.installation_directory:
+                report.install_dir = str(config.paths.installation_directory)
+                report.install_dir_source = str(config_path)
+            else:
+                report.install_dir_error = f"not configured in {config_path}"
+        except Exception as e:
+            report.install_dir_error = str(e)
+
+    try:
+        report.resolved_dir = str(find_current_ida_install_directory())
+    except MissingCurrentInstallationDirectory as e:
+        report.resolved_dir_error = str(e)
+
+    return report
+
+
+def collect_architecture_and_version(install_dir: Path) -> ArchitectureAndVersionReport:
+    report = ArchitectureAndVersionReport()
+
+    try:
+        ida_binary = find_current_ida_executable()
+        report.ida_binary = str(ida_binary)
+    except Exception as e:
+        report.ida_binary_error = str(e)
+    else:
+        try:
+            report.binary_arch = detect_binary_arch(ida_binary)
+        except Exception as e:
+            report.binary_arch_error = str(e)
+
+    try:
+        report.platform = find_current_ida_platform()
+    except Exception as e:
+        report.platform_error = str(e)
+
+    env_version = os.environ.get("HCLI_CURRENT_IDA_VERSION") or ENV.HCLI_CURRENT_IDA_VERSION
+    if env_version:
+        report.ida_version = env_version
+        report.ida_version_source = "$HCLI_CURRENT_IDA_VERSION"
+    else:
+        sdk_version = parse_version_from_ida_pro_py(install_dir)
+        dir_version = parse_version_from_dir_name(install_dir)
+        if sdk_version:
+            report.ida_version = sdk_version
+            report.ida_version_source = "python/ida_pro.py SDK docstring"
+        elif dir_version:
+            report.ida_version = dir_version
+            report.ida_version_source = "directory name"
+        else:
+            report.ida_version_error = "could not determine"
+
+    return report
+
+
+def collect_python_environment() -> PythonEnvironmentReport:
+    report = PythonEnvironmentReport()
+
+    process_virtual_env = os.environ.get("VIRTUAL_ENV")
+    report.virtual_env = process_virtual_env
+    report.virtual_env_is_uv_cache = process_virtual_env is not None and is_uv_cache_virtual_env(process_virtual_env)
+
+    user_venv = resolve_user_virtual_env()
+    report.user_virtual_env = str(user_venv) if user_venv else None
+
+    report.candidate_virtual_envs = [
+        CandidateVirtualEnv(path=str(candidate.path), source=candidate.source)
+        for candidate in find_candidate_virtual_envs()
+        if not is_uv_cache_virtual_env(candidate.path)
+    ]
+
+    env_python = os.environ.get("HCLI_CURRENT_IDA_PYTHON_EXE") or ENV.HCLI_CURRENT_IDA_PYTHON_EXE
+    if env_python:
+        # the interpreter is pinned, so there's nothing for idat to tell us.
+        report.python_exe = str(env_python)
+        report.python_exe_source = "$HCLI_CURRENT_IDA_PYTHON_EXE"
+        return report
+
+    try:
+        info = run_py_in_current_idapython(GET_PYTHON_INFO_PY)
+        report.idat_probe = IdatProbe.model_validate(info)
+
+        try:
+            report.derived_exe = str(_derive_python_exe(info))
+        except PythonNotFoundError as e:
+            report.derived_exe_error = str(e)
+    except Exception as e:
+        report.idat_probe_error = f"{type(e).__name__}: {e}"
+
+    return report
+
+
+def collect_idapython_virtualenv(probe: IdatProbe | None) -> IdaPythonVirtualEnvReport | None:
+    ida_venv = probe.virtual_env if probe else None
+    if not ida_venv:
+        return None
+
+    venv_path = Path(ida_venv)
+    report = IdaPythonVirtualEnvReport(venv=str(venv_path))
+
+    pyvenv_cfg = venv_path / "pyvenv.cfg"
+    if pyvenv_cfg.is_file():
+        for line in pyvenv_cfg.read_text().splitlines():
+            if line.startswith("home"):
+                report.home = line.split("=", 1)[1].strip()
+            elif line.startswith("include-system-site-packages"):
+                report.system_site_packages = line.split("=", 1)[1].strip()
+
+    return report
+
+
+def collect_python_version() -> PythonVersionReport:
+    report = PythonVersionReport(
+        hcli_interpreter_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+        hcli_interpreter_path=sys.executable,
+    )
+
+    python_exe: Path | None = None
+    try:
+        python_exe = find_current_python_executable()
+        report.final_python_exe = str(python_exe)
+
+        result = subprocess.run(
+            [str(python_exe), "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+        report.probed_version = result.stdout.strip()
+    except Exception as e:
+        if python_exe is None:
+            report.final_python_exe_error = f"{type(e).__name__}: {e}"
+        else:
+            report.probed_version_error = f"{type(e).__name__}: {e}"
+
+    try:
+        report.final_version = detect_current_python_version()
+    except Exception as e:
+        report.final_version_error = f"{type(e).__name__}: {e}"
+
+    return report
+
+
+def collect_notes(
+    python_environment: PythonEnvironmentReport,
+    idapython_virtualenv: IdaPythonVirtualEnvReport | None,
+) -> list[EnvironmentNote]:
+    notes: list[EnvironmentNote] = []
+
+    process_virtual_env = python_environment.virtual_env
+    is_uv_cache = python_environment.virtual_env_is_uv_cache
+    user_venv = python_environment.user_virtual_env
+    is_hcli_own_venv = bool(process_virtual_env) and os.path.normcase(
+        os.path.abspath(process_virtual_env or "")
+    ) == os.path.normcase(os.path.abspath(sys.prefix))
+
+    if is_uv_cache and user_venv:
+        notes.append(
+            EnvironmentNote(
+                kind="diagnostic",
+                text=f"$VIRTUAL_ENV is a uv cache overlay. Resolved user virtualenv: {user_venv}",
+            )
+        )
+    elif is_uv_cache:
+        notes.append(
+            EnvironmentNote(
+                kind="diagnostic",
+                text=(
+                    "$VIRTUAL_ENV is a uv cache overlay, not your virtualenv. No user virtualenvs were found on $PATH."
+                ),
+            )
+        )
+    elif process_virtual_env and is_hcli_own_venv:
+        notes.append(
+            EnvironmentNote(
+                kind="diagnostic",
+                text=(
+                    f"$VIRTUAL_ENV ({process_virtual_env}) is the hcli process environment, not the IDA Python "
+                    f"environment. It is not used for plugin installation."
+                ),
+            )
+        )
+    elif process_virtual_env and not idapython_virtualenv:
+        notes.append(
+            EnvironmentNote(
+                kind="diagnostic",
+                text=(
+                    f"$VIRTUAL_ENV is set ({process_virtual_env}) but was not detected inside IDA. "
+                    f"To use this virtualenv with IDA, activate it via idapythonrc.py."
+                ),
+            )
+        )
+
+    if not idapython_virtualenv:
+        notes.append(
+            EnvironmentNote(
+                kind="hint",
+                text=(
+                    "To use a virtualenv with IDA, see: "
+                    "https://community.hex-rays.com/t/using-a-virtualenv-for-idapython/261/5"
+                ),
+            )
+        )
+    if not user_venv and not is_uv_cache and not idapython_virtualenv:
+        notes.append(
+            EnvironmentNote(
+                kind="hint",
+                text="To change IDA's Python, use idapyswitch to point at a different interpreter.",
+            )
+        )
+
+    return notes
+
+
+def collect_environment_report() -> EnvironmentReport:
+    report = EnvironmentReport(
+        known_installations=collect_known_installations(),
+        selected_installation=collect_selected_installation(),
+    )
+
+    if report.selected_installation.resolved_dir is None:
+        return report
+
+    report.architecture_and_version = collect_architecture_and_version(Path(report.selected_installation.resolved_dir))
+    report.python_environment = collect_python_environment()
+    report.idapython_virtualenv = collect_idapython_virtualenv(report.python_environment.idat_probe)
+    report.python_version = collect_python_version()
+    report.notes = collect_notes(report.python_environment, report.idapython_virtualenv)
+
+    return report
+
+
 def _path(p: object) -> str:
     return f"[repr.path]{escape(str(p))}[/repr.path]"
 
@@ -49,394 +401,174 @@ def _err(key: str, error: str) -> None:
     console.print(f"  [bold]{key}[/bold]: [red]{escape(error)}[/red]")
 
 
+def render_known_installations_text(report: KnownInstallationsReport) -> None:
+    console.print("[bold]Known IDA installations[/bold]")
+
+    for installation in report.installations:
+        console.print(f"  {_path(installation.path)}  [dim](v{installation.version or '?'})[/dim]")
+
+    if report.error:
+        _err("scan", report.error)
+    elif not report.installations:
+        console.print("  [dim]none found[/dim]")
+
+
+def render_selected_installation_text(report: SelectedInstallationReport) -> None:
+    console.print("[bold]Selected installation[/bold]")
+
+    if report.install_dir:
+        _kv("install dir", _path(report.install_dir), report.install_dir_source)
+    elif report.install_dir_error:
+        _err("install dir", report.install_dir_error)
+
+    if report.resolved_dir:
+        _kv("resolved dir", _path(report.resolved_dir))
+    elif report.resolved_dir_error:
+        _err("resolved dir", report.resolved_dir_error)
+
+
+def render_architecture_and_version_text(report: ArchitectureAndVersionReport) -> None:
+    console.print("[bold]Architecture and version[/bold]")
+
+    if report.ida_binary:
+        _kv("ida binary", _path(report.ida_binary))
+    if report.ida_binary_error:
+        _err("ida binary", report.ida_binary_error)
+
+    if report.binary_arch_error:
+        _err("binary arch", report.binary_arch_error)
+    elif report.ida_binary:
+        ida_binary_name = escape(Path(report.ida_binary).name)
+        _kv("binary arch", report.binary_arch or "unknown", f"{ida_binary_name} binary header")
+
+    if report.platform:
+        _kv("platform", report.platform)
+    elif report.platform_error:
+        _err("platform", report.platform_error)
+
+    if report.ida_version:
+        _kv("ida version", report.ida_version, report.ida_version_source)
+    elif report.ida_version_error:
+        _err("ida version", report.ida_version_error)
+
+
+def render_python_environment_text(report: PythonEnvironmentReport) -> None:
+    console.print("[bold]Python environment[/bold]")
+
+    if report.virtual_env and report.virtual_env_is_uv_cache:
+        _kv("$VIRTUAL_ENV", f"{_path(report.virtual_env)}  [dim](uv cache)[/dim]")
+    elif report.virtual_env:
+        _kv("$VIRTUAL_ENV", _path(report.virtual_env))
+    else:
+        _kv("$VIRTUAL_ENV", "not set")
+
+    if report.user_virtual_env:
+        _kv("user virtualenv", _path(report.user_virtual_env), "resolved from $PATH")
+
+    for candidate in report.candidate_virtual_envs:
+        _kv("  candidate venv", f"{_path(candidate.path)}  [dim](via {candidate.source})[/dim]")
+
+    if report.python_exe:
+        _kv("python exe", _path(report.python_exe), report.python_exe_source)
+        return
+
+    _kv("HCLI_CURRENT_IDA_PYTHON_EXE", "not set")
+
+    if report.idat_probe_error:
+        _err("idat probe", report.idat_probe_error)
+        return
+
+    probe = report.idat_probe
+    if probe is None:
+        return
+
+    console.print("  [bold]idat probe[/bold]: [green]success[/green]")
+    _kv("  sys.prefix", _path(probe.prefix))
+    _kv("  sys.base_prefix", _path(probe.base_prefix))
+    _kv("  sys.executable", _path(probe.executable))
+    _kv("  $VIRTUAL_ENV", _path(probe.virtual_env))
+    _kv("  $IDAPYTHON_VENV_EXECUTABLE", _path(probe.idapython_venv_executable))
+    _kv("  sys.version_info", f"{probe.version_major}.{probe.version_minor}")
+
+    if report.derived_exe:
+        _kv("derived exe", _path(report.derived_exe))
+    elif report.derived_exe_error:
+        _err("derived exe", report.derived_exe_error)
+
+
+def render_idapython_virtualenv_text(report: IdaPythonVirtualEnvReport | None) -> None:
+    console.print("[bold]IDAPython virtualenv[/bold]")
+
+    if report is None:
+        console.print("  [dim]none detected[/dim]")
+        return
+
+    _kv("venv", _path(report.venv), "activated by idapythonrc.py")
+    if report.home is not None:
+        _kv("  home", report.home)
+    if report.system_site_packages is not None:
+        _kv("  system site-packages", report.system_site_packages)
+
+
+def render_python_version_text(report: PythonVersionReport) -> None:
+    console.print("[bold]Python version[/bold]")
+
+    if report.final_python_exe:
+        _kv("final python exe", _path(report.final_python_exe))
+
+    if report.probed_version:
+        exe_name = escape(Path(report.final_python_exe or "").name)
+        _kv("probed version", report.probed_version, f"running {exe_name}")
+    elif report.final_python_exe_error or report.probed_version_error:
+        _err("probed version", report.final_python_exe_error or report.probed_version_error or "")
+
+    _kv("hcli interpreter", report.hcli_interpreter_version, _path(report.hcli_interpreter_path))
+
+    if report.final_version:
+        style = "green" if report.final_version != report.hcli_interpreter_version else "yellow"
+        _kv("final version", f"[{style}]{report.final_version}[/{style}]")
+    elif report.final_version_error:
+        _err("final version", report.final_version_error)
+
+
+def render_notes_text(notes: list[EnvironmentNote]) -> None:
+    for note in notes:
+        if note.kind == "diagnostic":
+            console.print(f"[dim]Note: {escape(note.text)}[/dim]", highlight=False)
+            console.print()
+        else:
+            console.print(f"[dim]{escape(note.text)}[/dim]", highlight=False)
+
+
+def render_environment_report_text(report: EnvironmentReport) -> None:
+    render_known_installations_text(report.known_installations)
+    console.print()
+    render_selected_installation_text(report.selected_installation)
+    console.print()
+
+    if report.architecture_and_version is None or report.python_environment is None or report.python_version is None:
+        return
+
+    render_architecture_and_version_text(report.architecture_and_version)
+    console.print()
+    render_python_environment_text(report.python_environment)
+    console.print()
+    render_idapython_virtualenv_text(report.idapython_virtualenv)
+    console.print()
+    render_python_version_text(report.python_version)
+    console.print()
+    render_notes_text(report.notes)
+
+
+def render_environment_report_json(report: EnvironmentReport) -> None:
+    print_json(report.model_dump(mode="json"))
+
+
 @click.command(hidden=True)
 @click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
 def explain_environment(json_output: bool) -> None:
     """Show how the current IDA installation and Python version are detected."""
-
-    report: dict[str, Any] = {}
-
-    def emit(text: str, **kwargs) -> None:
-        if not json_output:
-            console.print(text, **kwargs)
-
-    # --- Known installations ---
-
-    emit("[bold]Known IDA installations[/bold]")
-    installations_report: dict[str, Any] = {"installations": [], "error": None}
-    report["known_installations"] = installations_report
-    try:
-        installations = find_standard_installations()
-        if installations:
-            for path in sorted(installations):
-                version = parse_version_from_ida_pro_py(path) or parse_version_from_dir_name(path) or None
-                installations_report["installations"].append({"path": str(path), "version": version})
-                emit(f"  {_path(path)}  [dim](v{version or '?'})[/dim]")
-        elif not json_output:
-            console.print("  [dim]none found[/dim]")
-    except Exception as e:
-        installations_report["error"] = str(e)
-        if not json_output:
-            _err("scan", str(e))
-
-    emit("")
-
-    # --- Selected installation ---
-
-    emit("[bold]Selected installation[/bold]")
-    selected_report: dict[str, Any] = {
-        "install_dir": None,
-        "install_dir_source": None,
-        "install_dir_error": None,
-        "resolved_dir": None,
-        "resolved_dir_error": None,
-    }
-    report["selected_installation"] = selected_report
-
-    env_install_dir = os.environ.get("HCLI_CURRENT_IDA_INSTALL_DIR") or ENV.HCLI_CURRENT_IDA_INSTALL_DIR
-    if env_install_dir:
-        selected_report["install_dir"] = str(env_install_dir)
-        selected_report["install_dir_source"] = "$HCLI_CURRENT_IDA_INSTALL_DIR"
-        if not json_output:
-            _kv("install dir", _path(env_install_dir), "$HCLI_CURRENT_IDA_INSTALL_DIR")
-    else:
-        config_path = get_ida_config_path()
-        try:
-            config = get_ida_config()
-            if config.paths.installation_directory:
-                selected_report["install_dir"] = str(config.paths.installation_directory)
-                selected_report["install_dir_source"] = str(config_path)
-                if not json_output:
-                    _kv("install dir", _path(config.paths.installation_directory), str(config_path))
-            else:
-                selected_report["install_dir_error"] = f"not configured in {config_path}"
-                if not json_output:
-                    _err("install dir", f"not configured in {config_path}")
-        except Exception as e:
-            selected_report["install_dir_error"] = str(e)
-            if not json_output:
-                _err("install dir", str(e))
-
-    install_dir: Path | None = None
-    try:
-        install_dir = find_current_ida_install_directory()
-        selected_report["resolved_dir"] = str(install_dir)
-        if not json_output:
-            _kv("resolved dir", _path(install_dir))
-    except MissingCurrentInstallationDirectory as e:
-        selected_report["resolved_dir_error"] = str(e)
-        if not json_output:
-            _err("resolved dir", str(e))
-            console.print()
-        if json_output:
-            print_json(report)
-        return
-
-    emit("")
-
-    # --- Architecture and version ---
-
-    emit("[bold]Architecture and version[/bold]")
-    arch_report: dict[str, Any] = {
-        "ida_binary": None,
-        "ida_binary_error": None,
-        "binary_arch": None,
-        "binary_arch_error": None,
-        "platform": None,
-        "platform_error": None,
-        "ida_version": None,
-        "ida_version_source": None,
-        "ida_version_error": None,
-    }
-    report["architecture_and_version"] = arch_report
-
-    try:
-        ida_binary = find_current_ida_executable()
-        arch_report["ida_binary"] = str(ida_binary)
-        if not json_output:
-            _kv("ida binary", _path(ida_binary))
-
-        arch = detect_binary_arch(ida_binary)
-        arch_report["binary_arch"] = arch
-        if not json_output:
-            _kv("binary arch", arch or "unknown", f"{escape(ida_binary.name)} binary header")
-    except Exception as e:
-        arch_report["ida_binary_error"] = str(e)
-        if not json_output:
-            _err("ida binary", str(e))
-
-    try:
-        platform_ = find_current_ida_platform()
-        arch_report["platform"] = platform_
-        if not json_output:
-            _kv("platform", platform_)
-    except Exception as e:
-        arch_report["platform_error"] = str(e)
-        if not json_output:
-            _err("platform", str(e))
-
-    env_version = os.environ.get("HCLI_CURRENT_IDA_VERSION") or ENV.HCLI_CURRENT_IDA_VERSION
-    if env_version:
-        arch_report["ida_version"] = env_version
-        arch_report["ida_version_source"] = "$HCLI_CURRENT_IDA_VERSION"
-        if not json_output:
-            _kv("ida version", env_version, "$HCLI_CURRENT_IDA_VERSION")
-    else:
-        sdk_version = parse_version_from_ida_pro_py(install_dir)
-        dir_version = parse_version_from_dir_name(install_dir)
-        if sdk_version:
-            arch_report["ida_version"] = sdk_version
-            arch_report["ida_version_source"] = "python/ida_pro.py SDK docstring"
-            if not json_output:
-                _kv("ida version", sdk_version, "python/ida_pro.py SDK docstring")
-        elif dir_version:
-            arch_report["ida_version"] = dir_version
-            arch_report["ida_version_source"] = "directory name"
-            if not json_output:
-                _kv("ida version", dir_version, "directory name")
-        else:
-            arch_report["ida_version_error"] = "could not determine"
-            if not json_output:
-                _err("ida version", "could not determine")
-
-    emit("")
-
-    # --- Python detection ---
-
-    emit("[bold]Python environment[/bold]")
-    python_env_report: dict[str, Any] = {
-        "virtual_env": None,
-        "virtual_env_is_uv_cache": False,
-        "user_virtual_env": None,
-        "candidate_virtual_envs": [],
-        "python_exe": None,
-        "python_exe_source": None,
-        "idat_probe": None,
-        "idat_probe_error": None,
-        "derived_exe": None,
-        "derived_exe_error": None,
-    }
-    report["python_environment"] = python_env_report
-
-    process_virtual_env = os.environ.get("VIRTUAL_ENV")
-    is_uv_cache = process_virtual_env is not None and is_uv_cache_virtual_env(process_virtual_env)
-    python_env_report["virtual_env"] = process_virtual_env
-    python_env_report["virtual_env_is_uv_cache"] = is_uv_cache
-    if not json_output:
-        if process_virtual_env and is_uv_cache:
-            _kv("$VIRTUAL_ENV", f"{_path(process_virtual_env)}  [dim](uv cache)[/dim]")
-        elif process_virtual_env:
-            _kv("$VIRTUAL_ENV", _path(process_virtual_env))
-        else:
-            _kv("$VIRTUAL_ENV", "not set")
-
-    user_venv = resolve_user_virtual_env()
-    python_env_report["user_virtual_env"] = str(user_venv) if user_venv else None
-    if user_venv and not json_output:
-        _kv("user virtualenv", _path(user_venv), "resolved from $PATH")
-
-    path_venvs = find_candidate_virtual_envs()
-    non_uv_candidates = [c for c in path_venvs if not is_uv_cache_virtual_env(c.path)]
-    python_env_report["candidate_virtual_envs"] = [{"path": str(c.path), "source": c.source} for c in non_uv_candidates]
-    if non_uv_candidates and not json_output:
-        for candidate in non_uv_candidates:
-            _kv("  candidate venv", f"{_path(candidate.path)}  [dim](via {candidate.source})[/dim]")
-
-    info: dict | None = None
-    env_python = os.environ.get("HCLI_CURRENT_IDA_PYTHON_EXE") or ENV.HCLI_CURRENT_IDA_PYTHON_EXE
-    if env_python:
-        python_env_report["python_exe"] = str(env_python)
-        python_env_report["python_exe_source"] = "$HCLI_CURRENT_IDA_PYTHON_EXE"
-        if not json_output:
-            _kv("python exe", _path(env_python), "$HCLI_CURRENT_IDA_PYTHON_EXE")
-    else:
-        if not json_output:
-            _kv("HCLI_CURRENT_IDA_PYTHON_EXE", "not set")
-
-        try:
-            info = run_py_in_current_idapython(GET_PYTHON_INFO_PY)
-            python_env_report["idat_probe"] = info
-            if not json_output:
-                console.print("  [bold]idat probe[/bold]: [green]success[/green]")
-                _kv("  sys.prefix", _path(info["prefix"]))
-                _kv("  sys.base_prefix", _path(info["base_prefix"]))
-                _kv("  sys.executable", _path(info.get("executable")))
-                _kv("  $VIRTUAL_ENV", _path(info.get("virtual_env")))
-                _kv("  $IDAPYTHON_VENV_EXECUTABLE", _path(info.get("idapython_venv_executable")))
-                _kv("  sys.version_info", f"{info['version_major']}.{info['version_minor']}")
-
-            try:
-                derived = _derive_python_exe(info)
-                python_env_report["derived_exe"] = str(derived)
-                if not json_output:
-                    _kv("derived exe", _path(derived))
-            except PythonNotFoundError as e:
-                python_env_report["derived_exe_error"] = str(e)
-                if not json_output:
-                    _err("derived exe", str(e))
-
-        except Exception as e:
-            python_env_report["idat_probe_error"] = f"{type(e).__name__}: {e}"
-            if not json_output:
-                _err("idat probe", f"{type(e).__name__}: {e}")
-
-    emit("")
-
-    # --- IDAPython virtualenv ---
-
-    emit("[bold]IDAPython virtualenv[/bold]")
-    ida_venv_report: dict[str, Any] | None = None
-    report["idapython_virtualenv"] = ida_venv_report
-
-    ida_venv = info.get("virtual_env") if info else None
-
-    if ida_venv:
-        venv_path = Path(ida_venv)
-        ida_venv_report = {"venv": str(venv_path), "home": None, "system_site_packages": None}
-        report["idapython_virtualenv"] = ida_venv_report
-        if not json_output:
-            _kv("venv", _path(venv_path), "activated by idapythonrc.py")
-        pyvenv_cfg = venv_path / "pyvenv.cfg"
-        if pyvenv_cfg.is_file():
-            for line in pyvenv_cfg.read_text().splitlines():
-                if line.startswith("home"):
-                    ida_venv_report["home"] = line.split("=", 1)[1].strip()
-                    if not json_output:
-                        _kv("  home", ida_venv_report["home"])
-                elif line.startswith("include-system-site-packages"):
-                    ida_venv_report["system_site_packages"] = line.split("=", 1)[1].strip()
-                    if not json_output:
-                        _kv("  system site-packages", ida_venv_report["system_site_packages"])
-    elif not json_output:
-        console.print("  [dim]none detected[/dim]")
-
-    emit("")
-
-    # --- Final Python version ---
-
-    emit("[bold]Python version[/bold]")
-    python_version_report: dict[str, Any] = {
-        "final_python_exe": None,
-        "final_python_exe_error": None,
-        "probed_version": None,
-        "probed_version_error": None,
-        "hcli_interpreter_version": f"{sys.version_info.major}.{sys.version_info.minor}",
-        "hcli_interpreter_path": sys.executable,
-        "final_version": None,
-        "final_version_error": None,
-    }
-    report["python_version"] = python_version_report
-
-    python_exe: Path | None = None
-    try:
-        python_exe = find_current_python_executable()
-        python_version_report["final_python_exe"] = str(python_exe)
-        if not json_output:
-            _kv("final python exe", _path(python_exe))
-
-        result = subprocess.run(
-            [str(python_exe), "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=10,
-        )
-        python_version_report["probed_version"] = result.stdout.strip()
-        if not json_output:
-            _kv("probed version", result.stdout.strip(), f"running {escape(python_exe.name)}")
-    except Exception as e:
-        python_version_report["final_python_exe_error" if python_exe is None else "probed_version_error"] = (
-            f"{type(e).__name__}: {e}"
-        )
-        if not json_output:
-            _err("probed version", f"{type(e).__name__}: {e}")
-
-    if not json_output:
-        interpreter_version = python_version_report["hcli_interpreter_version"]
-        _kv("hcli interpreter", interpreter_version, _path(sys.executable))
-
-    try:
-        final = detect_current_python_version()
-        python_version_report["final_version"] = final
-        if not json_output:
-            style = "green" if final != python_version_report["hcli_interpreter_version"] else "yellow"
-            _kv("final version", f"[{style}]{final}[/{style}]")
-    except Exception as e:
-        python_version_report["final_version_error"] = f"{type(e).__name__}: {e}"
-        if not json_output:
-            _err("final version", f"{type(e).__name__}: {e}")
-
-    emit("")
-
-    is_hcli_own_venv = process_virtual_env and os.path.normcase(
-        os.path.abspath(process_virtual_env)
-    ) == os.path.normcase(os.path.abspath(sys.prefix))
-
-    notes: list[str] = []
-    report["notes"] = notes
-
-    if is_uv_cache and user_venv:
-        note = f"$VIRTUAL_ENV is a uv cache overlay. Resolved user virtualenv: {user_venv}"
-        notes.append(note)
-        if not json_output:
-            console.print(
-                f"[dim]Note: $VIRTUAL_ENV is a uv cache overlay. Resolved user virtualenv: {escape(str(user_venv))}[/dim]",
-                highlight=False,
-            )
-            console.print()
-    elif is_uv_cache:
-        note = "$VIRTUAL_ENV is a uv cache overlay, not your virtualenv. No user virtualenvs were found on $PATH."
-        notes.append(note)
-        if not json_output:
-            console.print(
-                "[dim]Note: $VIRTUAL_ENV is a uv cache overlay, not your virtualenv. "
-                "No user virtualenvs were found on $PATH.[/dim]",
-                highlight=False,
-            )
-            console.print()
-    elif process_virtual_env and is_hcli_own_venv:
-        note = (
-            f"$VIRTUAL_ENV ({process_virtual_env}) is the hcli process environment, not the IDA Python "
-            f"environment. It is not used for plugin installation."
-        )
-        notes.append(note)
-        if not json_output:
-            console.print(
-                f"[dim]Note: $VIRTUAL_ENV ({escape(process_virtual_env)}) "
-                f"is the hcli process environment, not the IDA Python environment. "
-                f"It is not used for plugin installation.[/dim]",
-                highlight=False,
-            )
-            console.print()
-    elif process_virtual_env and not ida_venv:
-        note = (
-            f"$VIRTUAL_ENV is set ({process_virtual_env}) but was not detected inside IDA. "
-            f"To use this virtualenv with IDA, activate it via idapythonrc.py."
-        )
-        notes.append(note)
-        if not json_output:
-            console.print(
-                f"[dim]Note: $VIRTUAL_ENV is set ({escape(process_virtual_env)}) "
-                f"but was not detected inside IDA. "
-                f"To use this virtualenv with IDA, activate it via idapythonrc.py.[/dim]",
-                highlight=False,
-            )
-            console.print()
-
-    if not ida_venv:
-        notes.append(
-            "To use a virtualenv with IDA, see: https://community.hex-rays.com/t/using-a-virtualenv-for-idapython/261/5"
-        )
-        if not json_output:
-            console.print(
-                "[dim]To use a virtualenv with IDA, see: "
-                "https://community.hex-rays.com/t/using-a-virtualenv-for-idapython/261/5[/dim]",
-                highlight=False,
-            )
-    if not user_venv and not is_uv_cache and not ida_venv:
-        notes.append("To change IDA's Python, use idapyswitch to point at a different interpreter.")
-        if not json_output:
-            console.print("[dim]To change IDA's Python, use idapyswitch to point at a different interpreter.[/dim]")
+    report = collect_environment_report()
 
     try:
         final_version = detect_current_python_version()
@@ -459,4 +591,6 @@ def explain_environment(json_output: bool) -> None:
         pass
 
     if json_output:
-        print_json(report)
+        render_environment_report_json(report)
+    else:
+        render_environment_report_text(report)

--- a/src/hcli/commands/plugin/explain_environment.py
+++ b/src/hcli/commands/plugin/explain_environment.py
@@ -4,12 +4,13 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import rich_click as click
 from rich.markup import escape
 
 from hcli.env import ENV
-from hcli.lib.console import console
+from hcli.lib.console import console, print_json
 from hcli.lib.ida import (
     MissingCurrentInstallationDirectory,
     detect_binary_arch,
@@ -27,8 +28,10 @@ from hcli.lib.ida.python import (
     GET_PYTHON_INFO_PY,
     PythonNotFoundError,
     _derive_python_exe,
+    build_console_script_search_dirs,
     detect_current_python_version,
     find_current_python_executable,
+    probe_console_script_info,
 )
 from hcli.lib.venv import find_candidate_virtual_envs, is_uv_cache_virtual_env, resolve_user_virtual_env
 
@@ -49,166 +52,289 @@ def _err(key: str, error: str) -> None:
 
 
 @click.command(hidden=True)
-def explain_environment() -> None:
+@click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
+def explain_environment(json_output: bool) -> None:
     """Show how the current IDA installation and Python version are detected."""
+
+    report: dict[str, Any] = {}
+
+    def emit(text: str, **kwargs) -> None:
+        if not json_output:
+            console.print(text, **kwargs)
 
     # --- Known installations ---
 
-    console.print("[bold]Known IDA installations[/bold]")
+    emit("[bold]Known IDA installations[/bold]")
+    installations_report: dict[str, Any] = {"installations": [], "error": None}
+    report["known_installations"] = installations_report
     try:
         installations = find_standard_installations()
         if installations:
             for path in sorted(installations):
-                version = parse_version_from_ida_pro_py(path) or parse_version_from_dir_name(path) or "?"
-                console.print(f"  {_path(path)}  [dim](v{version})[/dim]")
-        else:
+                version = parse_version_from_ida_pro_py(path) or parse_version_from_dir_name(path) or None
+                installations_report["installations"].append({"path": str(path), "version": version})
+                emit(f"  {_path(path)}  [dim](v{version or '?'})[/dim]")
+        elif not json_output:
             console.print("  [dim]none found[/dim]")
     except Exception as e:
-        _err("scan", str(e))
+        installations_report["error"] = str(e)
+        if not json_output:
+            _err("scan", str(e))
 
-    console.print()
+    emit("")
 
     # --- Selected installation ---
 
-    console.print("[bold]Selected installation[/bold]")
+    emit("[bold]Selected installation[/bold]")
+    selected_report: dict[str, Any] = {
+        "install_dir": None,
+        "install_dir_source": None,
+        "install_dir_error": None,
+        "resolved_dir": None,
+        "resolved_dir_error": None,
+    }
+    report["selected_installation"] = selected_report
 
     env_install_dir = os.environ.get("HCLI_CURRENT_IDA_INSTALL_DIR") or ENV.HCLI_CURRENT_IDA_INSTALL_DIR
     if env_install_dir:
-        _kv("install dir", _path(env_install_dir), "$HCLI_CURRENT_IDA_INSTALL_DIR")
+        selected_report["install_dir"] = str(env_install_dir)
+        selected_report["install_dir_source"] = "$HCLI_CURRENT_IDA_INSTALL_DIR"
+        if not json_output:
+            _kv("install dir", _path(env_install_dir), "$HCLI_CURRENT_IDA_INSTALL_DIR")
     else:
         config_path = get_ida_config_path()
         try:
             config = get_ida_config()
             if config.paths.installation_directory:
-                _kv("install dir", _path(config.paths.installation_directory), str(config_path))
+                selected_report["install_dir"] = str(config.paths.installation_directory)
+                selected_report["install_dir_source"] = str(config_path)
+                if not json_output:
+                    _kv("install dir", _path(config.paths.installation_directory), str(config_path))
             else:
-                _err("install dir", f"not configured in {config_path}")
+                selected_report["install_dir_error"] = f"not configured in {config_path}"
+                if not json_output:
+                    _err("install dir", f"not configured in {config_path}")
         except Exception as e:
-            _err("install dir", str(e))
+            selected_report["install_dir_error"] = str(e)
+            if not json_output:
+                _err("install dir", str(e))
 
+    install_dir: Path | None = None
     try:
         install_dir = find_current_ida_install_directory()
-        _kv("resolved dir", _path(install_dir))
+        selected_report["resolved_dir"] = str(install_dir)
+        if not json_output:
+            _kv("resolved dir", _path(install_dir))
     except MissingCurrentInstallationDirectory as e:
-        _err("resolved dir", str(e))
-        console.print()
+        selected_report["resolved_dir_error"] = str(e)
+        if not json_output:
+            _err("resolved dir", str(e))
+            console.print()
+        if json_output:
+            print_json(report)
         return
 
-    console.print()
+    emit("")
 
     # --- Architecture and version ---
 
-    console.print("[bold]Architecture and version[/bold]")
+    emit("[bold]Architecture and version[/bold]")
+    arch_report: dict[str, Any] = {
+        "ida_binary": None,
+        "ida_binary_error": None,
+        "binary_arch": None,
+        "binary_arch_error": None,
+        "platform": None,
+        "platform_error": None,
+        "ida_version": None,
+        "ida_version_source": None,
+        "ida_version_error": None,
+    }
+    report["architecture_and_version"] = arch_report
 
     try:
         ida_binary = find_current_ida_executable()
-        _kv("ida binary", _path(ida_binary))
+        arch_report["ida_binary"] = str(ida_binary)
+        if not json_output:
+            _kv("ida binary", _path(ida_binary))
 
         arch = detect_binary_arch(ida_binary)
-        _kv("binary arch", arch or "unknown", f"{escape(ida_binary.name)} binary header")
+        arch_report["binary_arch"] = arch
+        if not json_output:
+            _kv("binary arch", arch or "unknown", f"{escape(ida_binary.name)} binary header")
     except Exception as e:
-        _err("ida binary", str(e))
+        arch_report["ida_binary_error"] = str(e)
+        if not json_output:
+            _err("ida binary", str(e))
 
     try:
-        platform = find_current_ida_platform()
-        _kv("platform", platform)
+        platform_ = find_current_ida_platform()
+        arch_report["platform"] = platform_
+        if not json_output:
+            _kv("platform", platform_)
     except Exception as e:
-        _err("platform", str(e))
+        arch_report["platform_error"] = str(e)
+        if not json_output:
+            _err("platform", str(e))
 
     env_version = os.environ.get("HCLI_CURRENT_IDA_VERSION") or ENV.HCLI_CURRENT_IDA_VERSION
     if env_version:
-        _kv("ida version", env_version, "$HCLI_CURRENT_IDA_VERSION")
+        arch_report["ida_version"] = env_version
+        arch_report["ida_version_source"] = "$HCLI_CURRENT_IDA_VERSION"
+        if not json_output:
+            _kv("ida version", env_version, "$HCLI_CURRENT_IDA_VERSION")
     else:
         sdk_version = parse_version_from_ida_pro_py(install_dir)
         dir_version = parse_version_from_dir_name(install_dir)
         if sdk_version:
-            _kv("ida version", sdk_version, "python/ida_pro.py SDK docstring")
+            arch_report["ida_version"] = sdk_version
+            arch_report["ida_version_source"] = "python/ida_pro.py SDK docstring"
+            if not json_output:
+                _kv("ida version", sdk_version, "python/ida_pro.py SDK docstring")
         elif dir_version:
-            _kv("ida version", dir_version, "directory name")
+            arch_report["ida_version"] = dir_version
+            arch_report["ida_version_source"] = "directory name"
+            if not json_output:
+                _kv("ida version", dir_version, "directory name")
         else:
-            _err("ida version", "could not determine")
+            arch_report["ida_version_error"] = "could not determine"
+            if not json_output:
+                _err("ida version", "could not determine")
 
-    console.print()
+    emit("")
 
     # --- Python detection ---
 
-    console.print("[bold]Python environment[/bold]")
+    emit("[bold]Python environment[/bold]")
+    python_env_report: dict[str, Any] = {
+        "virtual_env": None,
+        "virtual_env_is_uv_cache": False,
+        "user_virtual_env": None,
+        "candidate_virtual_envs": [],
+        "python_exe": None,
+        "python_exe_source": None,
+        "idat_probe": None,
+        "idat_probe_error": None,
+        "derived_exe": None,
+        "derived_exe_error": None,
+    }
+    report["python_environment"] = python_env_report
 
     process_virtual_env = os.environ.get("VIRTUAL_ENV")
     is_uv_cache = process_virtual_env is not None and is_uv_cache_virtual_env(process_virtual_env)
-    if process_virtual_env and is_uv_cache:
-        _kv("$VIRTUAL_ENV", f"{_path(process_virtual_env)}  [dim](uv cache)[/dim]")
-    elif process_virtual_env:
-        _kv("$VIRTUAL_ENV", _path(process_virtual_env))
-    else:
-        _kv("$VIRTUAL_ENV", "not set")
+    python_env_report["virtual_env"] = process_virtual_env
+    python_env_report["virtual_env_is_uv_cache"] = is_uv_cache
+    if not json_output:
+        if process_virtual_env and is_uv_cache:
+            _kv("$VIRTUAL_ENV", f"{_path(process_virtual_env)}  [dim](uv cache)[/dim]")
+        elif process_virtual_env:
+            _kv("$VIRTUAL_ENV", _path(process_virtual_env))
+        else:
+            _kv("$VIRTUAL_ENV", "not set")
 
     user_venv = resolve_user_virtual_env()
-    if user_venv:
+    python_env_report["user_virtual_env"] = str(user_venv) if user_venv else None
+    if user_venv and not json_output:
         _kv("user virtualenv", _path(user_venv), "resolved from $PATH")
 
     path_venvs = find_candidate_virtual_envs()
     non_uv_candidates = [c for c in path_venvs if not is_uv_cache_virtual_env(c.path)]
-    if non_uv_candidates:
+    python_env_report["candidate_virtual_envs"] = [{"path": str(c.path), "source": c.source} for c in non_uv_candidates]
+    if non_uv_candidates and not json_output:
         for candidate in non_uv_candidates:
             _kv("  candidate venv", f"{_path(candidate.path)}  [dim](via {candidate.source})[/dim]")
 
     info: dict | None = None
     env_python = os.environ.get("HCLI_CURRENT_IDA_PYTHON_EXE") or ENV.HCLI_CURRENT_IDA_PYTHON_EXE
     if env_python:
-        _kv("python exe", _path(env_python), "$HCLI_CURRENT_IDA_PYTHON_EXE")
+        python_env_report["python_exe"] = str(env_python)
+        python_env_report["python_exe_source"] = "$HCLI_CURRENT_IDA_PYTHON_EXE"
+        if not json_output:
+            _kv("python exe", _path(env_python), "$HCLI_CURRENT_IDA_PYTHON_EXE")
     else:
-        _kv("HCLI_CURRENT_IDA_PYTHON_EXE", "not set")
+        if not json_output:
+            _kv("HCLI_CURRENT_IDA_PYTHON_EXE", "not set")
 
         try:
             info = run_py_in_current_idapython(GET_PYTHON_INFO_PY)
-            console.print("  [bold]idat probe[/bold]: [green]success[/green]")
-            _kv("  sys.prefix", _path(info["prefix"]))
-            _kv("  sys.base_prefix", _path(info["base_prefix"]))
-            _kv("  sys.executable", _path(info.get("executable")))
-            _kv("  $VIRTUAL_ENV", _path(info.get("virtual_env")))
-            _kv("  $IDAPYTHON_VENV_EXECUTABLE", _path(info.get("idapython_venv_executable")))
-            _kv("  sys.version_info", f"{info['version_major']}.{info['version_minor']}")
+            python_env_report["idat_probe"] = info
+            if not json_output:
+                console.print("  [bold]idat probe[/bold]: [green]success[/green]")
+                _kv("  sys.prefix", _path(info["prefix"]))
+                _kv("  sys.base_prefix", _path(info["base_prefix"]))
+                _kv("  sys.executable", _path(info.get("executable")))
+                _kv("  $VIRTUAL_ENV", _path(info.get("virtual_env")))
+                _kv("  $IDAPYTHON_VENV_EXECUTABLE", _path(info.get("idapython_venv_executable")))
+                _kv("  sys.version_info", f"{info['version_major']}.{info['version_minor']}")
 
             try:
                 derived = _derive_python_exe(info)
-                _kv("derived exe", _path(derived))
+                python_env_report["derived_exe"] = str(derived)
+                if not json_output:
+                    _kv("derived exe", _path(derived))
             except PythonNotFoundError as e:
-                _err("derived exe", str(e))
+                python_env_report["derived_exe_error"] = str(e)
+                if not json_output:
+                    _err("derived exe", str(e))
 
         except Exception as e:
-            _err("idat probe", f"{type(e).__name__}: {e}")
+            python_env_report["idat_probe_error"] = f"{type(e).__name__}: {e}"
+            if not json_output:
+                _err("idat probe", f"{type(e).__name__}: {e}")
 
-    console.print()
+    emit("")
 
     # --- IDAPython virtualenv ---
 
-    console.print("[bold]IDAPython virtualenv[/bold]")
+    emit("[bold]IDAPython virtualenv[/bold]")
+    ida_venv_report: dict[str, Any] | None = None
+    report["idapython_virtualenv"] = ida_venv_report
 
     ida_venv = info.get("virtual_env") if info else None
 
     if ida_venv:
         venv_path = Path(ida_venv)
-        _kv("venv", _path(venv_path), "activated by idapythonrc.py")
+        ida_venv_report = {"venv": str(venv_path), "home": None, "system_site_packages": None}
+        report["idapython_virtualenv"] = ida_venv_report
+        if not json_output:
+            _kv("venv", _path(venv_path), "activated by idapythonrc.py")
         pyvenv_cfg = venv_path / "pyvenv.cfg"
         if pyvenv_cfg.is_file():
             for line in pyvenv_cfg.read_text().splitlines():
                 if line.startswith("home"):
-                    _kv("  home", line.split("=", 1)[1].strip())
+                    ida_venv_report["home"] = line.split("=", 1)[1].strip()
+                    if not json_output:
+                        _kv("  home", ida_venv_report["home"])
                 elif line.startswith("include-system-site-packages"):
-                    _kv("  system site-packages", line.split("=", 1)[1].strip())
-    else:
+                    ida_venv_report["system_site_packages"] = line.split("=", 1)[1].strip()
+                    if not json_output:
+                        _kv("  system site-packages", ida_venv_report["system_site_packages"])
+    elif not json_output:
         console.print("  [dim]none detected[/dim]")
 
-    console.print()
+    emit("")
 
     # --- Final Python version ---
 
-    console.print("[bold]Python version[/bold]")
+    emit("[bold]Python version[/bold]")
+    python_version_report: dict[str, Any] = {
+        "final_python_exe": None,
+        "final_python_exe_error": None,
+        "probed_version": None,
+        "probed_version_error": None,
+        "hcli_interpreter_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "hcli_interpreter_path": sys.executable,
+        "final_version": None,
+        "final_version_error": None,
+    }
+    report["python_version"] = python_version_report
 
+    python_exe: Path | None = None
     try:
         python_exe = find_current_python_executable()
-        _kv("final python exe", _path(python_exe))
+        python_version_report["final_python_exe"] = str(python_exe)
+        if not json_output:
+            _kv("final python exe", _path(python_exe))
 
         result = subprocess.run(
             [str(python_exe), "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
@@ -217,74 +343,168 @@ def explain_environment() -> None:
             check=True,
             timeout=10,
         )
-        _kv("probed version", result.stdout.strip(), f"running {escape(python_exe.name)}")
+        python_version_report["probed_version"] = result.stdout.strip()
+        if not json_output:
+            _kv("probed version", result.stdout.strip(), f"running {escape(python_exe.name)}")
     except Exception as e:
-        _err("probed version", f"{type(e).__name__}: {e}")
+        python_version_report["final_python_exe_error" if python_exe is None else "probed_version_error"] = (
+            f"{type(e).__name__}: {e}"
+        )
+        if not json_output:
+            _err("probed version", f"{type(e).__name__}: {e}")
 
-    interpreter_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    _kv("hcli interpreter", interpreter_version, _path(sys.executable))
+    if not json_output:
+        interpreter_version = python_version_report["hcli_interpreter_version"]
+        _kv("hcli interpreter", interpreter_version, _path(sys.executable))
 
     try:
         final = detect_current_python_version()
-        style = "green" if final != interpreter_version else "yellow"
-        _kv("final version", f"[{style}]{final}[/{style}]")
+        python_version_report["final_version"] = final
+        if not json_output:
+            style = "green" if final != python_version_report["hcli_interpreter_version"] else "yellow"
+            _kv("final version", f"[{style}]{final}[/{style}]")
     except Exception as e:
-        _err("final version", f"{type(e).__name__}: {e}")
+        python_version_report["final_version_error"] = f"{type(e).__name__}: {e}"
+        if not json_output:
+            _err("final version", f"{type(e).__name__}: {e}")
 
-    console.print()
+    emit("")
+
+    # --- Console scripts (e.g. locating a pip-installed script like `speakeasy`) ---
+
+    emit("[bold]Console scripts[/bold]")
+    console_scripts_report: dict[str, Any] = {
+        "python_exe": None,
+        "prefix": None,
+        "base_prefix": None,
+        "scripts_dir": None,
+        "os_name": None,
+        "search_dirs": [],
+        "error": None,
+    }
+    report["console_scripts"] = console_scripts_report
+
+    if python_exe is None:
+        console_scripts_report["error"] = "no final python exe was detected above"
+        if not json_output:
+            _err("search dirs", "no final python exe was detected above")
+    else:
+        try:
+            csi = probe_console_script_info(python_exe)
+            search_dirs = build_console_script_search_dirs(
+                csi["prefix"], csi["base_prefix"], csi["scripts_dir"], csi["os_name"]
+            )
+            console_scripts_report.update(
+                {
+                    "python_exe": str(python_exe),
+                    "prefix": csi["prefix"],
+                    "base_prefix": csi["base_prefix"],
+                    "scripts_dir": csi["scripts_dir"],
+                    "os_name": csi["os_name"],
+                    "search_dirs": search_dirs,
+                }
+            )
+            if not json_output:
+                _kv("prefix", _path(csi["prefix"]))
+                _kv("base_prefix", _path(csi["base_prefix"]))
+                _kv("scripts dir", _path(csi["scripts_dir"]))
+                for directory in search_dirs:
+                    _kv("  search dir", _path(directory))
+        except Exception as e:
+            console_scripts_report["error"] = f"{type(e).__name__}: {e}"
+            if not json_output:
+                _err("search dirs", f"{type(e).__name__}: {e}")
+
+    emit("")
     is_hcli_own_venv = process_virtual_env and os.path.normcase(
         os.path.abspath(process_virtual_env)
     ) == os.path.normcase(os.path.abspath(sys.prefix))
 
+    notes: list[str] = []
+    report["notes"] = notes
+
     if is_uv_cache and user_venv:
-        console.print(
-            f"[dim]Note: $VIRTUAL_ENV is a uv cache overlay. Resolved user virtualenv: {escape(str(user_venv))}[/dim]",
-            highlight=False,
-        )
-        console.print()
+        note = f"$VIRTUAL_ENV is a uv cache overlay. Resolved user virtualenv: {user_venv}"
+        notes.append(note)
+        if not json_output:
+            console.print(
+                f"[dim]Note: $VIRTUAL_ENV is a uv cache overlay. Resolved user virtualenv: {escape(str(user_venv))}[/dim]",
+                highlight=False,
+            )
+            console.print()
     elif is_uv_cache:
-        console.print(
-            "[dim]Note: $VIRTUAL_ENV is a uv cache overlay, not your virtualenv. "
-            "No user virtualenvs were found on $PATH.[/dim]",
-            highlight=False,
-        )
-        console.print()
+        note = "$VIRTUAL_ENV is a uv cache overlay, not your virtualenv. No user virtualenvs were found on $PATH."
+        notes.append(note)
+        if not json_output:
+            console.print(
+                "[dim]Note: $VIRTUAL_ENV is a uv cache overlay, not your virtualenv. "
+                "No user virtualenvs were found on $PATH.[/dim]",
+                highlight=False,
+            )
+            console.print()
     elif process_virtual_env and is_hcli_own_venv:
-        console.print(
-            f"[dim]Note: $VIRTUAL_ENV ({escape(process_virtual_env)}) "
-            f"is the hcli process environment, not the IDA Python environment. "
-            f"It is not used for plugin installation.[/dim]",
-            highlight=False,
+        note = (
+            f"$VIRTUAL_ENV ({process_virtual_env}) is the hcli process environment, not the IDA Python "
+            f"environment. It is not used for plugin installation."
         )
-        console.print()
+        notes.append(note)
+        if not json_output:
+            console.print(
+                f"[dim]Note: $VIRTUAL_ENV ({escape(process_virtual_env)}) "
+                f"is the hcli process environment, not the IDA Python environment. "
+                f"It is not used for plugin installation.[/dim]",
+                highlight=False,
+            )
+            console.print()
     elif process_virtual_env and not ida_venv:
-        console.print(
-            f"[dim]Note: $VIRTUAL_ENV is set ({escape(process_virtual_env)}) "
-            f"but was not detected inside IDA. "
-            f"To use this virtualenv with IDA, activate it via idapythonrc.py.[/dim]",
-            highlight=False,
+        note = (
+            f"$VIRTUAL_ENV is set ({process_virtual_env}) but was not detected inside IDA. "
+            f"To use this virtualenv with IDA, activate it via idapythonrc.py."
         )
-        console.print()
+        notes.append(note)
+        if not json_output:
+            console.print(
+                f"[dim]Note: $VIRTUAL_ENV is set ({escape(process_virtual_env)}) "
+                f"but was not detected inside IDA. "
+                f"To use this virtualenv with IDA, activate it via idapythonrc.py.[/dim]",
+                highlight=False,
+            )
+            console.print()
 
     if not ida_venv:
-        console.print(
-            "[dim]To use a virtualenv with IDA, see: "
-            "https://community.hex-rays.com/t/using-a-virtualenv-for-idapython/261/5[/dim]",
-            highlight=False,
+        notes.append(
+            "To use a virtualenv with IDA, see: https://community.hex-rays.com/t/using-a-virtualenv-for-idapython/261/5"
         )
+        if not json_output:
+            console.print(
+                "[dim]To use a virtualenv with IDA, see: "
+                "https://community.hex-rays.com/t/using-a-virtualenv-for-idapython/261/5[/dim]",
+                highlight=False,
+            )
     if not user_venv and not is_uv_cache and not ida_venv:
-        console.print("[dim]To change IDA's Python, use idapyswitch to point at a different interpreter.[/dim]")
+        notes.append("To change IDA's Python, use idapyswitch to point at a different interpreter.")
+        if not json_output:
+            console.print("[dim]To change IDA's Python, use idapyswitch to point at a different interpreter.[/dim]")
 
     try:
         final_version = detect_current_python_version()
         parts = final_version.split(".")
         major, minor = int(parts[0]), int(parts[1])
         if (major, minor) <= (3, 9):
-            console.print()
-            console.print(
-                f"[bold yellow]Warning:[/bold yellow] Python {final_version} has reached end-of-life. "
+            notes.append(
+                f"Python {final_version} has reached end-of-life. "
                 "Many IDA plugins may not support it. "
-                "Consider upgrading to a newer Python and using idapyswitch to point IDA at it.",
+                "Consider upgrading to a newer Python and using idapyswitch to point IDA at it."
             )
+            if not json_output:
+                console.print()
+                console.print(
+                    f"[bold yellow]Warning:[/bold yellow] Python {final_version} has reached end-of-life. "
+                    "Many IDA plugins may not support it. "
+                    "Consider upgrading to a newer Python and using idapyswitch to point IDA at it.",
+                )
     except Exception:
         pass
+
+    if json_output:
+        print_json(report)

--- a/src/hcli/commands/plugin/explain_environment.py
+++ b/src/hcli/commands/plugin/explain_environment.py
@@ -120,6 +120,7 @@ class EnvironmentNote(BaseModel):
 
 
 class EnvironmentReport(BaseModel):
+    experimental: bool = True
     known_installations: KnownInstallationsReport
     selected_installation: SelectedInstallationReport
     # the sections below need an installation directory, so they're absent when it can't be resolved.
@@ -567,7 +568,7 @@ def render_environment_report_json(report: EnvironmentReport) -> None:
 @click.command(hidden=True)
 @click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
 def explain_environment(json_output: bool) -> None:
-    """Show how the current IDA installation and Python version are detected."""
+    """Show how the current IDA installation and Python version are detected. (experimental)"""
     report = collect_environment_report()
 
     try:

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -9,7 +9,7 @@ import rich.table
 import rich_click as click
 import semantic_version
 
-from hcli.lib.console import console
+from hcli.lib.console import console, print_json
 from hcli.lib.ida import (
     FailedToDetectIDAVersion,
     MissingCurrentInstallationDirectory,
@@ -106,14 +106,62 @@ def render_ambiguity_error(err: AmbiguousPluginReferenceError) -> None:
         console.print(f"  {format_qualified_plugin_reference(ref)}")
 
 
-def output_plugin_metadata(metadata) -> None:
-    metadata_dict = metadata.plugin.model_dump()
+def build_plugin_metadata_dict(metadata) -> dict:
+    metadata_dict = metadata.plugin.model_dump(mode="json")
     del metadata_dict["platforms"]
     metadata_dict["idaVersions"] = render_ida_versions(metadata_dict["idaVersions"])
+    return metadata_dict
 
+
+def output_plugin_metadata(metadata) -> None:
+    metadata_dict = build_plugin_metadata_dict(metadata)
     for key, value in sorted(metadata_dict.items()):
         console.print(f"{key}: {value}")
     console.print()
+
+
+def collect_version_entries(
+    plugin: Plugin,
+    versions: Sequence[str],
+    current_version: str,
+    current_platform: str,
+    installed_records: list[InstalledPluginRecord],
+) -> tuple[list[dict], str | None]:
+    """Build per-version compatibility/install status entries for `plugin`.
+
+    Returns (entries, installed_version), where installed_version is the
+    version string currently installed, or None if this specific repository
+    plugin (name+host) isn't installed.
+    """
+    installed_record = find_installed_matching(plugin, installed_records)
+    existing_version = None
+    if installed_record is not None:
+        existing_version = parse_plugin_version(installed_record.version)
+
+    entries = []
+    for version in versions:
+        locations = plugin.versions[version]
+        metadata = locations[0].metadata
+        is_compatible = is_compatible_plugin_version(plugin, version, locations, current_platform, current_version)
+
+        currently_installed = False
+        upgradable = False
+        if installed_record is not None and existing_version is not None:
+            if parse_plugin_version(metadata.plugin.version) == existing_version:
+                currently_installed = True
+            if parse_plugin_version(metadata.plugin.version) > existing_version and is_compatible:
+                upgradable = True
+
+        entries.append(
+            {
+                "version": version,
+                "compatible": is_compatible,
+                "currently_installed": currently_installed,
+                "upgradable": upgradable,
+            }
+        )
+
+    return entries, (installed_record.version if installed_record is not None else None)
 
 
 def output_plugin_versions_table(
@@ -124,32 +172,27 @@ def output_plugin_versions_table(
     title: str,
     installed_records: list[InstalledPluginRecord],
 ) -> None:
+    entries, installed_version = collect_version_entries(
+        plugin, versions, current_version, current_platform, installed_records
+    )
+
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("version", style="default")
     table.add_column("status")
 
-    installed_record = find_installed_matching(plugin, installed_records)
-    existing_version = None
-    if installed_record is not None:
-        existing_version = parse_plugin_version(installed_record.version)
-
-    for version in versions:
-        locations = plugin.versions[version]
-        metadata = locations[0].metadata
-        is_compatible = is_compatible_plugin_version(plugin, version, locations, current_platform, current_version)
-
+    for entry in entries:
         status = ""
-        if installed_record is not None and existing_version is not None:
-            if parse_plugin_version(metadata.plugin.version) == existing_version:
+        # An installed version takes precedence: never show "incompatible" for
+        # an old/uninstalled version once something is installed, mirroring
+        # what a user cares about (their own upgrade path, not every release).
+        if installed_version is not None:
+            if entry["currently_installed"]:
                 status = "[green]currently installed[/green]"
-
-            if parse_plugin_version(metadata.plugin.version) > existing_version and is_compatible:
-                status = f"[yellow]upgradable[/yellow] from {existing_version}"
-
-        elif not is_compatible:
+            elif entry["upgradable"]:
+                status = f"[yellow]upgradable[/yellow] from {installed_version}"
+        elif not entry["compatible"]:
             status = "[grey69]incompatible[/grey69]"
-
-        table.add_row(version, status)
+        table.add_row(entry["version"], status)
 
     console.print(title)
     console.print(table)
@@ -164,6 +207,13 @@ def get_matching_versions(plugin: Plugin, version_spec: str) -> list[str]:
     ]
 
 
+def all_versions_newest_first(plugin: Plugin) -> list[str]:
+    return [
+        version
+        for version, _ in sorted(plugin.versions.items(), key=lambda p: parse_plugin_version(p[0]), reverse=True)
+    ]
+
+
 def handle_plugin_name_query(
     plugins: list[Plugin],
     ref: PluginReference,
@@ -175,15 +225,30 @@ def handle_plugin_name_query(
     output_plugin_metadata(get_latest_plugin_metadata(plugin))
     output_plugin_versions_table(
         plugin,
-        [
-            version
-            for version, _ in sorted(plugin.versions.items(), key=lambda p: parse_plugin_version(p[0]), reverse=True)
-        ],
+        all_versions_newest_first(plugin),
         current_version,
         current_platform,
         "available versions:",
         installed_records,
     )
+
+
+def build_plugin_name_query_result(
+    plugins: list[Plugin],
+    ref: PluginReference,
+    current_version: str,
+    current_platform: str,
+    installed_records: list[InstalledPluginRecord],
+) -> dict:
+    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
+    entries, installed_version = collect_version_entries(
+        plugin, all_versions_newest_first(plugin), current_version, current_platform, installed_records
+    )
+    return {
+        "plugin": build_plugin_metadata_dict(get_latest_plugin_metadata(plugin)),
+        "installed_version": installed_version,
+        "versions": entries,
+    }
 
 
 def render_ida_versions(versions: Sequence[IdaVersion]) -> str:
@@ -206,6 +271,17 @@ def render_platforms(platforms: Sequence[Platform]) -> str:
     return ", ".join(sorted(platforms))
 
 
+def collect_download_locations(locations) -> list[dict]:
+    return [
+        {
+            "ida_versions": render_ida_versions(location.metadata.plugin.ida_versions),
+            "platforms": render_platforms(location.metadata.plugin.platforms),
+            "url": location.url,
+        }
+        for location in locations
+    ]
+
+
 def handle_plugin_exact_version_query(plugin: Plugin, version: str):
     if version not in plugin.versions:
         raise KeyError(f"version {version} not found for plugin {plugin.name}")
@@ -219,15 +295,27 @@ def handle_plugin_exact_version_query(plugin: Plugin, version: str):
     table.add_column("IDA platforms", style="default")
     table.add_column("URL")
 
-    for location in locations:
+    for location in collect_download_locations(locations):
         table.add_row(
-            "IDA: " + render_ida_versions(location.metadata.plugin.ida_versions),
-            "platforms: " + render_platforms(location.metadata.plugin.platforms),
-            "URL: " + location.url,
+            "IDA: " + location["ida_versions"],
+            "platforms: " + location["platforms"],
+            "URL: " + location["url"],
         )
 
     console.print("download locations:")
     console.print(table)
+
+
+def build_plugin_exact_version_query_result(plugin: Plugin, version: str) -> dict:
+    if version not in plugin.versions:
+        raise KeyError(f"version {version} not found for plugin {plugin.name}")
+
+    locations = plugin.versions[version]
+    metadata = locations[0].metadata
+    return {
+        "plugin": build_plugin_metadata_dict(metadata),
+        "download_locations": collect_download_locations(locations),
+    }
 
 
 def handle_plugin_version_range_query(
@@ -245,6 +333,27 @@ def handle_plugin_version_range_query(
     output_plugin_versions_table(
         plugin, matching_versions, current_version, current_platform, "matching versions:", installed_records
     )
+
+
+def build_plugin_version_range_query_result(
+    plugin: Plugin,
+    ref: PluginReference,
+    current_version: str,
+    current_platform: str,
+    installed_records: list[InstalledPluginRecord],
+) -> dict:
+    matching_versions = get_matching_versions(plugin, ref.version_spec)
+    if not matching_versions:
+        raise KeyError(f"no versions matching {ref.version_spec!r} found for plugin {plugin.name!r}")
+
+    entries, installed_version = collect_version_entries(
+        plugin, matching_versions, current_version, current_platform, installed_records
+    )
+    return {
+        "plugin": build_plugin_metadata_dict(plugin.versions[matching_versions[0]][0].metadata),
+        "installed_version": installed_version,
+        "versions": entries,
+    }
 
 
 def handle_plugin_spec_query(
@@ -266,6 +375,75 @@ def handle_plugin_spec_query(
     handle_plugin_version_range_query(plugin, ref, current_version, current_platform, installed_records)
 
 
+def build_plugin_spec_query_result(
+    plugins: list[Plugin],
+    ref: PluginReference,
+    current_version: str,
+    current_platform: str,
+    installed_records: list[InstalledPluginRecord],
+) -> dict:
+    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
+
+    if ref.version_spec.startswith("=="):
+        version = ref.version_spec[2:]
+        if not version:
+            raise ValueError(f"invalid plugin version: {ref.version_spec!r}")
+        return build_plugin_exact_version_query_result(plugin, version)
+
+    return build_plugin_version_range_query_result(plugin, ref, current_version, current_platform, installed_records)
+
+
+def collect_keyword_matches(
+    plugins: list[Plugin],
+    query: str,
+    current_version: str,
+    current_platform: str,
+    installed_records: list[InstalledPluginRecord],
+) -> list[dict]:
+    matches = []
+
+    for plugin in sorted(plugins, key=lambda p: p.name.lower()):
+        if not does_plugin_match_query(query or "", plugin):
+            continue
+
+        latest_metadata = get_latest_plugin_metadata(plugin)
+
+        if not is_compatible_plugin(plugin, current_platform, current_version):
+            matches.append(
+                {
+                    "name": latest_metadata.plugin.name,
+                    "version": latest_metadata.plugin.version,
+                    "repository": latest_metadata.plugin.urls.repository,
+                    "compatible": False,
+                    "installed": False,
+                    "installed_version": None,
+                    "upgradable": False,
+                }
+            )
+            continue
+
+        latest_compatible_metadata = get_latest_compatible_plugin_metadata(plugin, current_platform, current_version)
+        installed_record = find_installed_matching(plugin, installed_records)
+        installed_version = installed_record.version if installed_record is not None else None
+        upgradable = installed_version is not None and parse_plugin_version(
+            latest_compatible_metadata.plugin.version
+        ) > parse_plugin_version(installed_version)
+
+        matches.append(
+            {
+                "name": latest_metadata.plugin.name,
+                "version": latest_metadata.plugin.version,
+                "repository": latest_metadata.plugin.urls.repository,
+                "compatible": True,
+                "installed": installed_record is not None,
+                "installed_version": installed_version,
+                "upgradable": upgradable,
+            }
+        )
+
+    return matches
+
+
 def handle_keyword_query(
     plugins: list[Plugin],
     query: str,
@@ -273,60 +451,37 @@ def handle_keyword_query(
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
 ):
+    matches = collect_keyword_matches(plugins, query, current_version, current_platform, installed_records)
+
+    if not matches:
+        console.print("[grey69]No plugins found[/grey69]")
+        return
+
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("name", style="blue")
     table.add_column("version", style="default")
     table.add_column("status")
     table.add_column("repo", style="grey69")
-    has_matches = False
 
-    for plugin in sorted(plugins, key=lambda p: p.name.lower()):
-        if not does_plugin_match_query(query or "", plugin):
+    for match in matches:
+        if not match["compatible"]:
+            table.add_row(
+                f"[grey69]{match['name']} (incompatible)[/grey69]",
+                f"[grey69]{match['version']}[/grey69]",
+                "",
+                match["repository"],
+            )
             continue
 
-        has_matches = True
-        latest_metadata = get_latest_plugin_metadata(plugin)
+        status = ""
+        if match["upgradable"]:
+            status = f"[yellow]upgradable[/yellow] from {match['installed_version']}"
+        elif match["installed"]:
+            status = "installed"
 
-        if not is_compatible_plugin(plugin, current_platform, current_version):
-            table.add_row(
-                f"[grey69]{latest_metadata.plugin.name} (incompatible)[/grey69]",
-                f"[grey69]{latest_metadata.plugin.version}[/grey69]",
-                "",
-                latest_metadata.plugin.urls.repository,
-            )
+        table.add_row(f"[blue]{match['name']}[/blue]", match["version"], status, match["repository"])
 
-        else:
-            latest_compatible_metadata = get_latest_compatible_plugin_metadata(
-                plugin, current_platform, current_version
-            )
-
-            installed_record = find_installed_matching(plugin, installed_records)
-            is_upgradable = False
-            existing_version: str | None = None
-            if installed_record is not None:
-                existing_version = installed_record.version
-                if parse_plugin_version(latest_compatible_metadata.plugin.version) > parse_plugin_version(
-                    existing_version
-                ):
-                    is_upgradable = True
-
-            status = ""
-            if is_upgradable:
-                status = f"[yellow]upgradable[/yellow] from {existing_version}"
-            elif installed_record is not None:
-                status = "installed"
-
-            table.add_row(
-                f"[blue]{latest_metadata.plugin.name}[/blue]",
-                latest_metadata.plugin.version,
-                status,
-                latest_metadata.plugin.urls.repository,
-            )
-
-    if has_matches:
-        console.print(table)
-    else:
-        console.print("[grey69]No plugins found[/grey69]")
+    console.print(table)
 
 
 def _has_exact_name_match(plugins: list[Plugin], name: str) -> bool:
@@ -334,56 +489,108 @@ def _has_exact_name_match(plugins: list[Plugin], name: str) -> bool:
     return any(p.name.lower() == wanted for p in plugins)
 
 
+def resolve_query_reference(plugins: list[Plugin], query: str | None) -> PluginReference | None:
+    """Parse `query` as a qualified plugin reference, or None to fall back to keyword search.
+
+    A qualified query (with a host) is always an exact plugin query. An
+    unqualified query is only an exact plugin query if it exactly matches a
+    known bare name case-insensitively; otherwise it's a keyword/substring
+    search. Parse failures (malformed version spec, etc.) also fall back to
+    keyword search so unusual user input still works.
+    """
+    if not query:
+        return None
+
+    try:
+        ref = parse_plugin_reference(query)
+    except ValueError:
+        return None
+
+    if ref.host is None and not _has_exact_name_match(plugins, ref.name):
+        return None
+
+    return ref
+
+
 @click.command()
 @click.argument("query", required=False)
+@click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
 @click.pass_context
-def search_plugins(ctx, query: str | None = None) -> None:
+def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> None:
     """Search for plugins by name, keyword, category, or author."""
     try:
         current_platform = find_current_ida_platform()
         current_version = find_current_ida_version()
 
-        console.print(f"[grey69]current platform:[/grey69] {current_platform}")
-        console.print(f"[grey69]current version:[/grey69] {current_version}")
-        console.print()
+        if not json_output:
+            console.print(f"[grey69]current platform:[/grey69] {current_platform}")
+            console.print(f"[grey69]current version:[/grey69] {current_version}")
+            console.print()
 
         plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
         plugins: list[Plugin] = plugin_repo.get_plugins()
         installed_records = get_installed_plugin_records()
 
-        if not query:
-            handle_keyword_query(plugins, "", current_version, current_platform, installed_records)
-            return
+        ref = resolve_query_reference(plugins, query)
 
-        # Try to parse the query as a qualified reference. If parsing fails
-        # (malformed version spec, etc.) fall back to keyword search so the
-        # substring path continues to work for unusual user input.
-        try:
-            ref = parse_plugin_reference(query)
-        except ValueError:
-            handle_keyword_query(plugins, query, current_version, current_platform, installed_records)
-            return
-
-        # A qualified query (with a host) is always an exact plugin query.
-        # An unqualified query is only an exact plugin query if it exactly
-        # matches a known bare name case-insensitively; otherwise fall back
-        # to keyword/substring search.
-        if ref.host is None and not _has_exact_name_match(plugins, ref.name):
-            handle_keyword_query(plugins, query, current_version, current_platform, installed_records)
+        if ref is None:
+            if json_output:
+                print_json(
+                    {
+                        "query": query or None,
+                        "results": collect_keyword_matches(
+                            plugins, query or "", current_version, current_platform, installed_records
+                        ),
+                    }
+                )
+            else:
+                handle_keyword_query(plugins, query or "", current_version, current_platform, installed_records)
             return
 
         try:
             if ref.version_spec:
-                handle_plugin_spec_query(plugins, ref, current_version, current_platform, installed_records)
+                if json_output:
+                    print_json(
+                        build_plugin_spec_query_result(
+                            plugins, ref, current_version, current_platform, installed_records
+                        )
+                    )
+                else:
+                    handle_plugin_spec_query(plugins, ref, current_version, current_platform, installed_records)
             else:
-                handle_plugin_name_query(plugins, ref, current_version, current_platform, installed_records)
+                if json_output:
+                    print_json(
+                        build_plugin_name_query_result(
+                            plugins, ref, current_version, current_platform, installed_records
+                        )
+                    )
+                else:
+                    handle_plugin_name_query(plugins, ref, current_version, current_platform, installed_records)
+
         except AmbiguousPluginReferenceError as e:
-            # ``get_plugin_by_name`` does not know the user's version spec;
-            # attach it here so candidate suggestions render ``name==1.2.3@repo``.
+            # get_plugin_by_name does not know the user's version spec; attach
+            # it here so candidate suggestions render name==1.2.3@repo.
             if ref.version_spec and not e.version_spec:
                 e = AmbiguousPluginReferenceError(e.name, e.candidates, ref.version_spec)
+
+            if json_output:
+                print_json(
+                    {
+                        "error": "ambiguous plugin reference",
+                        "name": e.name,
+                        "candidates": [format_qualified_plugin_reference(c) for c in e.candidate_refs],
+                    }
+                )
+                ctx.exit(1)
+
             render_ambiguity_error(e)
             raise click.Abort()
+
+        except (KeyError, ValueError) as e:
+            if not json_output:
+                raise
+            print_json({"error": str(e)})
+            ctx.exit(1)
 
     except MissingCurrentInstallationDirectory:
         explain_missing_current_installation_directory(console)
@@ -394,6 +601,9 @@ def search_plugins(ctx, query: str | None = None) -> None:
         raise click.Abort()
 
     except click.Abort:
+        raise
+
+    except click.exceptions.Exit:
         raise
 
     except Exception as e:

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 import rich.table
 import rich_click as click
@@ -87,6 +87,17 @@ class KeywordMatchEntry(TypedDict):
     upgradable: bool
 
 
+class KeywordQueryResult(TypedDict):
+    query: str | None
+    results: list[KeywordMatchEntry]
+
+
+class AmbiguityErrorResult(TypedDict):
+    error: str
+    name: str
+    candidates: list[str]
+
+
 def does_plugin_match_query(query: str, plugin: Plugin) -> bool:
     if not query:
         return True
@@ -139,7 +150,15 @@ def find_installed_matching(
     return find_installed_plugin_in(installed_records, plugin.name, host=plugin.host)
 
 
-def render_ambiguity_error(err: AmbiguousPluginReferenceError) -> None:
+def collect_ambiguity_error(err: AmbiguousPluginReferenceError) -> AmbiguityErrorResult:
+    return {
+        "error": "ambiguous plugin reference",
+        "name": err.name,
+        "candidates": [format_qualified_plugin_reference(ref) for ref in err.candidate_refs],
+    }
+
+
+def render_ambiguity_error_text(err: AmbiguousPluginReferenceError) -> None:
     """Render the user-facing message for an ambiguous bare-name query."""
     console.print(f"[red]Error[/red]: plugin name '{err.name}' is ambiguous")
     console.print("Choose one of:")
@@ -147,16 +166,15 @@ def render_ambiguity_error(err: AmbiguousPluginReferenceError) -> None:
         console.print(f"  {format_qualified_plugin_reference(ref)}")
 
 
-def build_plugin_metadata_dict(metadata) -> dict:
+def collect_plugin_metadata(metadata) -> dict[str, Any]:
     metadata_dict = metadata.plugin.model_dump(mode="json")
     del metadata_dict["platforms"]
     metadata_dict["idaVersions"] = render_ida_versions(metadata_dict["idaVersions"])
     return metadata_dict
 
 
-def output_plugin_metadata(metadata) -> None:
-    metadata_dict = build_plugin_metadata_dict(metadata)
-    for key, value in sorted(metadata_dict.items()):
+def render_plugin_metadata_text(plugin: dict[str, Any]) -> None:
+    for key, value in sorted(plugin.items()):
         console.print(f"{key}: {value}")
     console.print()
 
@@ -205,18 +223,7 @@ def collect_version_entries(
     return entries, (installed_record.version if installed_record is not None else None)
 
 
-def output_plugin_versions_table(
-    plugin: Plugin,
-    versions: Sequence[str],
-    current_version: str,
-    current_platform: str,
-    title: str,
-    installed_records: list[InstalledPluginRecord],
-) -> None:
-    entries, installed_version = collect_version_entries(
-        plugin, versions, current_version, current_platform, installed_records
-    )
-
+def render_plugin_versions_text(entries: list[VersionEntry], installed_version: str | None, title: str) -> None:
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("version", style="default")
     table.add_column("status")
@@ -248,33 +255,14 @@ def get_matching_versions(plugin: Plugin, version_spec: str) -> list[str]:
     ]
 
 
-def all_versions_newest_first(plugin: Plugin) -> list[str]:
+def get_all_versions_newest_first(plugin: Plugin) -> list[str]:
     return [
         version
         for version, _ in sorted(plugin.versions.items(), key=lambda p: parse_plugin_version(p[0]), reverse=True)
     ]
 
 
-def handle_plugin_name_query(
-    plugins: list[Plugin],
-    ref: PluginReference,
-    current_version: str,
-    current_platform: str,
-    installed_records: list[InstalledPluginRecord],
-):
-    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
-    output_plugin_metadata(get_latest_plugin_metadata(plugin))
-    output_plugin_versions_table(
-        plugin,
-        all_versions_newest_first(plugin),
-        current_version,
-        current_platform,
-        "available versions:",
-        installed_records,
-    )
-
-
-def build_plugin_name_query_result(
+def collect_plugin_name_query_result(
     plugins: list[Plugin],
     ref: PluginReference,
     current_version: str,
@@ -283,13 +271,18 @@ def build_plugin_name_query_result(
 ) -> PluginNameQueryResult:
     plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
     entries, installed_version = collect_version_entries(
-        plugin, all_versions_newest_first(plugin), current_version, current_platform, installed_records
+        plugin, get_all_versions_newest_first(plugin), current_version, current_platform, installed_records
     )
     return {
-        "plugin": build_plugin_metadata_dict(get_latest_plugin_metadata(plugin)),
+        "plugin": collect_plugin_metadata(get_latest_plugin_metadata(plugin)),
         "installed_version": installed_version,
         "versions": entries,
     }
+
+
+def render_plugin_name_query_text(result: PluginNameQueryResult) -> None:
+    render_plugin_metadata_text(result["plugin"])
+    render_plugin_versions_text(result["versions"], result["installed_version"], "available versions:")
 
 
 def render_ida_versions(versions: Sequence[IdaVersion]) -> str:
@@ -323,20 +316,27 @@ def collect_download_locations(locations) -> list[DownloadLocationEntry]:
     ]
 
 
-def handle_plugin_exact_version_query(plugin: Plugin, version: str):
+def collect_plugin_exact_version_query_result(plugin: Plugin, version: str) -> PluginExactVersionQueryResult:
     if version not in plugin.versions:
         raise KeyError(f"version {version} not found for plugin {plugin.name}")
 
     locations = plugin.versions[version]
     metadata = locations[0].metadata
-    output_plugin_metadata(metadata)
+    return {
+        "plugin": collect_plugin_metadata(metadata),
+        "download_locations": collect_download_locations(locations),
+    }
+
+
+def render_plugin_exact_version_query_text(result: PluginExactVersionQueryResult) -> None:
+    render_plugin_metadata_text(result["plugin"])
 
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("IDA version spec", style="default")
     table.add_column("IDA platforms", style="default")
     table.add_column("URL")
 
-    for location in collect_download_locations(locations):
+    for location in result["download_locations"]:
         table.add_row(
             "IDA: " + location["ida_versions"],
             "platforms: " + location["platforms"],
@@ -347,36 +347,7 @@ def handle_plugin_exact_version_query(plugin: Plugin, version: str):
     console.print(table)
 
 
-def build_plugin_exact_version_query_result(plugin: Plugin, version: str) -> PluginExactVersionQueryResult:
-    if version not in plugin.versions:
-        raise KeyError(f"version {version} not found for plugin {plugin.name}")
-
-    locations = plugin.versions[version]
-    metadata = locations[0].metadata
-    return {
-        "plugin": build_plugin_metadata_dict(metadata),
-        "download_locations": collect_download_locations(locations),
-    }
-
-
-def handle_plugin_version_range_query(
-    plugin: Plugin,
-    ref: PluginReference,
-    current_version: str,
-    current_platform: str,
-    installed_records: list[InstalledPluginRecord],
-):
-    matching_versions = get_matching_versions(plugin, ref.version_spec)
-    if not matching_versions:
-        raise KeyError(f"no versions matching {ref.version_spec!r} found for plugin {plugin.name!r}")
-
-    output_plugin_metadata(plugin.versions[matching_versions[0]][0].metadata)
-    output_plugin_versions_table(
-        plugin, matching_versions, current_version, current_platform, "matching versions:", installed_records
-    )
-
-
-def build_plugin_version_range_query_result(
+def collect_plugin_version_range_query_result(
     plugin: Plugin,
     ref: PluginReference,
     current_version: str,
@@ -391,32 +362,18 @@ def build_plugin_version_range_query_result(
         plugin, matching_versions, current_version, current_platform, installed_records
     )
     return {
-        "plugin": build_plugin_metadata_dict(plugin.versions[matching_versions[0]][0].metadata),
+        "plugin": collect_plugin_metadata(plugin.versions[matching_versions[0]][0].metadata),
         "installed_version": installed_version,
         "versions": entries,
     }
 
 
-def handle_plugin_spec_query(
-    plugins: list[Plugin],
-    ref: PluginReference,
-    current_version: str,
-    current_platform: str,
-    installed_records: list[InstalledPluginRecord],
-):
-    plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
-
-    if ref.version_spec.startswith("=="):
-        version = ref.version_spec[2:]
-        if not version:
-            raise ValueError(f"invalid plugin version: {ref.version_spec!r}")
-        handle_plugin_exact_version_query(plugin, version)
-        return
-
-    handle_plugin_version_range_query(plugin, ref, current_version, current_platform, installed_records)
+def render_plugin_version_range_query_text(result: PluginVersionRangeQueryResult) -> None:
+    render_plugin_metadata_text(result["plugin"])
+    render_plugin_versions_text(result["versions"], result["installed_version"], "matching versions:")
 
 
-def build_plugin_spec_query_result(
+def collect_plugin_spec_query_result(
     plugins: list[Plugin],
     ref: PluginReference,
     current_version: str,
@@ -429,9 +386,17 @@ def build_plugin_spec_query_result(
         version = ref.version_spec[2:]
         if not version:
             raise ValueError(f"invalid plugin version: {ref.version_spec!r}")
-        return build_plugin_exact_version_query_result(plugin, version)
+        return collect_plugin_exact_version_query_result(plugin, version)
 
-    return build_plugin_version_range_query_result(plugin, ref, current_version, current_platform, installed_records)
+    return collect_plugin_version_range_query_result(plugin, ref, current_version, current_platform, installed_records)
+
+
+def render_plugin_spec_query_text(result: PluginExactVersionQueryResult | PluginVersionRangeQueryResult) -> None:
+    # mypy doesn't narrow a TypedDict union via `in`, so discriminate and cast explicitly.
+    if "download_locations" in result:
+        render_plugin_exact_version_query_text(cast(PluginExactVersionQueryResult, result))
+    else:
+        render_plugin_version_range_query_text(cast(PluginVersionRangeQueryResult, result))
 
 
 def collect_keyword_matches(
@@ -485,14 +450,21 @@ def collect_keyword_matches(
     return matches
 
 
-def handle_keyword_query(
+def collect_keyword_query_result(
     plugins: list[Plugin],
     query: str,
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-):
-    matches = collect_keyword_matches(plugins, query, current_version, current_platform, installed_records)
+) -> KeywordQueryResult:
+    return {
+        "query": query or None,
+        "results": collect_keyword_matches(plugins, query, current_version, current_platform, installed_records),
+    }
+
+
+def render_keyword_query_text(result: KeywordQueryResult) -> None:
+    matches = result["results"]
 
     if not matches:
         console.print("[grey69]No plugins found[/grey69]")
@@ -575,38 +547,32 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
         ref = resolve_query_reference(plugins, query)
 
         if ref is None:
+            keyword_result = collect_keyword_query_result(
+                plugins, query or "", current_version, current_platform, installed_records
+            )
             if json_output:
-                print_json(
-                    {
-                        "query": query or None,
-                        "results": collect_keyword_matches(
-                            plugins, query or "", current_version, current_platform, installed_records
-                        ),
-                    }
-                )
+                print_json(keyword_result)
             else:
-                handle_keyword_query(plugins, query or "", current_version, current_platform, installed_records)
+                render_keyword_query_text(keyword_result)
             return
 
         try:
             if ref.version_spec:
+                spec_result = collect_plugin_spec_query_result(
+                    plugins, ref, current_version, current_platform, installed_records
+                )
                 if json_output:
-                    print_json(
-                        build_plugin_spec_query_result(
-                            plugins, ref, current_version, current_platform, installed_records
-                        )
-                    )
+                    print_json(spec_result)
                 else:
-                    handle_plugin_spec_query(plugins, ref, current_version, current_platform, installed_records)
+                    render_plugin_spec_query_text(spec_result)
             else:
+                name_result = collect_plugin_name_query_result(
+                    plugins, ref, current_version, current_platform, installed_records
+                )
                 if json_output:
-                    print_json(
-                        build_plugin_name_query_result(
-                            plugins, ref, current_version, current_platform, installed_records
-                        )
-                    )
+                    print_json(name_result)
                 else:
-                    handle_plugin_name_query(plugins, ref, current_version, current_platform, installed_records)
+                    render_plugin_name_query_text(name_result)
 
         except AmbiguousPluginReferenceError as e:
             # get_plugin_by_name does not know the user's version spec; attach
@@ -615,16 +581,10 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
                 e = AmbiguousPluginReferenceError(e.name, e.candidates, ref.version_spec)
 
             if json_output:
-                print_json(
-                    {
-                        "error": "ambiguous plugin reference",
-                        "name": e.name,
-                        "candidates": [format_qualified_plugin_reference(c) for c in e.candidate_refs],
-                    }
-                )
+                print_json(collect_ambiguity_error(e))
                 ctx.exit(1)
 
-            render_ambiguity_error(e)
+            render_ambiguity_error_text(e)
             raise click.Abort()
 
         except (KeyError, ValueError) as e:

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import Any, TypedDict, cast
+from typing import Any
 
 import rich.table
 import rich_click as click
 import semantic_version
+from pydantic import BaseModel
 
 from hcli.lib.console import console, print_json
 from hcli.lib.ida import (
@@ -47,37 +48,37 @@ from hcli.lib.ida.plugin.repo import (
 logger = logging.getLogger(__name__)
 
 
-class VersionEntry(TypedDict):
+class VersionEntry(BaseModel):
     version: str
     compatible: bool
     currently_installed: bool
     upgradable: bool
 
 
-class DownloadLocationEntry(TypedDict):
+class DownloadLocationEntry(BaseModel):
     ida_versions: str
     platforms: str
     url: str
 
 
-class PluginNameQueryResult(TypedDict):
+class PluginNameQueryResult(BaseModel):
     plugin: dict[str, Any]
     installed_version: str | None
     versions: list[VersionEntry]
 
 
-class PluginExactVersionQueryResult(TypedDict):
+class PluginExactVersionQueryResult(BaseModel):
     plugin: dict[str, Any]
     download_locations: list[DownloadLocationEntry]
 
 
-class PluginVersionRangeQueryResult(TypedDict):
+class PluginVersionRangeQueryResult(BaseModel):
     plugin: dict[str, Any]
     installed_version: str | None
     versions: list[VersionEntry]
 
 
-class KeywordMatchEntry(TypedDict):
+class KeywordMatchEntry(BaseModel):
     name: str
     version: str
     repository: str | None
@@ -87,12 +88,12 @@ class KeywordMatchEntry(TypedDict):
     upgradable: bool
 
 
-class KeywordQueryResult(TypedDict):
+class KeywordQueryResult(BaseModel):
     query: str | None
     results: list[KeywordMatchEntry]
 
 
-class AmbiguityErrorResult(TypedDict):
+class AmbiguityErrorResult(BaseModel):
     error: str
     name: str
     candidates: list[str]
@@ -151,11 +152,11 @@ def find_installed_matching(
 
 
 def collect_ambiguity_error(err: AmbiguousPluginReferenceError) -> AmbiguityErrorResult:
-    return {
-        "error": "ambiguous plugin reference",
-        "name": err.name,
-        "candidates": [format_qualified_plugin_reference(ref) for ref in err.candidate_refs],
-    }
+    return AmbiguityErrorResult(
+        error="ambiguous plugin reference",
+        name=err.name,
+        candidates=[format_qualified_plugin_reference(ref) for ref in err.candidate_refs],
+    )
 
 
 def render_ambiguity_error_text(err: AmbiguousPluginReferenceError) -> None:
@@ -212,12 +213,12 @@ def collect_version_entries(
                 upgradable = True
 
         entries.append(
-            {
-                "version": version,
-                "compatible": is_compatible,
-                "currently_installed": currently_installed,
-                "upgradable": upgradable,
-            }
+            VersionEntry(
+                version=version,
+                compatible=is_compatible,
+                currently_installed=currently_installed,
+                upgradable=upgradable,
+            )
         )
 
     return entries, (installed_record.version if installed_record is not None else None)
@@ -234,13 +235,13 @@ def render_plugin_versions_text(entries: list[VersionEntry], installed_version: 
         # an old/uninstalled version once something is installed, mirroring
         # what a user cares about (their own upgrade path, not every release).
         if installed_version is not None:
-            if entry["currently_installed"]:
+            if entry.currently_installed:
                 status = "[green]currently installed[/green]"
-            elif entry["upgradable"]:
+            elif entry.upgradable:
                 status = f"[yellow]upgradable[/yellow] from {installed_version}"
-        elif not entry["compatible"]:
+        elif not entry.compatible:
             status = "[grey69]incompatible[/grey69]"
-        table.add_row(entry["version"], status)
+        table.add_row(entry.version, status)
 
     console.print(title)
     console.print(table)
@@ -273,16 +274,16 @@ def collect_plugin_name_query_result(
     entries, installed_version = collect_version_entries(
         plugin, get_all_versions_newest_first(plugin), current_version, current_platform, installed_records
     )
-    return {
-        "plugin": collect_plugin_metadata(get_latest_plugin_metadata(plugin)),
-        "installed_version": installed_version,
-        "versions": entries,
-    }
+    return PluginNameQueryResult(
+        plugin=collect_plugin_metadata(get_latest_plugin_metadata(plugin)),
+        installed_version=installed_version,
+        versions=entries,
+    )
 
 
 def render_plugin_name_query_text(result: PluginNameQueryResult) -> None:
-    render_plugin_metadata_text(result["plugin"])
-    render_plugin_versions_text(result["versions"], result["installed_version"], "available versions:")
+    render_plugin_metadata_text(result.plugin)
+    render_plugin_versions_text(result.versions, result.installed_version, "available versions:")
 
 
 def render_ida_versions(versions: Sequence[IdaVersion]) -> str:
@@ -307,11 +308,11 @@ def render_platforms(platforms: Sequence[Platform]) -> str:
 
 def collect_download_locations(locations) -> list[DownloadLocationEntry]:
     return [
-        {
-            "ida_versions": render_ida_versions(location.metadata.plugin.ida_versions),
-            "platforms": render_platforms(location.metadata.plugin.platforms),
-            "url": location.url,
-        }
+        DownloadLocationEntry(
+            ida_versions=render_ida_versions(location.metadata.plugin.ida_versions),
+            platforms=render_platforms(location.metadata.plugin.platforms),
+            url=location.url,
+        )
         for location in locations
     ]
 
@@ -322,25 +323,25 @@ def collect_plugin_exact_version_query_result(plugin: Plugin, version: str) -> P
 
     locations = plugin.versions[version]
     metadata = locations[0].metadata
-    return {
-        "plugin": collect_plugin_metadata(metadata),
-        "download_locations": collect_download_locations(locations),
-    }
+    return PluginExactVersionQueryResult(
+        plugin=collect_plugin_metadata(metadata),
+        download_locations=collect_download_locations(locations),
+    )
 
 
 def render_plugin_exact_version_query_text(result: PluginExactVersionQueryResult) -> None:
-    render_plugin_metadata_text(result["plugin"])
+    render_plugin_metadata_text(result.plugin)
 
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("IDA version spec", style="default")
     table.add_column("IDA platforms", style="default")
     table.add_column("URL")
 
-    for location in result["download_locations"]:
+    for location in result.download_locations:
         table.add_row(
-            "IDA: " + location["ida_versions"],
-            "platforms: " + location["platforms"],
-            "URL: " + location["url"],
+            "IDA: " + location.ida_versions,
+            "platforms: " + location.platforms,
+            "URL: " + location.url,
         )
 
     console.print("download locations:")
@@ -361,16 +362,16 @@ def collect_plugin_version_range_query_result(
     entries, installed_version = collect_version_entries(
         plugin, matching_versions, current_version, current_platform, installed_records
     )
-    return {
-        "plugin": collect_plugin_metadata(plugin.versions[matching_versions[0]][0].metadata),
-        "installed_version": installed_version,
-        "versions": entries,
-    }
+    return PluginVersionRangeQueryResult(
+        plugin=collect_plugin_metadata(plugin.versions[matching_versions[0]][0].metadata),
+        installed_version=installed_version,
+        versions=entries,
+    )
 
 
 def render_plugin_version_range_query_text(result: PluginVersionRangeQueryResult) -> None:
-    render_plugin_metadata_text(result["plugin"])
-    render_plugin_versions_text(result["versions"], result["installed_version"], "matching versions:")
+    render_plugin_metadata_text(result.plugin)
+    render_plugin_versions_text(result.versions, result.installed_version, "matching versions:")
 
 
 def collect_plugin_spec_query_result(
@@ -392,11 +393,10 @@ def collect_plugin_spec_query_result(
 
 
 def render_plugin_spec_query_text(result: PluginExactVersionQueryResult | PluginVersionRangeQueryResult) -> None:
-    # mypy doesn't narrow a TypedDict union via `in`, so discriminate and cast explicitly.
-    if "download_locations" in result:
-        render_plugin_exact_version_query_text(cast(PluginExactVersionQueryResult, result))
+    if isinstance(result, PluginExactVersionQueryResult):
+        render_plugin_exact_version_query_text(result)
     else:
-        render_plugin_version_range_query_text(cast(PluginVersionRangeQueryResult, result))
+        render_plugin_version_range_query_text(result)
 
 
 def collect_keyword_matches(
@@ -416,15 +416,15 @@ def collect_keyword_matches(
 
         if not is_compatible_plugin(plugin, current_platform, current_version):
             matches.append(
-                {
-                    "name": latest_metadata.plugin.name,
-                    "version": latest_metadata.plugin.version,
-                    "repository": latest_metadata.plugin.urls.repository,
-                    "compatible": False,
-                    "installed": False,
-                    "installed_version": None,
-                    "upgradable": False,
-                }
+                KeywordMatchEntry(
+                    name=latest_metadata.plugin.name,
+                    version=latest_metadata.plugin.version,
+                    repository=latest_metadata.plugin.urls.repository,
+                    compatible=False,
+                    installed=False,
+                    installed_version=None,
+                    upgradable=False,
+                )
             )
             continue
 
@@ -436,15 +436,15 @@ def collect_keyword_matches(
         ) > parse_plugin_version(installed_version)
 
         matches.append(
-            {
-                "name": latest_metadata.plugin.name,
-                "version": latest_metadata.plugin.version,
-                "repository": latest_metadata.plugin.urls.repository,
-                "compatible": True,
-                "installed": installed_record is not None,
-                "installed_version": installed_version,
-                "upgradable": upgradable,
-            }
+            KeywordMatchEntry(
+                name=latest_metadata.plugin.name,
+                version=latest_metadata.plugin.version,
+                repository=latest_metadata.plugin.urls.repository,
+                compatible=True,
+                installed=installed_record is not None,
+                installed_version=installed_version,
+                upgradable=upgradable,
+            )
         )
 
     return matches
@@ -457,14 +457,14 @@ def collect_keyword_query_result(
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
 ) -> KeywordQueryResult:
-    return {
-        "query": query or None,
-        "results": collect_keyword_matches(plugins, query, current_version, current_platform, installed_records),
-    }
+    return KeywordQueryResult(
+        query=query or None,
+        results=collect_keyword_matches(plugins, query, current_version, current_platform, installed_records),
+    )
 
 
 def render_keyword_query_text(result: KeywordQueryResult) -> None:
-    matches = result["results"]
+    matches = result.results
 
     if not matches:
         console.print("[grey69]No plugins found[/grey69]")
@@ -477,22 +477,22 @@ def render_keyword_query_text(result: KeywordQueryResult) -> None:
     table.add_column("repo", style="grey69")
 
     for match in matches:
-        if not match["compatible"]:
+        if not match.compatible:
             table.add_row(
-                f"[grey69]{match['name']} (incompatible)[/grey69]",
-                f"[grey69]{match['version']}[/grey69]",
+                f"[grey69]{match.name} (incompatible)[/grey69]",
+                f"[grey69]{match.version}[/grey69]",
                 "",
-                match["repository"],
+                match.repository,
             )
             continue
 
         status = ""
-        if match["upgradable"]:
-            status = f"[yellow]upgradable[/yellow] from {match['installed_version']}"
-        elif match["installed"]:
+        if match.upgradable:
+            status = f"[yellow]upgradable[/yellow] from {match.installed_version}"
+        elif match.installed:
             status = "installed"
 
-        table.add_row(f"[blue]{match['name']}[/blue]", match["version"], status, match["repository"])
+        table.add_row(f"[blue]{match.name}[/blue]", match.version, status, match.repository)
 
     console.print(table)
 
@@ -525,6 +525,10 @@ def resolve_query_reference(plugins: list[Plugin], query: str | None) -> PluginR
     return ref
 
 
+def _dump_result(result: BaseModel) -> dict[str, Any]:
+    return result.model_dump(mode="json")
+
+
 @click.command()
 @click.argument("query", required=False)
 @click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
@@ -551,7 +555,7 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
                 plugins, query or "", current_version, current_platform, installed_records
             )
             if json_output:
-                print_json(keyword_result)
+                print_json(_dump_result(keyword_result))
             else:
                 render_keyword_query_text(keyword_result)
             return
@@ -562,7 +566,7 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
                     plugins, ref, current_version, current_platform, installed_records
                 )
                 if json_output:
-                    print_json(spec_result)
+                    print_json(_dump_result(spec_result))
                 else:
                     render_plugin_spec_query_text(spec_result)
             else:
@@ -570,7 +574,7 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
                     plugins, ref, current_version, current_platform, installed_records
                 )
                 if json_output:
-                    print_json(name_result)
+                    print_json(_dump_result(name_result))
                 else:
                     render_plugin_name_query_text(name_result)
 
@@ -581,7 +585,7 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
                 e = AmbiguousPluginReferenceError(e.name, e.candidates, ref.version_spec)
 
             if json_output:
-                print_json(collect_ambiguity_error(e))
+                print_json(_dump_result(collect_ambiguity_error(e)))
                 ctx.exit(1)
 
             render_ambiguity_error_text(e)

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -23,6 +23,7 @@ from hcli.lib.ida import (
 from hcli.lib.ida.plugin import (
     ALL_IDA_VERSIONS,
     ALL_PLATFORMS,
+    IDAMetadataDescriptor,
     IdaVersion,
     Platform,
     parse_ida_version,
@@ -38,6 +39,7 @@ from hcli.lib.ida.plugin.reference import (
 from hcli.lib.ida.plugin.repo import (
     BasePluginRepo,
     Plugin,
+    PluginArchiveLocation,
     get_latest_compatible_plugin_metadata,
     get_latest_plugin_metadata,
     get_plugin_by_name,
@@ -167,7 +169,7 @@ def render_ambiguity_error_text(err: AmbiguousPluginReferenceError) -> None:
         console.print(f"  {format_qualified_plugin_reference(ref)}")
 
 
-def collect_plugin_metadata(metadata) -> dict[str, Any]:
+def collect_plugin_metadata(metadata: IDAMetadataDescriptor) -> dict[str, Any]:
     metadata_dict = metadata.plugin.model_dump(mode="json")
     del metadata_dict["platforms"]
     metadata_dict["idaVersions"] = render_ida_versions(metadata_dict["idaVersions"])
@@ -306,7 +308,7 @@ def render_platforms(platforms: Sequence[Platform]) -> str:
     return ", ".join(sorted(platforms))
 
 
-def collect_download_locations(locations) -> list[DownloadLocationEntry]:
+def collect_download_locations(locations: list[PluginArchiveLocation]) -> list[DownloadLocationEntry]:
     return [
         DownloadLocationEntry(
             ida_versions=render_ida_versions(location.metadata.plugin.ida_versions),

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from typing import Any, TypedDict
 
 import rich.table
 import rich_click as click
@@ -44,6 +45,46 @@ from hcli.lib.ida.plugin.repo import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class VersionEntry(TypedDict):
+    version: str
+    compatible: bool
+    currently_installed: bool
+    upgradable: bool
+
+
+class DownloadLocationEntry(TypedDict):
+    ida_versions: str
+    platforms: str
+    url: str
+
+
+class PluginNameQueryResult(TypedDict):
+    plugin: dict[str, Any]
+    installed_version: str | None
+    versions: list[VersionEntry]
+
+
+class PluginExactVersionQueryResult(TypedDict):
+    plugin: dict[str, Any]
+    download_locations: list[DownloadLocationEntry]
+
+
+class PluginVersionRangeQueryResult(TypedDict):
+    plugin: dict[str, Any]
+    installed_version: str | None
+    versions: list[VersionEntry]
+
+
+class KeywordMatchEntry(TypedDict):
+    name: str
+    version: str
+    repository: str | None
+    compatible: bool
+    installed: bool
+    installed_version: str | None
+    upgradable: bool
 
 
 def does_plugin_match_query(query: str, plugin: Plugin) -> bool:
@@ -126,7 +167,7 @@ def collect_version_entries(
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-) -> tuple[list[dict], str | None]:
+) -> tuple[list[VersionEntry], str | None]:
     """Build per-version compatibility/install status entries for `plugin`.
 
     Returns (entries, installed_version), where installed_version is the
@@ -138,7 +179,7 @@ def collect_version_entries(
     if installed_record is not None:
         existing_version = parse_plugin_version(installed_record.version)
 
-    entries = []
+    entries: list[VersionEntry] = []
     for version in versions:
         locations = plugin.versions[version]
         metadata = locations[0].metadata
@@ -239,7 +280,7 @@ def build_plugin_name_query_result(
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-) -> dict:
+) -> PluginNameQueryResult:
     plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
     entries, installed_version = collect_version_entries(
         plugin, all_versions_newest_first(plugin), current_version, current_platform, installed_records
@@ -271,7 +312,7 @@ def render_platforms(platforms: Sequence[Platform]) -> str:
     return ", ".join(sorted(platforms))
 
 
-def collect_download_locations(locations) -> list[dict]:
+def collect_download_locations(locations) -> list[DownloadLocationEntry]:
     return [
         {
             "ida_versions": render_ida_versions(location.metadata.plugin.ida_versions),
@@ -306,7 +347,7 @@ def handle_plugin_exact_version_query(plugin: Plugin, version: str):
     console.print(table)
 
 
-def build_plugin_exact_version_query_result(plugin: Plugin, version: str) -> dict:
+def build_plugin_exact_version_query_result(plugin: Plugin, version: str) -> PluginExactVersionQueryResult:
     if version not in plugin.versions:
         raise KeyError(f"version {version} not found for plugin {plugin.name}")
 
@@ -341,7 +382,7 @@ def build_plugin_version_range_query_result(
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-) -> dict:
+) -> PluginVersionRangeQueryResult:
     matching_versions = get_matching_versions(plugin, ref.version_spec)
     if not matching_versions:
         raise KeyError(f"no versions matching {ref.version_spec!r} found for plugin {plugin.name!r}")
@@ -381,7 +422,7 @@ def build_plugin_spec_query_result(
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-) -> dict:
+) -> PluginExactVersionQueryResult | PluginVersionRangeQueryResult:
     plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
 
     if ref.version_spec.startswith("=="):
@@ -399,8 +440,8 @@ def collect_keyword_matches(
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-) -> list[dict]:
-    matches = []
+) -> list[KeywordMatchEntry]:
+    matches: list[KeywordMatchEntry] = []
 
     for plugin in sorted(plugins, key=lambda p: p.name.lower()):
         if not does_plugin_match_query(query or "", plugin):

--- a/src/hcli/commands/plugin/status.py
+++ b/src/hcli/commands/plugin/status.py
@@ -8,7 +8,7 @@ import rich.table
 import rich_click as click
 
 from hcli.env import ENV
-from hcli.lib.console import console
+from hcli.lib.console import console, print_json
 from hcli.lib.ida import (
     FailedToDetectIDAVersion,
     MissingCurrentInstallationDirectory,
@@ -31,6 +31,78 @@ from hcli.lib.ida.plugin.repo import BasePluginRepo
 logger = logging.getLogger(__name__)
 
 
+def _build_installed_entry(
+    plugin_repo: BasePluginRepo,
+    record,
+    current_platform: str,
+    current_ida_version: str,
+    offline: bool,
+) -> dict:
+    entry = {"name": record.name, "version": record.version, "installed": True, "kind": "installed"}
+
+    if offline:
+        entry["upgrade_checked"] = False
+        entry["in_repository"] = None
+        entry["upgradable_to"] = None
+        return entry
+
+    try:
+        # Anchor the repository lookup on the installed plugin's host so a
+        # colliding plugin name in the repository does not raise ambiguity
+        # or pick the wrong variant.
+        location = plugin_repo.find_compatible_plugin_from_spec(
+            record.name, current_platform, current_ida_version, host=record.host
+        )
+        entry["upgrade_checked"] = True
+        entry["in_repository"] = True
+        latest_version = location.metadata.plugin.version
+        entry["upgradable_to"] = (
+            latest_version if parse_plugin_version(latest_version) > parse_plugin_version(record.version) else None
+        )
+    except (ValueError, KeyError, AmbiguousPluginReferenceError):
+        # AmbiguousPluginReferenceError should not escape this command. The
+        # installed plugin's own metadata carries its host, so anchoring on
+        # that host above should normally resolve the collision; if it does
+        # not, treat the plugin as absent from the repository rather than
+        # crashing status.
+        entry["upgrade_checked"] = True
+        entry["in_repository"] = False
+        entry["upgradable_to"] = None
+
+    return entry
+
+
+def _render_status_row(table: rich.table.Table, entry: dict) -> None:
+    kind = entry.get("kind")
+
+    if kind == "incompatible":
+        table.add_row(
+            f"[grey69](incompatible)[/grey69] [blue]{entry['name']}[/blue]",
+            entry["version"] or "",
+            f"[grey69]found at: $IDAPLUGINS/[/grey69]{entry['path']}",
+        )
+        return
+
+    if kind == "legacy":
+        table.add_row(
+            f"[grey69](legacy)[/grey69] [blue]{entry['name']}[/blue]",
+            "",
+            f"[grey69]found at: $IDAPLUGINS/[/grey69]{entry['path']}",
+        )
+        return
+
+    if not entry["upgrade_checked"]:
+        status = "[dim]skipped (offline)[/dim]"
+    elif not entry["in_repository"]:
+        status = "[yellow]not found in repository[/yellow]"
+    elif entry["upgradable_to"]:
+        status = f"upgradable to [yellow]{entry['upgradable_to']}[/yellow]"
+    else:
+        status = ""
+
+    table.add_row(entry["name"], entry["version"], status)
+
+
 @click.command()
 @click.argument("plugins", nargs=-1)
 @click.option(
@@ -39,8 +111,9 @@ logger = logging.getLogger(__name__)
     default=False,
     help="skip the per-plugin upgrade check against the plugin repository",
 )
+@click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
 @click.pass_context
-def get_plugin_status(ctx, plugins: tuple[str, ...], offline: bool) -> None:
+def get_plugin_status(ctx, plugins: tuple[str, ...], offline: bool, json_output: bool) -> None:
     """Show installed plugins and their upgrade status.
 
     If one or more PLUGINS are given, show status for just those plugins,
@@ -51,11 +124,6 @@ def get_plugin_status(ctx, plugins: tuple[str, ...], offline: bool) -> None:
     try:
         current_platform = find_current_ida_platform()
         current_ida_version = find_current_ida_version()
-
-        table = rich.table.Table(show_header=False, box=None)
-        table.add_column("name", style="blue")
-        table.add_column("version", style="default")
-        table.add_column("status")
 
         all_records = get_installed_plugin_records()
         if plugins:
@@ -69,72 +137,71 @@ def get_plugin_status(ctx, plugins: tuple[str, ...], offline: bool) -> None:
         else:
             installed_records = all_records
 
-        for record in installed_records:
-            status = ""
-            if offline:
-                status = "[dim]skipped (offline)[/dim]"
-            else:
-                try:
-                    # Anchor the repository lookup on the installed plugin's host so a
-                    # colliding plugin name in the repository does not raise ambiguity
-                    # or pick the wrong variant.
-                    location = plugin_repo.find_compatible_plugin_from_spec(
-                        record.name, current_platform, current_ida_version, host=record.host
-                    )
-                    if parse_plugin_version(location.metadata.plugin.version) > parse_plugin_version(record.version):
-                        status = f"upgradable to [yellow]{location.metadata.plugin.version}[/yellow]"
-                except (ValueError, KeyError, AmbiguousPluginReferenceError):
-                    # AmbiguousPluginReferenceError should not escape this command.
-                    # The installed plugin's own metadata carries its host, so
-                    # anchoring on that host above should normally resolve the
-                    # collision; if it does not, treat the plugin as absent from
-                    # the repository rather than crashing status.
-                    status = "[yellow]not found in repository[/yellow]"
+        entries = [
+            _build_installed_entry(plugin_repo, record, current_platform, current_ida_version, offline)
+            for record in installed_records
+        ]
+        not_found_entries = [{"name": name, "installed": False} for name in not_found_names]
 
-            table.add_row(record.name, record.version, status)
-
-        has_incompatible_plugins = False
-        has_legacy_plugins = False
+        incompatible_entries = []
+        legacy_entries = []
         if not plugins:
             plugin_directory = get_plugins_directory()
             for path, metadata in get_installed_minimal_plugins():
                 plugin_path = path.parent.relative_to(plugin_directory)
-                table.add_row(
-                    f"[grey69](incompatible)[/grey69] [blue]{metadata.plugin.name}[/blue]",
-                    metadata.plugin.version or "",
-                    f"[grey69]found at: $IDAPLUGINS/[/grey69]{plugin_path}/",
+                incompatible_entries.append(
+                    {
+                        "name": metadata.plugin.name,
+                        "version": metadata.plugin.version or None,
+                        "installed": True,
+                        "kind": "incompatible",
+                        "path": f"{plugin_path}/",
+                    }
                 )
-                has_incompatible_plugins = True
 
             for path in get_installed_legacy_plugins():
                 plugin_path = path.parent.relative_to(plugin_directory)
-                table.add_row(
-                    f"[grey69](legacy)[/grey69] [blue]{path.name}[/blue]",
-                    "",
-                    f"[grey69]found at: $IDAPLUGINS/[/grey69]{path.name}",
+                legacy_entries.append(
+                    {
+                        "name": path.name,
+                        "version": None,
+                        "installed": True,
+                        "kind": "legacy",
+                        "path": f"{path.name}",
+                    }
                 )
-                has_legacy_plugins = True
 
-        if table.row_count:
-            console.print(table)
-        elif not plugins:
-            console.print("[grey69]No plugins found[/grey69]")
+        if json_output:
+            print_json({"plugins": entries + not_found_entries + incompatible_entries + legacy_entries})
+        else:
+            table = rich.table.Table(show_header=False, box=None)
+            table.add_column("name", style="blue")
+            table.add_column("version", style="default")
+            table.add_column("status")
 
-        for name in not_found_names:
-            console.print(f"[red]Not installed[/red]: {name}")
+            for entry in entries + incompatible_entries + legacy_entries:
+                _render_status_row(table, entry)
 
-        if has_incompatible_plugins:
-            console.print()
-            console.print("[yellow]Incompatible plugins[/yellow] don't work with this version of hcli.")
-            console.print(
-                f"[dim]They might be broken or outdated. Try using `{ENV.HCLI_BINARY_NAME} plugin lint /path/to/plugin`.[/dim]"
-            )
+            if table.row_count:
+                console.print(table)
+            elif not plugins:
+                console.print("[grey69]No plugins found[/grey69]")
 
-        if has_legacy_plugins:
-            # TODO: suggest plugins in the repo, by maintaining a translation list from filename to package name
-            console.print()
-            console.print("[yellow]Legacy plugins[/yellow] are old, single-file plugins.")
-            console.print("They aren't managed by hcli. Try finding an updated version in the plugin repository.")
+            for name in not_found_names:
+                console.print(f"[red]Not installed[/red]: {name}")
+
+            if incompatible_entries:
+                console.print()
+                console.print("[yellow]Incompatible plugins[/yellow] don't work with this version of hcli.")
+                console.print(
+                    f"[dim]They might be broken or outdated. Try using `{ENV.HCLI_BINARY_NAME} plugin lint /path/to/plugin`.[/dim]"
+                )
+
+            if legacy_entries:
+                # TODO: suggest plugins in the repo, by maintaining a translation list from filename to package name
+                console.print()
+                console.print("[yellow]Legacy plugins[/yellow] are old, single-file plugins.")
+                console.print("They aren't managed by hcli. Try finding an updated version in the plugin repository.")
 
     except MissingCurrentInstallationDirectory:
         explain_missing_current_installation_directory(console)

--- a/src/hcli/commands/plugin/status.py
+++ b/src/hcli/commands/plugin/status.py
@@ -33,8 +33,14 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.argument("plugins", nargs=-1)
+@click.option(
+    "--offline",
+    is_flag=True,
+    default=False,
+    help="skip the per-plugin upgrade check against the plugin repository",
+)
 @click.pass_context
-def get_plugin_status(ctx, plugins: tuple[str, ...]) -> None:
+def get_plugin_status(ctx, plugins: tuple[str, ...], offline: bool) -> None:
     """Show installed plugins and their upgrade status.
 
     If one or more PLUGINS are given, show status for just those plugins,
@@ -65,22 +71,25 @@ def get_plugin_status(ctx, plugins: tuple[str, ...]) -> None:
 
         for record in installed_records:
             status = ""
-            try:
-                # Anchor the repository lookup on the installed plugin's host so a
-                # colliding plugin name in the repository does not raise ambiguity
-                # or pick the wrong variant.
-                location = plugin_repo.find_compatible_plugin_from_spec(
-                    record.name, current_platform, current_ida_version, host=record.host
-                )
-                if parse_plugin_version(location.metadata.plugin.version) > parse_plugin_version(record.version):
-                    status = f"upgradable to [yellow]{location.metadata.plugin.version}[/yellow]"
-            except (ValueError, KeyError, AmbiguousPluginReferenceError):
-                # AmbiguousPluginReferenceError should not escape this command.
-                # The installed plugin's own metadata carries its host, so
-                # anchoring on that host above should normally resolve the
-                # collision; if it does not, treat the plugin as absent from
-                # the repository rather than crashing status.
-                status = "[yellow]not found in repository[/yellow]"
+            if offline:
+                status = "[dim]skipped (offline)[/dim]"
+            else:
+                try:
+                    # Anchor the repository lookup on the installed plugin's host so a
+                    # colliding plugin name in the repository does not raise ambiguity
+                    # or pick the wrong variant.
+                    location = plugin_repo.find_compatible_plugin_from_spec(
+                        record.name, current_platform, current_ida_version, host=record.host
+                    )
+                    if parse_plugin_version(location.metadata.plugin.version) > parse_plugin_version(record.version):
+                        status = f"upgradable to [yellow]{location.metadata.plugin.version}[/yellow]"
+                except (ValueError, KeyError, AmbiguousPluginReferenceError):
+                    # AmbiguousPluginReferenceError should not escape this command.
+                    # The installed plugin's own metadata carries its host, so
+                    # anchoring on that host above should normally resolve the
+                    # collision; if it does not, treat the plugin as absent from
+                    # the repository rather than crashing status.
+                    status = "[yellow]not found in repository[/yellow]"
 
             table.add_row(record.name, record.version, status)
 

--- a/src/hcli/commands/plugin/status.py
+++ b/src/hcli/commands/plugin/status.py
@@ -31,7 +31,7 @@ from hcli.lib.ida.plugin.repo import BasePluginRepo
 logger = logging.getLogger(__name__)
 
 
-def _build_installed_entry(
+def _collect_installed_entry(
     plugin_repo: BasePluginRepo,
     record,
     current_platform: str,
@@ -138,7 +138,7 @@ def get_plugin_status(ctx, plugins: tuple[str, ...], skip_upgrade_check: bool, j
             installed_records = all_records
 
         entries = [
-            _build_installed_entry(plugin_repo, record, current_platform, current_ida_version, skip_upgrade_check)
+            _collect_installed_entry(plugin_repo, record, current_platform, current_ida_version, skip_upgrade_check)
             for record in installed_records
         ]
         not_found_entries = [{"name": name, "installed": False} for name in not_found_names]

--- a/src/hcli/commands/plugin/status.py
+++ b/src/hcli/commands/plugin/status.py
@@ -20,6 +20,7 @@ from hcli.lib.ida import (
 from hcli.lib.ida.plugin import parse_plugin_version
 from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError
 from hcli.lib.ida.plugin.install import (
+    find_installed_plugin_in,
     get_installed_legacy_plugins,
     get_installed_minimal_plugins,
     get_installed_plugin_records,
@@ -31,10 +32,16 @@ logger = logging.getLogger(__name__)
 
 
 @click.command()
+@click.argument("plugins", nargs=-1)
 @click.pass_context
-def get_plugin_status(ctx) -> None:
-    """Show installed plugins and their upgrade status."""
+def get_plugin_status(ctx, plugins: tuple[str, ...]) -> None:
+    """Show installed plugins and their upgrade status.
+
+    If one or more PLUGINS are given, show status for just those plugins,
+    and exit with a non-zero status if any of them isn't installed.
+    """
     plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
+    not_found_names: list[str] = []
     try:
         current_platform = find_current_ida_platform()
         current_ida_version = find_current_ida_version()
@@ -44,7 +51,19 @@ def get_plugin_status(ctx) -> None:
         table.add_column("version", style="default")
         table.add_column("status")
 
-        for record in get_installed_plugin_records():
+        all_records = get_installed_plugin_records()
+        if plugins:
+            installed_records = []
+            for name in plugins:
+                record = find_installed_plugin_in(all_records, name)
+                if record is None:
+                    not_found_names.append(name)
+                else:
+                    installed_records.append(record)
+        else:
+            installed_records = all_records
+
+        for record in installed_records:
             status = ""
             try:
                 # Anchor the repository lookup on the installed plugin's host so a
@@ -66,30 +85,34 @@ def get_plugin_status(ctx) -> None:
             table.add_row(record.name, record.version, status)
 
         has_incompatible_plugins = False
-        plugin_directory = get_plugins_directory()
-        for path, metadata in get_installed_minimal_plugins():
-            plugin_path = path.parent.relative_to(plugin_directory)
-            table.add_row(
-                f"[grey69](incompatible)[/grey69] [blue]{metadata.plugin.name}[/blue]",
-                metadata.plugin.version or "",
-                f"[grey69]found at: $IDAPLUGINS/[/grey69]{plugin_path}/",
-            )
-            has_incompatible_plugins = True
-
         has_legacy_plugins = False
-        for path in get_installed_legacy_plugins():
-            plugin_path = path.parent.relative_to(plugin_directory)
-            table.add_row(
-                f"[grey69](legacy)[/grey69] [blue]{path.name}[/blue]",
-                "",
-                f"[grey69]found at: $IDAPLUGINS/[/grey69]{path.name}",
-            )
-            has_legacy_plugins = True
+        if not plugins:
+            plugin_directory = get_plugins_directory()
+            for path, metadata in get_installed_minimal_plugins():
+                plugin_path = path.parent.relative_to(plugin_directory)
+                table.add_row(
+                    f"[grey69](incompatible)[/grey69] [blue]{metadata.plugin.name}[/blue]",
+                    metadata.plugin.version or "",
+                    f"[grey69]found at: $IDAPLUGINS/[/grey69]{plugin_path}/",
+                )
+                has_incompatible_plugins = True
+
+            for path in get_installed_legacy_plugins():
+                plugin_path = path.parent.relative_to(plugin_directory)
+                table.add_row(
+                    f"[grey69](legacy)[/grey69] [blue]{path.name}[/blue]",
+                    "",
+                    f"[grey69]found at: $IDAPLUGINS/[/grey69]{path.name}",
+                )
+                has_legacy_plugins = True
 
         if table.row_count:
             console.print(table)
-        else:
+        elif not plugins:
             console.print("[grey69]No plugins found[/grey69]")
+
+        for name in not_found_names:
+            console.print(f"[red]Not installed[/red]: {name}")
 
         if has_incompatible_plugins:
             console.print()
@@ -116,3 +139,6 @@ def get_plugin_status(ctx) -> None:
         logger.debug("error: %s", e, exc_info=True)
         console.print(f"[red]Error[/red]: {e}")
         raise click.Abort()
+
+    if not_found_names:
+        ctx.exit(1)

--- a/src/hcli/commands/plugin/status.py
+++ b/src/hcli/commands/plugin/status.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 import rich.table
 import rich_click as click
+from pydantic import BaseModel
 
 from hcli.env import ENV
 from hcli.lib.console import console, print_json
@@ -20,6 +22,7 @@ from hcli.lib.ida import (
 from hcli.lib.ida.plugin import parse_plugin_version
 from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError
 from hcli.lib.ida.plugin.install import (
+    InstalledPluginRecord,
     find_installed_plugin_in,
     get_installed_legacy_plugins,
     get_installed_minimal_plugins,
@@ -31,76 +34,213 @@ from hcli.lib.ida.plugin.repo import BasePluginRepo
 logger = logging.getLogger(__name__)
 
 
+class InstalledPluginStatusEntry(BaseModel):
+    name: str
+    version: str
+    installed: Literal[True] = True
+    kind: Literal["installed"] = "installed"
+    upgrade_checked: bool
+    in_repository: bool | None
+    upgradable_to: str | None
+
+
+class NotFoundPluginStatusEntry(BaseModel):
+    name: str
+    installed: Literal[False] = False
+
+
+class IncompatiblePluginStatusEntry(BaseModel):
+    name: str
+    version: str | None
+    installed: Literal[True] = True
+    kind: Literal["incompatible"] = "incompatible"
+    path: str
+
+
+class LegacyPluginStatusEntry(BaseModel):
+    name: str
+    version: None = None
+    installed: Literal[True] = True
+    kind: Literal["legacy"] = "legacy"
+    path: str
+
+
+PluginStatusEntry = (
+    InstalledPluginStatusEntry | NotFoundPluginStatusEntry | IncompatiblePluginStatusEntry | LegacyPluginStatusEntry
+)
+
+
+class StatusReport(BaseModel):
+    plugins: list[PluginStatusEntry]
+
+
 def _collect_installed_entry(
     plugin_repo: BasePluginRepo,
-    record,
+    record: InstalledPluginRecord,
     current_platform: str,
     current_ida_version: str,
     skip_upgrade_check: bool,
-) -> dict:
-    entry = {"name": record.name, "version": record.version, "installed": True, "kind": "installed"}
-
+) -> InstalledPluginStatusEntry:
     if skip_upgrade_check:
-        entry["upgrade_checked"] = False
-        entry["in_repository"] = None
-        entry["upgradable_to"] = None
-        return entry
+        return InstalledPluginStatusEntry(
+            name=record.name,
+            version=record.version,
+            upgrade_checked=False,
+            in_repository=None,
+            upgradable_to=None,
+        )
 
     try:
-        # Anchor the repository lookup on the installed plugin's host so a
-        # colliding plugin name in the repository does not raise ambiguity
-        # or pick the wrong variant.
         location = plugin_repo.find_compatible_plugin_from_spec(
             record.name, current_platform, current_ida_version, host=record.host
         )
-        entry["upgrade_checked"] = True
-        entry["in_repository"] = True
         latest_version = location.metadata.plugin.version
-        entry["upgradable_to"] = (
-            latest_version if parse_plugin_version(latest_version) > parse_plugin_version(record.version) else None
+        return InstalledPluginStatusEntry(
+            name=record.name,
+            version=record.version,
+            upgrade_checked=True,
+            in_repository=True,
+            upgradable_to=(
+                latest_version if parse_plugin_version(latest_version) > parse_plugin_version(record.version) else None
+            ),
         )
     except (ValueError, KeyError, AmbiguousPluginReferenceError):
-        # AmbiguousPluginReferenceError should not escape this command. The
-        # installed plugin's own metadata carries its host, so anchoring on
-        # that host above should normally resolve the collision; if it does
-        # not, treat the plugin as absent from the repository rather than
-        # crashing status.
-        entry["upgrade_checked"] = True
-        entry["in_repository"] = False
-        entry["upgradable_to"] = None
-
-    return entry
+        return InstalledPluginStatusEntry(
+            name=record.name,
+            version=record.version,
+            upgrade_checked=True,
+            in_repository=False,
+            upgradable_to=None,
+        )
 
 
-def _render_status_row(table: rich.table.Table, entry: dict) -> None:
-    kind = entry.get("kind")
-
-    if kind == "incompatible":
+def _render_status_row(table: rich.table.Table, entry: PluginStatusEntry) -> None:
+    if isinstance(entry, IncompatiblePluginStatusEntry):
         table.add_row(
-            f"[grey69](incompatible)[/grey69] [blue]{entry['name']}[/blue]",
-            entry["version"] or "",
-            f"[grey69]found at: $IDAPLUGINS/[/grey69]{entry['path']}",
+            f"[grey69](incompatible)[/grey69] [blue]{entry.name}[/blue]",
+            entry.version or "",
+            f"[grey69]found at: $IDAPLUGINS/[/grey69]{entry.path}",
         )
         return
 
-    if kind == "legacy":
+    if isinstance(entry, LegacyPluginStatusEntry):
         table.add_row(
-            f"[grey69](legacy)[/grey69] [blue]{entry['name']}[/blue]",
+            f"[grey69](legacy)[/grey69] [blue]{entry.name}[/blue]",
             "",
-            f"[grey69]found at: $IDAPLUGINS/[/grey69]{entry['path']}",
+            f"[grey69]found at: $IDAPLUGINS/[/grey69]{entry.path}",
         )
         return
 
-    if not entry["upgrade_checked"]:
+    if isinstance(entry, NotFoundPluginStatusEntry):
+        return
+
+    if not entry.upgrade_checked:
         status = "[dim]skipped[/dim]"
-    elif not entry["in_repository"]:
+    elif not entry.in_repository:
         status = "[yellow]not found in repository[/yellow]"
-    elif entry["upgradable_to"]:
-        status = f"upgradable to [yellow]{entry['upgradable_to']}[/yellow]"
+    elif entry.upgradable_to:
+        status = f"upgradable to [yellow]{entry.upgradable_to}[/yellow]"
     else:
         status = ""
 
-    table.add_row(entry["name"], entry["version"], status)
+    table.add_row(entry.name, entry.version, status)
+
+
+def collect_status_report(
+    plugin_repo: BasePluginRepo,
+    plugins: tuple[str, ...],
+    skip_upgrade_check: bool,
+) -> StatusReport:
+    current_platform = find_current_ida_platform()
+    current_ida_version = find_current_ida_version()
+
+    all_records = get_installed_plugin_records()
+
+    not_found_names: list[str] = []
+    if plugins:
+        installed_records = []
+        for name in plugins:
+            record = find_installed_plugin_in(all_records, name)
+            if record is None:
+                not_found_names.append(name)
+            else:
+                installed_records.append(record)
+    else:
+        installed_records = all_records
+
+    entries: list[PluginStatusEntry] = [
+        _collect_installed_entry(plugin_repo, record, current_platform, current_ida_version, skip_upgrade_check)
+        for record in installed_records
+    ]
+
+    entries.extend(NotFoundPluginStatusEntry(name=name) for name in not_found_names)
+
+    if not plugins:
+        plugin_directory = get_plugins_directory()
+        for path, metadata in get_installed_minimal_plugins():
+            plugin_path = path.parent.relative_to(plugin_directory)
+            entries.append(
+                IncompatiblePluginStatusEntry(
+                    name=metadata.plugin.name,
+                    version=metadata.plugin.version or None,
+                    path=f"{plugin_path}/",
+                )
+            )
+
+        for path in get_installed_legacy_plugins():
+            entries.append(
+                LegacyPluginStatusEntry(
+                    name=path.name,
+                    path=path.name,
+                )
+            )
+
+    return StatusReport(plugins=entries)
+
+
+def render_status_report_text(report: StatusReport, plugins_filter: tuple[str, ...]) -> None:
+    table = rich.table.Table(show_header=False, box=None)
+    table.add_column("name", style="blue")
+    table.add_column("version", style="default")
+    table.add_column("status")
+
+    not_found_names: list[str] = []
+    has_incompatible = False
+    has_legacy = False
+
+    for entry in report.plugins:
+        if isinstance(entry, NotFoundPluginStatusEntry):
+            not_found_names.append(entry.name)
+            continue
+        if isinstance(entry, IncompatiblePluginStatusEntry):
+            has_incompatible = True
+        elif isinstance(entry, LegacyPluginStatusEntry):
+            has_legacy = True
+        _render_status_row(table, entry)
+
+    if table.row_count:
+        console.print(table)
+    elif not plugins_filter:
+        console.print("[grey69]No plugins found[/grey69]")
+
+    for name in not_found_names:
+        console.print(f"[red]Not installed[/red]: {name}")
+
+    if has_incompatible:
+        console.print()
+        console.print("[yellow]Incompatible plugins[/yellow] don't work with this version of hcli.")
+        console.print(
+            f"[dim]They might be broken or outdated. Try using `{ENV.HCLI_BINARY_NAME} plugin lint /path/to/plugin`.[/dim]"
+        )
+
+    if has_legacy:
+        console.print()
+        console.print("[yellow]Legacy plugins[/yellow] are old, single-file plugins.")
+        console.print("They aren't managed by hcli. Try finding an updated version in the plugin repository.")
+
+
+def render_status_report_json(report: StatusReport) -> None:
+    print_json(report.model_dump(mode="json"))
 
 
 @click.command()
@@ -120,88 +260,13 @@ def get_plugin_status(ctx, plugins: tuple[str, ...], skip_upgrade_check: bool, j
     and exit with a non-zero status if any of them isn't installed.
     """
     plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
-    not_found_names: list[str] = []
     try:
-        current_platform = find_current_ida_platform()
-        current_ida_version = find_current_ida_version()
-
-        all_records = get_installed_plugin_records()
-        if plugins:
-            installed_records = []
-            for name in plugins:
-                record = find_installed_plugin_in(all_records, name)
-                if record is None:
-                    not_found_names.append(name)
-                else:
-                    installed_records.append(record)
-        else:
-            installed_records = all_records
-
-        entries = [
-            _collect_installed_entry(plugin_repo, record, current_platform, current_ida_version, skip_upgrade_check)
-            for record in installed_records
-        ]
-        not_found_entries = [{"name": name, "installed": False} for name in not_found_names]
-
-        incompatible_entries = []
-        legacy_entries = []
-        if not plugins:
-            plugin_directory = get_plugins_directory()
-            for path, metadata in get_installed_minimal_plugins():
-                plugin_path = path.parent.relative_to(plugin_directory)
-                incompatible_entries.append(
-                    {
-                        "name": metadata.plugin.name,
-                        "version": metadata.plugin.version or None,
-                        "installed": True,
-                        "kind": "incompatible",
-                        "path": f"{plugin_path}/",
-                    }
-                )
-
-            for path in get_installed_legacy_plugins():
-                plugin_path = path.parent.relative_to(plugin_directory)
-                legacy_entries.append(
-                    {
-                        "name": path.name,
-                        "version": None,
-                        "installed": True,
-                        "kind": "legacy",
-                        "path": f"{path.name}",
-                    }
-                )
+        report = collect_status_report(plugin_repo, plugins, skip_upgrade_check)
 
         if json_output:
-            print_json({"plugins": entries + not_found_entries + incompatible_entries + legacy_entries})
+            render_status_report_json(report)
         else:
-            table = rich.table.Table(show_header=False, box=None)
-            table.add_column("name", style="blue")
-            table.add_column("version", style="default")
-            table.add_column("status")
-
-            for entry in entries + incompatible_entries + legacy_entries:
-                _render_status_row(table, entry)
-
-            if table.row_count:
-                console.print(table)
-            elif not plugins:
-                console.print("[grey69]No plugins found[/grey69]")
-
-            for name in not_found_names:
-                console.print(f"[red]Not installed[/red]: {name}")
-
-            if incompatible_entries:
-                console.print()
-                console.print("[yellow]Incompatible plugins[/yellow] don't work with this version of hcli.")
-                console.print(
-                    f"[dim]They might be broken or outdated. Try using `{ENV.HCLI_BINARY_NAME} plugin lint /path/to/plugin`.[/dim]"
-                )
-
-            if legacy_entries:
-                # TODO: suggest plugins in the repo, by maintaining a translation list from filename to package name
-                console.print()
-                console.print("[yellow]Legacy plugins[/yellow] are old, single-file plugins.")
-                console.print("They aren't managed by hcli. Try finding an updated version in the plugin repository.")
+            render_status_report_text(report, plugins)
 
     except MissingCurrentInstallationDirectory:
         explain_missing_current_installation_directory(console)
@@ -216,5 +281,6 @@ def get_plugin_status(ctx, plugins: tuple[str, ...], skip_upgrade_check: bool, j
         console.print(f"[red]Error[/red]: {e}")
         raise click.Abort()
 
-    if not_found_names:
+    has_not_found = any(isinstance(e, NotFoundPluginStatusEntry) for e in report.plugins)
+    if has_not_found:
         ctx.exit(1)

--- a/src/hcli/commands/plugin/status.py
+++ b/src/hcli/commands/plugin/status.py
@@ -36,11 +36,11 @@ def _build_installed_entry(
     record,
     current_platform: str,
     current_ida_version: str,
-    offline: bool,
+    skip_upgrade_check: bool,
 ) -> dict:
     entry = {"name": record.name, "version": record.version, "installed": True, "kind": "installed"}
 
-    if offline:
+    if skip_upgrade_check:
         entry["upgrade_checked"] = False
         entry["in_repository"] = None
         entry["upgradable_to"] = None
@@ -92,7 +92,7 @@ def _render_status_row(table: rich.table.Table, entry: dict) -> None:
         return
 
     if not entry["upgrade_checked"]:
-        status = "[dim]skipped (offline)[/dim]"
+        status = "[dim]skipped[/dim]"
     elif not entry["in_repository"]:
         status = "[yellow]not found in repository[/yellow]"
     elif entry["upgradable_to"]:
@@ -106,14 +106,14 @@ def _render_status_row(table: rich.table.Table, entry: dict) -> None:
 @click.command()
 @click.argument("plugins", nargs=-1)
 @click.option(
-    "--offline",
+    "--skip-upgrade-check",
     is_flag=True,
     default=False,
     help="skip the per-plugin upgrade check against the plugin repository",
 )
 @click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
 @click.pass_context
-def get_plugin_status(ctx, plugins: tuple[str, ...], offline: bool, json_output: bool) -> None:
+def get_plugin_status(ctx, plugins: tuple[str, ...], skip_upgrade_check: bool, json_output: bool) -> None:
     """Show installed plugins and their upgrade status.
 
     If one or more PLUGINS are given, show status for just those plugins,
@@ -138,7 +138,7 @@ def get_plugin_status(ctx, plugins: tuple[str, ...], offline: bool, json_output:
             installed_records = all_records
 
         entries = [
-            _build_installed_entry(plugin_repo, record, current_platform, current_ida_version, offline)
+            _build_installed_entry(plugin_repo, record, current_platform, current_ida_version, skip_upgrade_check)
             for record in installed_records
         ]
         not_found_entries = [{"name": name, "installed": False} for name in not_found_names]

--- a/src/hcli/lib/console.py
+++ b/src/hcli/lib/console.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from collections.abc import Mapping
 
@@ -45,3 +46,15 @@ def _sync_console_streams():
 
 
 _sync_console_streams()
+
+
+def print_json(data) -> None:
+    """Print `data` as JSON via `console`, not `click.echo`.
+
+    `click.echo` resolves its output stream independently of `console`, so it
+    isn't covered by `_sync_console_streams` and can write to a stale stdout
+    handle under Click's pytest CliRunner integration (see #190). Markup and
+    highlighting are disabled so JSON's own brackets aren't parsed as Rich
+    markup, and soft_wrap avoids Rich reflowing long lines.
+    """
+    console.print(json.dumps(data, indent=2), markup=False, highlight=False, soft_wrap=True)

--- a/src/hcli/lib/console.py
+++ b/src/hcli/lib/console.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from collections.abc import Mapping
+from typing import Any
 
 import rich_click as click
 from rich.console import Console
@@ -48,7 +49,7 @@ def _sync_console_streams():
 _sync_console_streams()
 
 
-def print_json(data) -> None:
+def print_json(data: Any) -> None:
     """Print `data` as JSON via `console`, not `click.echo`.
 
     `click.echo` resolves its output stream independently of `console`, so it

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -1,5 +1,4 @@
 # see also hcli.lib.util.python
-import json
 import logging
 import os
 import platform
@@ -203,55 +202,6 @@ def find_current_python_executable() -> Path:
 
     logger.debug("IDA Python info: %s", info)
     return _derive_python_exe(info)
-
-
-GET_CONSOLE_SCRIPT_INFO_PY = (
-    "import json, os, sys, sysconfig; "
-    "print(json.dumps({"
-    "'prefix': sys.prefix, "
-    "'base_prefix': sys.base_prefix, "
-    "'scripts_dir': sysconfig.get_path('scripts'), "
-    "'os_name': os.name, "
-    "}))"
-)
-
-
-def probe_console_script_info(python_exe: Path, timeout: float = 10.0) -> dict:
-    """Probe `python_exe` for the facts needed to locate its pip-installed console scripts.
-
-    These are exactly the ingredients used by ``find_console_script()`` in
-    one-click-debugging and ida-codemode-mcp: sys.prefix, sys.base_prefix, the
-    sysconfig scripts directory, and os.name, all as seen by that interpreter
-    (which may differ from hcli's own interpreter, and can't be observed from
-    outside the process any other way).
-    """
-    result = subprocess.run(
-        [str(python_exe), "-c", GET_CONSOLE_SCRIPT_INFO_PY],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=timeout,
-    )
-    return json.loads(result.stdout)
-
-
-def build_console_script_search_dirs(prefix: str, base_prefix: str, scripts_dir: str | None, os_name: str) -> list[str]:
-    """Build the ordered list of directories that hold `python_exe`'s console scripts.
-
-    Mirrors the directory order used by find_console_script() in
-    one-click-debugging and ida-codemode-mcp: the sysconfig scripts dir first,
-    then prefix/bin (prefix\\Scripts on Windows) for sys.prefix and
-    sys.base_prefix, deduplicated while preserving order.
-    """
-    dirs: list[str] = []
-    if scripts_dir:
-        dirs.append(scripts_dir)
-
-    bin_dir_name = "Scripts" if os_name == "nt" else "bin"
-    for prefix_ in dict.fromkeys([prefix, base_prefix]):
-        dirs.append(os.path.join(prefix_, bin_dir_name))
-
-    return dirs
 
 
 def does_current_ida_have_pip(python_exe: Path, timeout=10.0) -> bool:

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -1,4 +1,5 @@
 # see also hcli.lib.util.python
+import json
 import logging
 import os
 import platform
@@ -202,6 +203,55 @@ def find_current_python_executable() -> Path:
 
     logger.debug("IDA Python info: %s", info)
     return _derive_python_exe(info)
+
+
+GET_CONSOLE_SCRIPT_INFO_PY = (
+    "import json, os, sys, sysconfig; "
+    "print(json.dumps({"
+    "'prefix': sys.prefix, "
+    "'base_prefix': sys.base_prefix, "
+    "'scripts_dir': sysconfig.get_path('scripts'), "
+    "'os_name': os.name, "
+    "}))"
+)
+
+
+def probe_console_script_info(python_exe: Path, timeout: float = 10.0) -> dict:
+    """Probe `python_exe` for the facts needed to locate its pip-installed console scripts.
+
+    These are exactly the ingredients used by ``find_console_script()`` in
+    one-click-debugging and ida-codemode-mcp: sys.prefix, sys.base_prefix, the
+    sysconfig scripts directory, and os.name, all as seen by that interpreter
+    (which may differ from hcli's own interpreter, and can't be observed from
+    outside the process any other way).
+    """
+    result = subprocess.run(
+        [str(python_exe), "-c", GET_CONSOLE_SCRIPT_INFO_PY],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=timeout,
+    )
+    return json.loads(result.stdout)
+
+
+def build_console_script_search_dirs(prefix: str, base_prefix: str, scripts_dir: str | None, os_name: str) -> list[str]:
+    """Build the ordered list of directories that hold `python_exe`'s console scripts.
+
+    Mirrors the directory order used by find_console_script() in
+    one-click-debugging and ida-codemode-mcp: the sysconfig scripts dir first,
+    then prefix/bin (prefix\\Scripts on Windows) for sys.prefix and
+    sys.base_prefix, deduplicated while preserving order.
+    """
+    dirs: list[str] = []
+    if scripts_dir:
+        dirs.append(scripts_dir)
+
+    bin_dir_name = "Scripts" if os_name == "nt" else "bin"
+    for prefix_ in dict.fromkeys([prefix, base_prefix]):
+        dirs.append(os.path.join(prefix_, bin_dir_name))
+
+    return dirs
 
 
 def does_current_ida_have_pip(python_exe: Path, timeout=10.0) -> bool:

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -527,6 +527,105 @@ def test_status_offline_skips_upgrade_check(virtual_ida_environment):
     assert "skipped (offline)" in offline_result.output
 
 
+def test_status_json_installed_plugin(virtual_ida_environment):
+    """`status <name> --json` reports upgrade info as structured JSON."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.output)
+    assert payload["plugins"] == [
+        {
+            "name": "plugin1",
+            "version": "1.0.0",
+            "installed": True,
+            "kind": "installed",
+            "upgrade_checked": True,
+            "in_repository": True,
+            "upgradable_to": "6.0.0",
+        }
+    ]
+
+
+def test_status_json_not_installed_plugin(virtual_ida_environment):
+    """`status <name> --json` reports a missing plugin and exits non-zero."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "does-not-exist", "--json"])
+    assert result.exit_code != 0
+
+    payload = json.loads(result.output)
+    assert payload["plugins"] == [{"name": "does-not-exist", "installed": False}]
+
+
+def test_status_json_offline(virtual_ida_environment):
+    """`status <name> --json --offline` marks the upgrade check as skipped."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--offline", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.output)
+    assert payload["plugins"] == [
+        {
+            "name": "plugin1",
+            "version": "1.0.0",
+            "installed": True,
+            "kind": "installed",
+            "upgrade_checked": False,
+            "in_repository": None,
+            "upgradable_to": None,
+        }
+    ]
+
+
+def test_search_json_keyword_query(virtual_ida_environment):
+    """`search --json` (no query) reports the full plugin listing as JSON."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "search", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.output)
+    assert payload["query"] is None
+    names = {entry["name"] for entry in payload["results"]}
+    assert "plugin1" in names
+
+
+def test_search_json_exact_name_query(virtual_ida_environment):
+    """`search <name> --json` reports plugin metadata and versions as JSON."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "search", "plugin1", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.output)
+    assert payload["plugin"]["name"] == "plugin1"
+    assert payload["installed_version"] is None
+    assert any(v["version"] == "4.0.0" for v in payload["versions"])
+
+
+def test_search_json_ambiguous_reference(tmp_path):
+    """`search <name> --json` reports an ambiguity error as JSON and exits non-zero."""
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "search", "shared", "--json"])
+    assert result.exit_code != 0
+
+    payload = json.loads(result.output)
+    assert payload["error"] == "ambiguous plugin reference"
+    assert payload["name"] == "shared"
+    assert len(payload["candidates"]) == 2
+
+
 def test_status_multiple_plugins_all_installed(virtual_ida_environment):
     """`status <name1> <name2>` shows both plugins and exits 0 when both are installed."""
     runner = CliRunner(mix_stderr=False)

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -508,6 +508,25 @@ def test_status_named_plugin_not_installed(virtual_ida_environment):
     assert "does-not-exist" in result.output
 
 
+def test_status_offline_skips_upgrade_check(virtual_ida_environment):
+    """`status --offline` reports installed plugins without querying the repo for upgrades."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    # sanity check: online status detects the newer version available in PLUGINS_DIR
+    online_result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1"])
+    assert online_result.exit_code == 0, online_result.output
+    assert "upgradable to" in online_result.output
+
+    offline_result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--offline"])
+    assert offline_result.exit_code == 0, offline_result.output
+    assert "plugin1" in offline_result.output
+    assert "upgradable to" not in offline_result.output
+    assert "skipped (offline)" in offline_result.output
+
+
 def test_status_multiple_plugins_all_installed(virtual_ida_environment):
     """`status <name1> <name2>` shows both plugins and exits 0 when both are installed."""
     runner = CliRunner(mix_stderr=False)

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -487,6 +487,56 @@ def test_status_does_not_crash_on_colliding_name(tmp_path, virtual_ida_environme
     assert "3.0.0" in result.output
 
 
+def test_status_named_plugin_installed(virtual_ida_environment):
+    """`status <name>` shows just that plugin and exits 0 when it's installed."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1"])
+    assert result.exit_code == 0, result.output
+    assert "plugin1" in result.output
+
+
+def test_status_named_plugin_not_installed(virtual_ida_environment):
+    """`status <name>` exits non-zero and reports absence when not installed."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "does-not-exist"])
+    assert result.exit_code != 0
+    assert "does-not-exist" in result.output
+
+
+def test_status_multiple_plugins_all_installed(virtual_ida_environment):
+    """`status <name1> <name2>` shows both plugins and exits 0 when both are installed."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "zydisinfo==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "zydisinfo"])
+    assert result.exit_code == 0, result.output
+    assert "plugin1" in result.output
+    assert "zydisinfo" in result.output
+
+
+def test_status_multiple_plugins_partially_installed(virtual_ida_environment):
+    """`status <name1> <name2>` exits non-zero and reports only the missing one when mixed."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "does-not-exist"])
+    assert result.exit_code != 0
+    assert "plugin1" in result.output
+    assert "Not installed" in result.output
+    assert "does-not-exist" in result.output
+
+
 def test_upgrade_not_installed_fails(tmp_path, virtual_ida_environment):
     """Upgrade must fail cleanly when the plugin is not installed."""
     repo_dir = _build_colliding_repo_dir_with_v2(tmp_path)

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -508,23 +508,23 @@ def test_status_named_plugin_not_installed(virtual_ida_environment):
     assert "does-not-exist" in result.output
 
 
-def test_status_offline_skips_upgrade_check(virtual_ida_environment):
-    """`status --offline` reports installed plugins without querying the repo for upgrades."""
+def test_status_skip_upgrade_check(virtual_ida_environment):
+    """`status --skip-upgrade-check` reports installed plugins without querying the repo for upgrades."""
     runner = CliRunner(mix_stderr=False)
 
     result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
     assert result.exit_code == 0, result.output
 
-    # sanity check: online status detects the newer version available in PLUGINS_DIR
+    # sanity check: without the flag, status detects the newer version available in PLUGINS_DIR
     online_result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1"])
     assert online_result.exit_code == 0, online_result.output
     assert "upgradable to" in online_result.output
 
-    offline_result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--offline"])
-    assert offline_result.exit_code == 0, offline_result.output
-    assert "plugin1" in offline_result.output
-    assert "upgradable to" not in offline_result.output
-    assert "skipped (offline)" in offline_result.output
+    skip_result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--skip-upgrade-check"])
+    assert skip_result.exit_code == 0, skip_result.output
+    assert "plugin1" in skip_result.output
+    assert "upgradable to" not in skip_result.output
+    assert "skipped" in skip_result.output
 
 
 def test_status_json_installed_plugin(virtual_ida_environment):
@@ -562,14 +562,16 @@ def test_status_json_not_installed_plugin(virtual_ida_environment):
     assert payload["plugins"] == [{"name": "does-not-exist", "installed": False}]
 
 
-def test_status_json_offline(virtual_ida_environment):
-    """`status <name> --json --offline` marks the upgrade check as skipped."""
+def test_status_json_skip_upgrade_check(virtual_ida_environment):
+    """`status <name> --json --skip-upgrade-check` marks the upgrade check as skipped."""
     runner = CliRunner(mix_stderr=False)
 
     result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
     assert result.exit_code == 0, result.output
 
-    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--offline", "--json"])
+    result = runner.invoke(
+        plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--skip-upgrade-check", "--json"]
+    )
     assert result.exit_code == 0, result.output
 
     payload = json.loads(result.output)


### PR DESCRIPTION
## Summary

Add `--json` output and headless-friendly options to the plugin status, search, and explain-environment commands so they can be consumed by scripts, CI pipelines, and the IDA plugin (which runs without a terminal).

### Changes

**`plugin status`**
- Accept optional `PLUGINS` positional args to check specific plugins by name (exit non-zero if any are missing)
- Add `--skip-upgrade-check` to skip per-plugin repository queries (was `--offline`)
- Add `--json` for machine-readable output

**`plugin search`**
- Add `--json` for machine-readable output (keyword, exact-name, version-spec, and ambiguity-error results)
- Extract `resolve_query_reference()` to consolidate query-routing logic

**`plugin explain-environment`**
- Add `--json` for machine-readable output
- Split into collect/render architecture: `collect_*` functions produce Pydantic models, `render_*_text` functions handle Rich formatting
- Mark as experimental

**`plugin list`** (hidden alias for `status`)
- Forward new `--json`, `--skip-upgrade-check`, and `PLUGINS` args

**Infrastructure**
- Add `print_json()` helper in `hcli.lib.console` that routes through Rich's console (not `click.echo`) to respect `_sync_console_streams` under pytest's CliRunner
- Migrate search.py TypedDicts to Pydantic BaseModel for consistency

## Test plan

- [x] `test_status_named_plugin_installed` — single named plugin exits 0
- [x] `test_status_named_plugin_not_installed` — missing plugin exits non-zero
- [x] `test_status_skip_upgrade_check` — skips repo query, shows "skipped"
- [x] `test_status_json_installed_plugin` — JSON output with upgrade info
- [x] `test_status_json_not_installed_plugin` — JSON reports missing plugin
- [x] `test_status_json_skip_upgrade_check` — JSON marks upgrade_checked=false
- [x] `test_status_multiple_plugins_all_installed` — multi-plugin query
- [x] `test_status_multiple_plugins_partially_installed` — mixed installed/missing
- [x] `test_search_json_keyword_query` — full listing as JSON
- [x] `test_search_json_exact_name_query` — plugin metadata + versions as JSON
- [x] `test_search_json_ambiguous_reference` — ambiguity error as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)