### PR TITLE
feat: warn when IDA Python is 3.9 or older

### DIFF
--- a/docs/development/plugin-packaging-experience-reports.md
+++ b/docs/development/plugin-packaging-experience-reports.md
@@ -21,20 +21,24 @@ Notably it supports IDA 6.6+ - that will be hard to reproduce with HCLI.
 These are actually moderately complex:
 
 ```py
-      install_requires=[
-          'ipykernel>=4.6',
-          'ipykernel>=5.1.4; python_version >= "3.8" and platform_system=="Windows"',
-          'qtconsole>=4.3',
-          'qasync; python_version >= "3"',
-          'jupyter-client<6.1.13',
-          'nbformat',
-      ],
-      extras_require={
-          "notebook": [
-              "notebook<7",
-              "jupyter-kernel-proxy",
-          ]
-      },
+install_requires = (
+    [
+        "ipykernel>=4.6",
+        'ipykernel>=5.1.4; python_version >= "3.8" and platform_system=="Windows"',
+        "qtconsole>=4.3",
+        'qasync; python_version >= "3"',
+        "jupyter-client<6.1.13",
+        "nbformat",
+    ],
+)
+extras_require = (
+    {
+        "notebook": [
+            "notebook<7",
+            "jupyter-kernel-proxy",
+        ]
+    },
+)
 ```
 
 However, all these dependencies are packaged into the `ipyida` Python package from PyPI.

--- a/docs/how-to/test-plugin-before-publishing.md
+++ b/docs/how-to/test-plugin-before-publishing.md
@@ -252,6 +252,7 @@ Launch IDA Pro and verify:
    ```python
    # In IDA Python console
    import ida_loader
+
    ida_loader.load_and_run_plugin("my-awesome-plugin", 0)
    ```
 

--- a/src/hcli/commands/plugin/explain_environment.py
+++ b/src/hcli/commands/plugin/explain_environment.py
@@ -274,3 +274,16 @@ def explain_environment() -> None:
         )
     if not user_venv and not is_uv_cache and not ida_venv:
         console.print("[dim]To change IDA's Python, use idapyswitch to point at a different interpreter.[/dim]")
+
+    try:
+        final_version = detect_current_python_version()
+        major, minor = (int(x) for x in final_version.split("."))
+        if (major, minor) <= (3, 9):
+            console.print()
+            console.print(
+                f"[bold yellow]Warning:[/bold yellow] Python {final_version} has reached end-of-life. "
+                "Many IDA plugins may not support it. "
+                "Consider upgrading to a newer Python and using idapyswitch to point IDA at it.",
+            )
+    except Exception:
+        pass

--- a/src/hcli/commands/plugin/explain_environment.py
+++ b/src/hcli/commands/plugin/explain_environment.py
@@ -277,7 +277,8 @@ def explain_environment() -> None:
 
     try:
         final_version = detect_current_python_version()
-        major, minor = (int(x) for x in final_version.split("."))
+        parts = final_version.split(".")
+        major, minor = int(parts[0]), int(parts[1])
         if (major, minor) <= (3, 9):
             console.print()
             console.print(


### PR DESCRIPTION
## Summary
- `explain-environment` now prints a warning when the detected IDA Python version is 3.9 or below, advising the user to upgrade and use `idapyswitch` to point IDA at a newer interpreter.

Closes #272

## Test plan
- [ ] Run `hcli plugin explain-environment` with Python 3.9 — verify warning appears
- [ ] Run with Python 3.12+ — verify no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)