### PR TITLE
feat(config): namespace stored auth keys via HCLI_CONFIG_NAMESPACE

### DIFF
--- a/src/hcli/commands/login.py
+++ b/src/hcli/commands/login.py
@@ -4,12 +4,12 @@ import questionary
 import rich_click as click
 
 from hcli.commands.common import safe_ask_async
-from hcli.env import ENV
 from hcli.lib.auth import get_auth_service
 from hcli.lib.commands import async_command
 from hcli.lib.config import config_store
 from hcli.lib.console import console
 from hcli.lib.constants import cli
+from hcli.lib.constants.auth import CONFIG_LOGIN_EMAIL
 
 
 @click.command()
@@ -48,7 +48,7 @@ async def login(force: bool, name: str | None) -> None:
             return
 
     # Get the last used email for suggestions
-    current_email = config_store.get_string(f"{ENV.HCLI_BINARY_NAME}.login.email", "")
+    current_email = config_store.get_string(CONFIG_LOGIN_EMAIL, "")
 
     # Choose authentication method
     choices = ["Google OAuth", "Email (OTP)"]
@@ -75,7 +75,7 @@ async def login(force: bool, name: str | None) -> None:
 
             source = auth_service.verify_otp(email, otp, name=name)
             if source:
-                config_store.set_string(f"{ENV.HCLI_BINARY_NAME}.login.email", email)
+                config_store.set_string(CONFIG_LOGIN_EMAIL, email)
                 console.print("[green]Login successful![/green]")
             else:
                 console.print("[red]Login failed. Invalid OTP.[/red]")

--- a/src/hcli/env.py
+++ b/src/hcli/env.py
@@ -49,6 +49,10 @@ class ENV:
 
     HCLI_VERSION: str = os.getenv("HCLI_VERSION", __version__)
     HCLI_BINARY_NAME: str = os.getenv("HCLI_BINARY_NAME", "hcli")
+    # Namespace used for the stored auth keys (credentials, login.email). Defaults
+    # to the binary name so each binary keeps its own login, but can be set
+    # explicitly to let sibling binaries share a single credential store.
+    HCLI_CONFIG_NAMESPACE: str = os.getenv("HCLI_CONFIG_NAMESPACE", HCLI_BINARY_NAME)
     HCLI_VERSION_EXTRA: str = os.getenv("HCLI_VERSION_EXTRA", "")
     HCLI_MODE: str = os.getenv("HCLI_MODE", "user")
     QUIET: bool = False

--- a/src/hcli/lib/config/__init__.py
+++ b/src/hcli/lib/config/__init__.py
@@ -42,14 +42,14 @@ class ConfigStore:
         version_key = f"{binary}.version"
         current_version = self.get_string(version_key, "0.0.0")
         if current_version != ENV.HCLI_VERSION:
-            self._migrate_legacy_keys(binary)
+            self._migrate_legacy_keys(ENV.HCLI_CONFIG_NAMESPACE)
             self._data[version_key] = ENV.HCLI_VERSION
             self._save_config()
 
-    def _migrate_legacy_keys(self, binary: str):
-        """Migrate unscoped config keys to per-binary namespaced keys."""
+    def _migrate_legacy_keys(self, namespace: str):
+        """Migrate unscoped config keys to namespaced auth keys."""
         for old_key, suffix in [("credentials", "credentials"), ("login.email", "login.email")]:
-            new_key = f"{binary}.{suffix}"
+            new_key = f"{namespace}.{suffix}"
             if old_key in self._data and new_key not in self._data:
                 self._data[new_key] = self._data[old_key]
                 del self._data[old_key]

--- a/src/hcli/lib/constants/auth.py
+++ b/src/hcli/lib/constants/auth.py
@@ -96,4 +96,5 @@ class CredentialsConfig(BaseModel):
 
 
 # Configuration keys
-CONFIG_CREDENTIALS = f"{ENV.HCLI_BINARY_NAME}.credentials"
+CONFIG_CREDENTIALS = f"{ENV.HCLI_CONFIG_NAMESPACE}.credentials"
+CONFIG_LOGIN_EMAIL = f"{ENV.HCLI_CONFIG_NAMESPACE}.login.email"

--- a/tests/lib/test_config_namespace.py
+++ b/tests/lib/test_config_namespace.py
@@ -1,0 +1,63 @@
+"""HCLI_CONFIG_NAMESPACE controls the namespace of the stored auth keys.
+
+It defaults to HCLI_BINARY_NAME so each binary keeps its own login, but can be set
+explicitly so sibling binaries share a single credential store while still
+differing on their binary identity.
+"""
+
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+import hcli.env
+import hcli.lib.constants.auth as auth_const
+
+
+@pytest.fixture(autouse=True)
+def _restore_reloaded_modules():
+    # Both modules read the environment at import time, so tests reload them under
+    # patched env. Reload once more afterwards to restore the pristine state.
+    yield
+    importlib.reload(hcli.env)
+    importlib.reload(auth_const)
+
+
+def _reload_with(binary=None, namespace=None):
+    """Reload env + auth constants with a clean, explicit set of env vars."""
+    with patch.dict(os.environ, {}, clear=False):
+        for key in ("HCLI_BINARY_NAME", "HCLI_CONFIG_NAMESPACE"):
+            os.environ.pop(key, None)
+        if binary is not None:
+            os.environ["HCLI_BINARY_NAME"] = binary
+        if namespace is not None:
+            os.environ["HCLI_CONFIG_NAMESPACE"] = namespace
+        importlib.reload(hcli.env)
+        importlib.reload(auth_const)
+        return hcli.env.ENV, auth_const
+
+
+def test_namespace_defaults_to_default_binary_name():
+    env, const = _reload_with()
+    assert env.HCLI_CONFIG_NAMESPACE == "hcli"
+    assert const.CONFIG_CREDENTIALS == "hcli.credentials"
+    assert const.CONFIG_LOGIN_EMAIL == "hcli.login.email"
+
+
+def test_namespace_follows_custom_binary_name_by_default():
+    env, const = _reload_with(binary="other")
+    assert env.HCLI_BINARY_NAME == "other"
+    assert env.HCLI_CONFIG_NAMESPACE == "other"
+    assert const.CONFIG_CREDENTIALS == "other.credentials"
+    assert const.CONFIG_LOGIN_EMAIL == "other.login.email"
+
+
+def test_explicit_namespace_decouples_auth_keys_from_binary_name():
+    env, const = _reload_with(binary="other", namespace="hcli")
+    # Binary identity stays distinct...
+    assert env.HCLI_BINARY_NAME == "other"
+    # ...while the auth keys resolve to the shared namespace.
+    assert env.HCLI_CONFIG_NAMESPACE == "hcli"
+    assert const.CONFIG_CREDENTIALS == "hcli.credentials"
+    assert const.CONFIG_LOGIN_EMAIL == "hcli.login.email"


### PR DESCRIPTION
## Problem

The stored credential keys in `config.json` — `<name>.credentials` and `<name>.login.email` — are namespaced by `HCLI_BINARY_NAME`. That same name also drives the binary's *identity*: help text, update-cache directory, and the executable name shown to users.

This couples two unrelated concerns. A companion binary built on top of hcli (its own name, release URL, version string, etc.) cannot both keep a distinct identity **and** reuse the existing hcli login. Setting a different `HCLI_BINARY_NAME` moves its credentials into a separate namespace inside the *same* `config.json`, so the user is forced to authenticate a second time even though the account and auth backend are identical.

## Solution

Introduce a dedicated `HCLI_CONFIG_NAMESPACE` environment variable that controls **only** the namespace of the stored auth keys.

- It defaults to `HCLI_BINARY_NAME`, so the standard binary's behaviour is completely unchanged.
- It can be set explicitly so a companion binary shares a single credential store while still differing on every other binary-name-derived value (help text, cache dir, executable name, version).

## Changes

- `env.py`: new `HCLI_CONFIG_NAMESPACE`, defaulting to `HCLI_BINARY_NAME`.
- `constants/auth.py`: `CONFIG_CREDENTIALS` now derives from the namespace; adds a `CONFIG_LOGIN_EMAIL` constant (previously the key was inlined in `login.py`).
- `commands/login.py`: uses the new `CONFIG_LOGIN_EMAIL` constant.
- `config/__init__.py`: legacy-key migration targets the namespace. Version tracking stays per-binary.
- Adds unit tests covering the default, the binary-name fallback, and the decoupled-override case.

## Compatibility

Default behaviour is identical: when `HCLI_CONFIG_NAMESPACE` is unset it equals `HCLI_BINARY_NAME`, producing the exact same keys as before.

_AI-assisted change._