### PR TITLE
fix: detect old pip missing --dry-run and suggest upgrade

### DIFF
--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -305,7 +305,14 @@ def verify_pip_can_install_packages(
         logger.debug("can't install packages")
         logger.debug(stdout.decode("utf-8", errors="replace"))
         logger.debug(stderr.decode("utf-8", errors="replace"))
-        raise CantInstallPackagesError(_format_pip_error(stdout, stderr))
+
+        error_text = _format_pip_error(stdout, stderr)
+        if "no such option: --dry-run" in error_text:
+            raise CantInstallPackagesError(
+                f"pip does not support --dry-run (requires pip 22.2 or later). "
+                f"Please upgrade pip: {python_exe} -m pip install --upgrade pip"
+            )
+        raise CantInstallPackagesError(error_text)
 
 
 def pip_install_packages(


### PR DESCRIPTION
## Summary
- When a user's pip is too old to support `--dry-run` (added in pip 22.2), the error was an unhelpful wall of pip usage text
- Now detects `"no such option: --dry-run"` in the pip output and raises a clear message: tells the user the minimum pip version and the exact command to upgrade

Closes #271

## Test plan
- [x] `just lint` passes
- [x] Existing tests pass (pre-existing download integration failure unrelated)
- [ ] Manual test with a Python 3.9 environment using old pip (the scenario from the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)