### PR TITLE
Log Python-relevant environment variables passed to idat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Remove idat invocations for version and platform detection
 - Validate all plugin paths before extracting any
 
+### Changed
+- Log the Python-relevant environment variables (`VIRTUAL_ENV`, `PYTHONHOME`, `PATH`, ...) passed to `idat` at debug level
+
 ## [0.15.13] - 2026-01-27
 
 ### Fixed

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -994,11 +994,7 @@ def _prepare_headless_ida_user_dir(source_dir: Path, target_dir: Path) -> None:
 
 
 def _log_idat_env(env: dict[str, str] | None) -> None:
-    """Log the environment variables that affect idat's Python environment."""
-    # Variables that steer how IDA locates its user directory and reconstructs
-    # its Python environment. Only this curated set is logged: the environment
-    # passed to idat is a copy of our own, which may hold credentials and other
-    # unrelated secrets.
+    """Log the curated set of env vars that affect idat's Python environment."""
     keys = (
         "IDAUSR",
         "IDADIR",
@@ -1018,16 +1014,11 @@ def _log_idat_env(env: dict[str, str] | None) -> None:
         "PATH",
     )
 
-    if env is None:
-        # subprocess.run(env=None) means the child inherits our environment.
-        effective = dict(os.environ)
-        logger.debug("idat env: inherited from the current process")
-    else:
-        effective = env
+    effective = env if env is not None else os.environ
 
     for key in keys:
         value = effective.get(key)
-        logger.debug("idat env: %s=%s", key, value if value is not None else "<not set>")
+        logger.debug(f"idat env: {key}={value if value is not None else '<not set>'}")
 
 
 def _run_ida_batch_script(idat_path: Path, src: str, env: dict[str, str] | None = None) -> dict:
@@ -1059,8 +1050,7 @@ def _run_ida_batch_script(idat_path: Path, src: str, env: dict[str, str] | None 
             f"-S{script_path.absolute()!s}",
         ]
 
-        # log before invoking, so the environment is recorded even when idat
-        # hangs or crashes hard enough that we never get to the lines below.
+        # Log before invoking so the environment is captured even if idat hangs.
         logger.debug(f"idat command: {' '.join(cmd)}")
         _log_idat_env(env)
 

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -993,34 +993,31 @@ def _prepare_headless_ida_user_dir(source_dir: Path, target_dir: Path) -> None:
             shutil.copy2(license_file, target_dir / license_file.name)
 
 
-# Environment variables that steer how IDA locates its user directory and
-# reconstructs its Python environment. Logged before every idat invocation so
-# reports about Python detection show the environment idat actually saw.
-#
-# Only this curated set is logged: the environment passed to idat is a copy of
-# our own, which may hold credentials and other unrelated secrets.
-IDAT_ENV_VARS_OF_INTEREST = (
-    "IDAUSR",
-    "IDADIR",
-    "IDA_IS_INTERACTIVE",
-    "IDAPYTHON_VENV_EXECUTABLE",
-    "VIRTUAL_ENV",
-    "CONDA_PREFIX",
-    "PYENV_VERSION",
-    "PYTHONHOME",
-    "PYTHONPATH",
-    "PYTHONEXECUTABLE",
-    "PYTHONNOUSERSITE",
-    "PYTHONUSERBASE",
-    "PYTHONSTARTUP",
-    "PYTHONUTF8",
-    "PYTHONIOENCODING",
-    "PATH",
-)
-
-
 def _log_idat_env(env: dict[str, str] | None) -> None:
     """Log the environment variables that affect idat's Python environment."""
+    # Variables that steer how IDA locates its user directory and reconstructs
+    # its Python environment. Only this curated set is logged: the environment
+    # passed to idat is a copy of our own, which may hold credentials and other
+    # unrelated secrets.
+    keys = (
+        "IDAUSR",
+        "IDADIR",
+        "IDA_IS_INTERACTIVE",
+        "IDAPYTHON_VENV_EXECUTABLE",
+        "VIRTUAL_ENV",
+        "CONDA_PREFIX",
+        "PYENV_VERSION",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "PYTHONEXECUTABLE",
+        "PYTHONNOUSERSITE",
+        "PYTHONUSERBASE",
+        "PYTHONSTARTUP",
+        "PYTHONUTF8",
+        "PYTHONIOENCODING",
+        "PATH",
+    )
+
     if env is None:
         # subprocess.run(env=None) means the child inherits our environment.
         effective = dict(os.environ)
@@ -1028,7 +1025,7 @@ def _log_idat_env(env: dict[str, str] | None) -> None:
     else:
         effective = env
 
-    for key in IDAT_ENV_VARS_OF_INTEREST:
+    for key in keys:
         value = effective.get(key)
         logger.debug("idat env: %s=%s", key, value if value is not None else "<not set>")
 

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -1104,13 +1104,10 @@ def _clean_env_for_idat() -> dict[str, str]:
     #  with its own ephemeral virtual environment.
     # So, we try to resolve the *real* virtual environment, if possible.
     user_venv = resolve_user_virtual_env()
-    logger.debug("resolved user virtualenv for idat: %s", user_venv if user_venv is not None else "<none>")
 
     env = os.environ.copy()
     for key in ("VIRTUAL_ENV", "PYTHONHOME", "PYTHONPATH", "PATH"):
-        removed = env.pop(key, None)
-        if removed is not None:
-            logger.debug("stripping %s from idat environment (was: %s)", key, removed)
+        env.pop(key, None)
 
     if user_venv is not None:
         # we pass this along so idat can recognize the current virtualenv

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -993,6 +993,46 @@ def _prepare_headless_ida_user_dir(source_dir: Path, target_dir: Path) -> None:
             shutil.copy2(license_file, target_dir / license_file.name)
 
 
+# Environment variables that steer how IDA locates its user directory and
+# reconstructs its Python environment. Logged before every idat invocation so
+# reports about Python detection show the environment idat actually saw.
+#
+# Only this curated set is logged: the environment passed to idat is a copy of
+# our own, which may hold credentials and other unrelated secrets.
+IDAT_ENV_VARS_OF_INTEREST = (
+    "IDAUSR",
+    "IDADIR",
+    "IDA_IS_INTERACTIVE",
+    "IDAPYTHON_VENV_EXECUTABLE",
+    "VIRTUAL_ENV",
+    "CONDA_PREFIX",
+    "PYENV_VERSION",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "PYTHONEXECUTABLE",
+    "PYTHONNOUSERSITE",
+    "PYTHONUSERBASE",
+    "PYTHONSTARTUP",
+    "PYTHONUTF8",
+    "PYTHONIOENCODING",
+    "PATH",
+)
+
+
+def _log_idat_env(env: dict[str, str] | None) -> None:
+    """Log the environment variables that affect idat's Python environment."""
+    if env is None:
+        # subprocess.run(env=None) means the child inherits our environment.
+        effective = dict(os.environ)
+        logger.debug("idat env: inherited from the current process")
+    else:
+        effective = env
+
+    for key in IDAT_ENV_VARS_OF_INTEREST:
+        value = effective.get(key)
+        logger.debug("idat env: %s=%s", key, value if value is not None else "<not set>")
+
+
 def _run_ida_batch_script(idat_path: Path, src: str, env: dict[str, str] | None = None) -> dict:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
@@ -1022,6 +1062,11 @@ def _run_ida_batch_script(idat_path: Path, src: str, env: dict[str, str] | None 
             f"-S{script_path.absolute()!s}",
         ]
 
+        # log before invoking, so the environment is recorded even when idat
+        # hangs or crashes hard enough that we never get to the lines below.
+        logger.debug(f"idat command: {' '.join(cmd)}")
+        _log_idat_env(env)
+
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -1031,9 +1076,6 @@ def _run_ida_batch_script(idat_path: Path, src: str, env: dict[str, str] | None 
             check=False,
             env=env,
         )
-        logger.debug(f"idat command: {' '.join(cmd)}")
-        if env and env.get("IDAUSR"):
-            logger.debug(f"idat IDAUSR: {env['IDAUSR']}")
         logger.debug(f"idat exit code: {result.returncode}")
         if result.stdout:
             logger.debug(f"idat stdout: {result.stdout}")
@@ -1062,10 +1104,13 @@ def _clean_env_for_idat() -> dict[str, str]:
     #  with its own ephemeral virtual environment.
     # So, we try to resolve the *real* virtual environment, if possible.
     user_venv = resolve_user_virtual_env()
+    logger.debug("resolved user virtualenv for idat: %s", user_venv if user_venv is not None else "<none>")
 
     env = os.environ.copy()
     for key in ("VIRTUAL_ENV", "PYTHONHOME", "PYTHONPATH", "PATH"):
-        env.pop(key, None)
+        removed = env.pop(key, None)
+        if removed is not None:
+            logger.debug("stripping %s from idat environment (was: %s)", key, removed)
 
     if user_venv is not None:
         # we pass this along so idat can recognize the current virtualenv

--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -11,7 +11,6 @@ import pytest
 from hcli.lib.ida import (
     IdaProduct,
     _is_ida_install_dir_name,
-    _log_idat_env,
     _prepare_headless_ida_user_dir,
     accept_eula,
     detect_binary_arch,
@@ -451,40 +450,3 @@ def test_prepare_headless_ida_user_dir_copies_only_required_files(tmp_path):
     assert not (target_dir / "ida-config.json").exists()
     assert not (target_dir / "plugins").exists()
     assert not (target_dir / "mcp").exists()
-
-
-def test_log_idat_env_logs_set_and_unset_vars(caplog):
-    env = {
-        "IDAUSR": "/home/user/.idapro",
-        "VIRTUAL_ENV": "/home/user/.venv",
-        "HCLI_API_KEY": "s3cret",
-    }
-
-    with caplog.at_level("DEBUG", logger="hcli.lib.ida"):
-        _log_idat_env(env)
-
-    messages = [record.getMessage() for record in caplog.records]
-
-    assert "idat env: IDAUSR=/home/user/.idapro" in messages
-    assert "idat env: VIRTUAL_ENV=/home/user/.venv" in messages
-    # variables that were stripped or never set are reported too: their absence
-    # is what usually explains a broken Python environment.
-    assert "idat env: PYTHONHOME=<not set>" in messages
-    assert "idat env: PATH=<not set>" in messages
-
-    # nothing outside the curated set is logged: the env handed to idat is a copy
-    # of ours and may hold credentials.
-    assert not any("HCLI_API_KEY" in message for message in messages)
-    assert not any("s3cret" in message for message in messages)
-
-
-def test_log_idat_env_reports_inherited_environment(caplog, monkeypatch):
-    monkeypatch.setenv("IDAUSR", "/inherited/idausr")
-
-    with caplog.at_level("DEBUG", logger="hcli.lib.ida"):
-        _log_idat_env(None)
-
-    messages = [record.getMessage() for record in caplog.records]
-
-    assert "idat env: inherited from the current process" in messages
-    assert "idat env: IDAUSR=/inherited/idausr" in messages

--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -11,7 +11,6 @@ import pytest
 from hcli.lib.ida import (
     IDAT_ENV_VARS_OF_INTEREST,
     IdaProduct,
-    _clean_env_for_idat,
     _is_ida_install_dir_name,
     _log_idat_env,
     _prepare_headless_ida_user_dir,
@@ -490,22 +489,3 @@ def test_log_idat_env_reports_inherited_environment(caplog, monkeypatch):
 
     assert "idat env: inherited from the current process" in messages
     assert "idat env: IDAUSR=/inherited/idausr" in messages
-
-
-def test_clean_env_for_idat_logs_stripped_vars(caplog, monkeypatch):
-    monkeypatch.setenv("PYTHONHOME", "/some/pythonhome")
-    monkeypatch.setenv("PATH", "/usr/bin")
-    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-    monkeypatch.delenv("PYTHONPATH", raising=False)
-
-    with caplog.at_level("DEBUG", logger="hcli.lib.ida"):
-        env = _clean_env_for_idat()
-
-    messages = [record.getMessage() for record in caplog.records]
-
-    assert "PYTHONHOME" not in env
-    assert "PATH" not in env
-    assert "stripping PYTHONHOME from idat environment (was: /some/pythonhome)" in messages
-    assert "stripping PATH from idat environment (was: /usr/bin)" in messages
-    assert not any(message.startswith("stripping PYTHONPATH") for message in messages)
-    assert any(message.startswith("resolved user virtualenv for idat: ") for message in messages)

--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import pytest
 
 from hcli.lib.ida import (
-    IDAT_ENV_VARS_OF_INTEREST,
     IdaProduct,
     _is_ida_install_dir_name,
     _log_idat_env,
@@ -473,9 +472,9 @@ def test_log_idat_env_logs_set_and_unset_vars(caplog):
     assert "idat env: PYTHONHOME=<not set>" in messages
     assert "idat env: PATH=<not set>" in messages
 
-    # every variable of interest gets exactly one line ...
-    assert len(messages) == len(IDAT_ENV_VARS_OF_INTEREST)
-    # ... and nothing outside that curated set is logged.
+    # nothing outside the curated set is logged: the env handed to idat is a copy
+    # of ours and may hold credentials.
+    assert not any("HCLI_API_KEY" in message for message in messages)
     assert not any("s3cret" in message for message in messages)
 
 

--- a/tests/lib/test_ida.py
+++ b/tests/lib/test_ida.py
@@ -9,8 +9,11 @@ from pathlib import Path
 import pytest
 
 from hcli.lib.ida import (
+    IDAT_ENV_VARS_OF_INTEREST,
     IdaProduct,
+    _clean_env_for_idat,
     _is_ida_install_dir_name,
+    _log_idat_env,
     _prepare_headless_ida_user_dir,
     accept_eula,
     detect_binary_arch,
@@ -450,3 +453,59 @@ def test_prepare_headless_ida_user_dir_copies_only_required_files(tmp_path):
     assert not (target_dir / "ida-config.json").exists()
     assert not (target_dir / "plugins").exists()
     assert not (target_dir / "mcp").exists()
+
+
+def test_log_idat_env_logs_set_and_unset_vars(caplog):
+    env = {
+        "IDAUSR": "/home/user/.idapro",
+        "VIRTUAL_ENV": "/home/user/.venv",
+        "HCLI_API_KEY": "s3cret",
+    }
+
+    with caplog.at_level("DEBUG", logger="hcli.lib.ida"):
+        _log_idat_env(env)
+
+    messages = [record.getMessage() for record in caplog.records]
+
+    assert "idat env: IDAUSR=/home/user/.idapro" in messages
+    assert "idat env: VIRTUAL_ENV=/home/user/.venv" in messages
+    # variables that were stripped or never set are reported too: their absence
+    # is what usually explains a broken Python environment.
+    assert "idat env: PYTHONHOME=<not set>" in messages
+    assert "idat env: PATH=<not set>" in messages
+
+    # every variable of interest gets exactly one line ...
+    assert len(messages) == len(IDAT_ENV_VARS_OF_INTEREST)
+    # ... and nothing outside that curated set is logged.
+    assert not any("s3cret" in message for message in messages)
+
+
+def test_log_idat_env_reports_inherited_environment(caplog, monkeypatch):
+    monkeypatch.setenv("IDAUSR", "/inherited/idausr")
+
+    with caplog.at_level("DEBUG", logger="hcli.lib.ida"):
+        _log_idat_env(None)
+
+    messages = [record.getMessage() for record in caplog.records]
+
+    assert "idat env: inherited from the current process" in messages
+    assert "idat env: IDAUSR=/inherited/idausr" in messages
+
+
+def test_clean_env_for_idat_logs_stripped_vars(caplog, monkeypatch):
+    monkeypatch.setenv("PYTHONHOME", "/some/pythonhome")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    with caplog.at_level("DEBUG", logger="hcli.lib.ida"):
+        env = _clean_env_for_idat()
+
+    messages = [record.getMessage() for record in caplog.records]
+
+    assert "PYTHONHOME" not in env
+    assert "PATH" not in env
+    assert "stripping PYTHONHOME from idat environment (was: /some/pythonhome)" in messages
+    assert "stripping PATH from idat environment (was: /usr/bin)" in messages
+    assert not any(message.startswith("stripping PYTHONPATH") for message in messages)
+    assert any(message.startswith("resolved user virtualenv for idat: ") for message in messages)


### PR DESCRIPTION
## Summary
Log the Python-relevant environment variables passed to `idat` at debug level, and move all pre-subprocess logging before invocation so it's captured even when `idat` hangs or crashes.

## Changes
- Add `_log_idat_env()` — logs a curated set of 16 environment variables (`IDAUSR`, `VIRTUAL_ENV`, `PYTHONHOME`, `PATH`, etc.) that affect how IDA finds and configures its Python environment
- Variables not set are logged as `<not set>` to help diagnose broken environments
- Move `idat command:` logging and add env logging **before** `subprocess.run()` (previously the command was logged after invocation)
- Replace the old ad-hoc `IDAUSR`-only logging with the comprehensive curated set

Only the curated set is logged — the full environment is not dumped since it may contain credentials.

## Test plan
- [x] `just lint` passes
- [x] `just test` passes (pre-existing local failures in `test_ida_python.py` and integration tests unrelated to this change)
- [x] Verify env vars appear in debug output when running with `--verbose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)