### PR TITLE
account for IDAPYTHON_VENV_EXECUTABLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Warn when IDA's Python version (registered by idapyswitch) doesn't match the active virtualenv, in `explain-environment` and before installing plugin dependencies
+- Honor `$IDAPYTHON_VENV_EXECUTABLE` for plugin dependency management
 
 ### Fixed
 - Update uv.lock for better Python 3.14 support

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -28,10 +28,11 @@ HCLI respects the following system variables:
 
 Furthermore, HCLI reads the following IDA Pro-related environment variables:
 
-| Variable       | Purpose                                                          |
-|----------------|------------------------------------------------------------------|
-| IDAUSR         | Standard IDA Pro user directory (checked if HCLI_IDAUSR not set) |
-| IDADIR         | Set by HCLI during IDA Pro execution contexts                    |
+| Variable                      | Purpose                                                          |
+|-------------------------------|------------------------------------------------------------------|
+| IDAUSR                        | Standard IDA Pro user directory (checked if HCLI_IDAUSR not set) |
+| IDADIR                        | Set by HCLI during IDA Pro execution contexts                    |
+| IDAPYTHON_VENV_EXECUTABLE     | Python interpreter for IDA's virtualenv; used for plugin dependency management when the file exists (lower priority than `HCLI_CURRENT_IDA_PYTHON_EXE`) |
 
 ## Network & API Endpoints
 

--- a/src/hcli/commands/ida/python/explain_environment.py
+++ b/src/hcli/commands/ida/python/explain_environment.py
@@ -157,10 +157,22 @@ def explain_environment() -> None:
         for candidate in non_uv_candidates:
             _kv("  candidate venv", f"{_path(candidate.path)}  [dim](via {candidate.source})[/dim]")
 
+    idapython_venv_exe = os.environ.get("IDAPYTHON_VENV_EXECUTABLE") or ENV.IDAPYTHON_VENV_EXECUTABLE
+    if idapython_venv_exe:
+        exists = Path(idapython_venv_exe).is_file()
+        if exists:
+            _kv("$IDAPYTHON_VENV_EXECUTABLE", _path(idapython_venv_exe))
+        else:
+            _kv("$IDAPYTHON_VENV_EXECUTABLE", f"{_path(idapython_venv_exe)}  [red](not found)[/red]")
+    else:
+        _kv("$IDAPYTHON_VENV_EXECUTABLE", "not set")
+
     info: dict | None = None
     env_python = os.environ.get("HCLI_CURRENT_IDA_PYTHON_EXE") or ENV.HCLI_CURRENT_IDA_PYTHON_EXE
     if env_python:
         _kv("python exe", _path(env_python), "$HCLI_CURRENT_IDA_PYTHON_EXE")
+    elif idapython_venv_exe and Path(idapython_venv_exe).is_file():
+        _kv("python exe", _path(idapython_venv_exe), "$IDAPYTHON_VENV_EXECUTABLE")
     else:
         _kv("HCLI_CURRENT_IDA_PYTHON_EXE", "not set")
 

--- a/src/hcli/env.py
+++ b/src/hcli/env.py
@@ -68,6 +68,7 @@ class ENV:
     HCLI_CURRENT_IDA_PLATFORM: str | None = os.getenv("HCLI_CURRENT_IDA_PLATFORM")
     HCLI_CURRENT_IDA_VERSION: str | None = os.getenv("HCLI_CURRENT_IDA_VERSION")
     HCLI_CURRENT_IDA_PYTHON_EXE: str | None = os.getenv("HCLI_CURRENT_IDA_PYTHON_EXE")
+    IDAPYTHON_VENV_EXECUTABLE: str | None = os.getenv("IDAPYTHON_VENV_EXECUTABLE")
 
     # KE download settings
     HCLI_KE_DOWNLOADS_DIR: str | None = os.getenv("HCLI_KE_DOWNLOADS_DIR")

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -209,6 +209,11 @@ def resolve_current_python() -> tuple[Path, dict | None]:
     if ENV.HCLI_CURRENT_IDA_PYTHON_EXE is not None:
         return Path(ENV.HCLI_CURRENT_IDA_PYTHON_EXE), None
 
+    venv_exe = os.environ.get("IDAPYTHON_VENV_EXECUTABLE") or ENV.IDAPYTHON_VENV_EXECUTABLE
+    if venv_exe and Path(venv_exe).is_file():
+        logger.debug("using $IDAPYTHON_VENV_EXECUTABLE: %s", venv_exe)
+        return Path(venv_exe), None
+
     try:
         info = run_py_in_current_idapython(GET_PYTHON_INFO_PY)
     except RuntimeError as e:

--- a/tests/lib/test_ida_python.py
+++ b/tests/lib/test_ida_python.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from hcli.env import ENV
 from hcli.lib.ida import find_current_ida_install_directory, get_ida_user_dir
 from hcli.lib.ida.python import (
     CantInstallPackagesError,
@@ -74,6 +75,35 @@ def _venv_launcher_for_ida(venv_dir: Path) -> Path:
 
 def _venv_bin_dir(venv_dir: Path) -> Path:
     return venv_dir / ("Scripts" if os.name == "nt" else "bin")
+
+
+def test_find_current_python_executable_uses_idapython_venv_executable(tmp_path, monkeypatch):
+    python = tmp_path / "bin" / "python3"
+    python.parent.mkdir()
+    python.write_text("", encoding="utf-8")
+
+    monkeypatch.delenv("HCLI_CURRENT_IDA_PYTHON_EXE", raising=False)
+    monkeypatch.setattr(ENV, "HCLI_CURRENT_IDA_PYTHON_EXE", None)
+    monkeypatch.setenv("IDAPYTHON_VENV_EXECUTABLE", str(python))
+
+    result = find_current_python_executable()
+    assert result == python
+
+
+def test_find_current_python_executable_hcli_exe_overrides_idapython_venv(tmp_path, monkeypatch):
+    hcli_python = tmp_path / "hcli" / "python3"
+    hcli_python.parent.mkdir()
+    hcli_python.write_text("", encoding="utf-8")
+
+    venv_python = tmp_path / "venv" / "bin" / "python3"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("HCLI_CURRENT_IDA_PYTHON_EXE", str(hcli_python))
+    monkeypatch.setenv("IDAPYTHON_VENV_EXECUTABLE", str(venv_python))
+
+    result = find_current_python_executable()
+    assert result == hcli_python
 
 
 def test_derive_python_exe_uses_idapython_venv_executable_when_sys_executable_is_idat(tmp_path):


### PR DESCRIPTION
## Summary

When `$IDAPYTHON_VENV_EXECUTABLE` is set to an existing file, hcli now uses it directly as the Python interpreter for plugin dependency management (e.g. `hcli plugin install`), without needing to probe idat.

This mirrors IDA's own environment variable for selecting a virtualenv interpreter. The precedence is: `$HCLI_CURRENT_IDA_PYTHON_EXE` > `$IDAPYTHON_VENV_EXECUTABLE` > idat probe.

## Changes

- `src/hcli/env.py`: Register `IDAPYTHON_VENV_EXECUTABLE` in the ENV class
- `src/hcli/lib/ida/python.py`: Check `$IDAPYTHON_VENV_EXECUTABLE` in `find_current_python_executable()` before falling back to the idat probe
- `src/hcli/commands/plugin/explain_environment.py`: Show `$IDAPYTHON_VENV_EXECUTABLE` in the diagnostics output and use it as the resolved python exe when set
- `tests/lib/test_ida_python.py`: Tests for the new precedence (IDAPYTHON_VENV_EXECUTABLE used when set, HCLI_CURRENT_IDA_PYTHON_EXE takes priority)
- `docs/reference/environment-variables.md`: Document the variable
- `CHANGELOG.md`: Note the addition

## Test plan

- [x] `$IDAPYTHON_VENV_EXECUTABLE` pointing to an existing file is used as the python exe
- [x] `$HCLI_CURRENT_IDA_PYTHON_EXE` takes priority over `$IDAPYTHON_VENV_EXECUTABLE`
- [x] Non-existent `$IDAPYTHON_VENV_EXECUTABLE` falls through to idat probe
- [x] `explain-environment` displays the variable and its status

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)