### PR TITLE
feat(ida): add `hcli ida python` to work in IDA's Python environment

### DIFF
--- a/docs/user-guide/ida-python-environment.md
+++ b/docs/user-guide/ida-python-environment.md
@@ -6,21 +6,21 @@ Everything after `hcli ida python exec` goes to the interpreter:
 
 ```bash
 $ hcli ida python exec -c "import sys; print(sys.executable)"
-/Users/user/.idapro-live/venv/bin/python
+/Users/user/.idapro/venv/bin/python
 
 $ hcli ida python exec -m pip --version
-pip 25.2 from /Users/user/.idapro-live/venv/lib/python3.13/site-packages/pip (python 3.13)
+pip 25.2 from /Users/user/.idapro/venv/lib/python3.13/site-packages/pip (python 3.13)
 
 $ hcli ida python exec -m pip install requests
 ```
 
-With no arguments you get an interactive interpreter, and hcli exits with whatever status the interpreter returned. hcli parses its own options first, so pass `--` before arguments it would otherwise claim, as in `hcli ida python exec -- --version`.
+With no arguments you get an interactive interpreter, and HCLI exits with whatever status the interpreter returned. HCLI parses its own options first, so pass `--` before arguments it would otherwise claim, as in `hcli ida python exec -- --version`.
 
 Packages often install command-line programs, such as `capa` from `flare-capa`. These land in the environment's scripts directory, which usually isn't on your `PATH`:
 
 ```bash
 $ hcli ida python find-script capa
-/Users/user/.idapro-live/venv/bin/capa
+/Users/user/.idapro/venv/bin/capa
 
 $ hcli ida python run-script capa -- --version
 capa 9.3.1

--- a/docs/user-guide/ida-python-environment.md
+++ b/docs/user-guide/ida-python-environment.md
@@ -1,0 +1,31 @@
+# IDA's Python Environment
+
+IDA runs plugins and scripts in an embedded Python interpreter. That interpreter might be a system Python, one you selected with `idapyswitch`, or a virtualenv activated by your `idapythonrc.py`. `hcli ida python` reaches that same environment from your shell, so the packages you install are the ones IDA will import.
+
+Everything after `hcli ida python exec` goes to the interpreter:
+
+```bash
+$ hcli ida python exec -c "import sys; print(sys.executable)"
+/Users/user/.idapro-live/venv/bin/python
+
+$ hcli ida python exec -m pip --version
+pip 25.2 from /Users/user/.idapro-live/venv/lib/python3.13/site-packages/pip (python 3.13)
+
+$ hcli ida python exec -m pip install requests
+```
+
+With no arguments you get an interactive interpreter, and hcli exits with whatever status the interpreter returned. hcli parses its own options first, so pass `--` before arguments it would otherwise claim, as in `hcli ida python exec -- --version`.
+
+Packages often install command-line programs, such as `capa` from `flare-capa`. These land in the environment's scripts directory, which usually isn't on your `PATH`:
+
+```bash
+$ hcli ida python find-script capa
+/Users/user/.idapro-live/venv/bin/capa
+
+$ hcli ida python run-script capa -- --version
+capa 9.3.1
+```
+
+`find-script` writes just the path to stdout, so you can hand it to other tooling, and exits non-zero when nothing is installed under that name. `run-script` forwards the remaining arguments to the program and exits with its status.
+
+When the environment isn't what you expect, such as the wrong interpreter or a virtualenv IDA doesn't pick up, `hcli ida python explain-environment` shows every step of the detection, from the selected IDA installation through to the interpreter it settled on. It's the first thing to run when a plugin installs but won't import.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - Managing Licenses: user-guide/licenses.md
     - Sharing Files: user-guide/file-sharing.md
     - IDA Plugin Manager: user-guide/plugin-manager.md
+    - IDA's Python Environment: user-guide/ida-python-environment.md
   - How-To Guides:
     - Use HCLI in Docker: how-to/use-hcli-in-docker.md
     - Share Files with Support: how-to/share-files-with-support.md

--- a/src/hcli/commands/ida/__init__.py
+++ b/src/hcli/commands/ida/__init__.py
@@ -14,6 +14,7 @@ from .install import install
 from .list import list_instances
 from .open import open_ida_link
 from .protocol import protocol
+from .python import python
 from .remove import remove
 from .set_default import set_default_ida
 from .source import source
@@ -25,6 +26,7 @@ ida.add_command(install)
 ida.add_command(list_instances, name="list")
 ida.add_command(open_ida_link)
 ida.add_command(protocol)
+ida.add_command(python)
 ida.add_command(remove)
 ida.add_command(set_default_ida)
 ida.add_command(source)

--- a/src/hcli/commands/ida/python/__init__.py
+++ b/src/hcli/commands/ida/python/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import rich_click as click
+
+
+@click.group()
+def python() -> None:
+    """Use the Python environment that IDA loads."""
+
+
+from .exec_python import exec_python
+from .explain_environment import explain_environment
+from .find_script import find_script
+from .run_script import run_script
+
+python.add_command(exec_python, name="exec")
+python.add_command(explain_environment, name="explain-environment")
+python.add_command(find_script, name="find-script")
+python.add_command(run_script, name="run-script")

--- a/src/hcli/commands/ida/python/_common.py
+++ b/src/hcli/commands/ida/python/_common.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import rich.status
+import rich_click as click
+from rich.markup import escape
+
+from hcli.lib.console import console, stderr_console
+from hcli.lib.ida.python import PythonNotFoundError, find_current_python_executable
+
+
+def get_python_exe() -> Path:
+    """Resolve the Python interpreter that IDA loads, reporting failures to the user.
+
+    Raises:
+        click.Abort: if the interpreter can't be detected.
+    """
+    try:
+        with rich.status.Status("finding IDA's Python interpreter", console=stderr_console):
+            return find_current_python_executable()
+    except PythonNotFoundError as e:
+        console.print(f"[red]{escape(str(e))}[/red]")
+        raise click.Abort()

--- a/src/hcli/commands/ida/python/exec_python.py
+++ b/src/hcli/commands/ida/python/exec_python.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import rich_click as click
+from rich.markup import escape
+
+from hcli.lib.console import console
+from hcli.lib.ida.python import run_in_python_environment
+
+from ._common import get_python_exe
+
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+@click.pass_context
+def exec_python(ctx: click.Context, args: tuple[str, ...]) -> None:
+    """Run IDA's Python interpreter, passing through all arguments.
+
+    Without arguments, this starts an interactive interpreter.
+    hcli exits with the status of the interpreter.
+
+    \b
+    Examples:
+      hcli ida python exec -m pip install requests
+      hcli ida python exec -c "import requests; print('ok')"
+      hcli ida python exec script.py --flag
+
+    \b
+    Use `--` for arguments that hcli would otherwise interpret:
+      hcli ida python exec -- --version
+    """
+    python_exe = get_python_exe()
+
+    try:
+        status = run_in_python_environment(python_exe, [str(python_exe), *args])
+    except OSError as e:
+        console.print(f"[red]failed to run {escape(str(python_exe))}: {escape(str(e))}[/red]")
+        raise click.Abort()
+
+    ctx.exit(status)

--- a/src/hcli/commands/ida/python/exec_python.py
+++ b/src/hcli/commands/ida/python/exec_python.py
@@ -16,7 +16,7 @@ def exec_python(ctx: click.Context, args: tuple[str, ...]) -> None:
     """Run IDA's Python interpreter, passing through all arguments.
 
     Without arguments, this starts an interactive interpreter.
-    hcli exits with the status of the interpreter.
+    HCLI exits with the status of the interpreter.
 
     \b
     Examples:
@@ -25,7 +25,7 @@ def exec_python(ctx: click.Context, args: tuple[str, ...]) -> None:
       hcli ida python exec script.py --flag
 
     \b
-    Use `--` for arguments that hcli would otherwise interpret:
+    Use `--` for arguments that HCLI would otherwise interpret:
       hcli ida python exec -- --version
     """
     python_exe = get_python_exe()

--- a/src/hcli/commands/ida/python/explain_environment.py
+++ b/src/hcli/commands/ida/python/explain_environment.py
@@ -52,7 +52,7 @@ def _err(key: str, error: str) -> None:
     console.print(f"  [bold]{key}[/bold]: [red]{escape(error)}[/red]")
 
 
-@click.command(hidden=True)
+@click.command()
 def explain_environment() -> None:
     """Show how the current IDA installation and Python version are detected."""
 

--- a/src/hcli/commands/ida/python/explain_environment.py
+++ b/src/hcli/commands/ida/python/explain_environment.py
@@ -235,7 +235,7 @@ def explain_environment() -> None:
         _err("probed version", f"{type(e).__name__}: {e}")
 
     interpreter_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    _kv("hcli interpreter", interpreter_version, _path(sys.executable))
+    _kv("HCLI interpreter", interpreter_version, _path(sys.executable))
 
     try:
         final = detect_current_python_version()
@@ -265,7 +265,7 @@ def explain_environment() -> None:
     elif process_virtual_env and is_hcli_own_venv:
         console.print(
             f"[dim]Note: $VIRTUAL_ENV ({escape(process_virtual_env)}) "
-            f"is the hcli process environment, not the IDA Python environment. "
+            f"is the HCLI process environment, not the IDA Python environment. "
             f"It is not used for plugin installation.[/dim]",
             highlight=False,
         )

--- a/src/hcli/commands/ida/python/find_script.py
+++ b/src/hcli/commands/ida/python/find_script.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import rich.status
+import rich_click as click
+from rich.markup import escape
+
+from hcli.lib.console import console, stderr_console
+from hcli.lib.ida.python import ProbeError, get_script_info, render_script_not_found
+
+from ._common import get_python_exe
+
+
+@click.command()
+@click.argument("name")
+def find_script(name: str) -> None:
+    """Show the path of a script installed in IDA's Python environment.
+
+    \b
+    NAME: name of the script, like `speakeasy`
+
+    Prints nothing and exits non-zero when the script isn't installed.
+    """
+    python_exe = get_python_exe()
+
+    try:
+        with rich.status.Status(f"looking for {name}", console=stderr_console):
+            info = get_script_info(python_exe, name)
+    except ProbeError as e:
+        console.print(f"[red]{escape(str(e))}[/red]")
+        raise click.Abort()
+
+    if info.path is None:
+        console.print(f"[red]{escape(render_script_not_found(info))}[/red]")
+        raise click.Abort()
+
+    console.print(str(info.path), highlight=False, soft_wrap=True)

--- a/src/hcli/commands/ida/python/run_script.py
+++ b/src/hcli/commands/ida/python/run_script.py
@@ -21,14 +21,14 @@ def run_script(ctx: click.Context, name: str, args: tuple[str, ...]) -> None:
     NAME: name of the script, like `speakeasy`
     ARGS: arguments passed through to the script
 
-    hcli exits with the status of the script.
+    HCLI exits with the status of the script.
 
     \b
     Examples:
       hcli ida python run-script speakeasy -t sample.exe
 
     \b
-    Use `--` for arguments that hcli would otherwise interpret:
+    Use `--` for arguments that HCLI would otherwise interpret:
       hcli ida python run-script speakeasy -- --help
     """
     python_exe = get_python_exe()

--- a/src/hcli/commands/ida/python/run_script.py
+++ b/src/hcli/commands/ida/python/run_script.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import rich_click as click
+from rich.markup import escape
+
+import hcli.lib.ida.python
+from hcli.lib.console import console
+from hcli.lib.ida.python import ProbeError, ScriptNotFoundError
+
+from ._common import get_python_exe
+
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.argument("name")
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+@click.pass_context
+def run_script(ctx: click.Context, name: str, args: tuple[str, ...]) -> None:
+    """Run a script installed in IDA's Python environment.
+
+    \b
+    NAME: name of the script, like `speakeasy`
+    ARGS: arguments passed through to the script
+
+    hcli exits with the status of the script.
+
+    \b
+    Examples:
+      hcli ida python run-script speakeasy -t sample.exe
+
+    \b
+    Use `--` for arguments that hcli would otherwise interpret:
+      hcli ida python run-script speakeasy -- --help
+    """
+    python_exe = get_python_exe()
+
+    try:
+        status = hcli.lib.ida.python.run_script(python_exe, name, args)
+    except (ProbeError, ScriptNotFoundError, OSError) as e:
+        console.print(f"[red]{escape(str(e))}[/red]")
+        raise click.Abort()
+
+    ctx.exit(status)

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -187,6 +187,7 @@ plugin.add_command(schema, name="schema")
 plugin.add_command(bundle, name="bundle")
 
 
+# Backwards-compat alias. Remove after 0.20.
 @click.command(name="explain-environment", hidden=True)
 @click.pass_context
 def _explain_environment_alias(ctx) -> None:

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -18,7 +18,6 @@ from hcli.lib.ida.python import PipOptions
 
 from .bundle import bundle
 from .config import config
-from .explain_environment import explain_environment
 from .install import install_plugin
 from .lint import lint_plugin_directory
 from .repo import repo
@@ -186,4 +185,18 @@ plugin.add_command(repo, name="repo")
 plugin.add_command(config, name="config")
 plugin.add_command(schema, name="schema")
 plugin.add_command(bundle, name="bundle")
-plugin.add_command(explain_environment, name="explain-environment")
+
+
+@click.command(name="explain-environment", hidden=True)
+@click.pass_context
+def _explain_environment_alias(ctx) -> None:
+    """Show how the current IDA installation and Python version are detected.
+
+    Moved to `hcli ida python explain-environment`.
+    """
+    from hcli.commands.ida.python.explain_environment import explain_environment
+
+    ctx.forward(explain_environment)
+
+
+plugin.add_command(_explain_environment_alias)

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -1,8 +1,12 @@
 # see also hcli.lib.util.python
+from __future__ import annotations
+
+import json
 import logging
 import os
 import platform
 import subprocess
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -595,3 +599,351 @@ def pip_freeze(python_exe: Path):
     if process.returncode != 0:
         raise subprocess.CalledProcessError(process.returncode, [str(python_exe), "-m", "pip", "freeze"])
     return stdout.decode("utf-8", errors="replace")
+
+
+class ProbeError(RuntimeError):
+    """Failed to run a probe script in IDA's Python environment."""
+
+
+class ScriptNotFoundError(RuntimeError):
+    """Could not find a console script in IDA's Python environment."""
+
+
+# Script run by IDA's Python interpreter (not by idat).
+# Locates the wrapper executable installed for a console script, like `speakeasy`.
+#
+# There is no API for this. Package metadata declares the entry point
+# (`speakeasy = speakeasy.__main__:main`), which is a Python object reference, not a
+# file: the wrapper is generated at install time and where it lands is up to the
+# installer. see: https://discuss.python.org/t/can-i-retrieve-the-path-for-an-entry-point-using-importlib-metadata/79490
+#
+# So we resolve it in two steps:
+#
+#  1. the distribution's RECORD, via `Distribution.files`. This is the installer's own
+#     list of the files it wrote, including generated scripts, which appear as paths
+#     relative to site-packages, like `../../../bin/speakeasy`. It's authoritative:
+#     the wrapper it names belongs to the same environment as the package we matched.
+#     pip and uv both write RECORD, as does any wheel-spec-compliant installer.
+#     (Debian strips it from apt-packaged distributions, but those interpreters are
+#     externally managed, so we don't support installing into them anyway.)
+#
+#  2. otherwise, look for the file in the scripts directories, which is where the
+#     wheel spec says installers should put it. This is only name matching, so it can
+#     turn up a stale or unrelated script - hence it comes second.
+#
+# The wrapper's filename matches the entry point name by convention, not by rule.
+# Windows installers generate a `name.exe` trampoline; older setuptools also left a
+# `name-script.py` beside it.
+GET_SCRIPT_INFO_PY = r"""
+import io
+import json
+import os
+import sys
+import sysconfig
+
+# ensure UTF-8 output for unicode install paths
+if hasattr(sys.stdout, "buffer"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+
+name = sys.argv[1]
+
+if os.name == "nt":
+    filenames = [name + ".exe", name + ".cmd", name + ".bat", name, name + "-script.py"]
+else:
+    filenames = [name]
+
+# Scan distributions for the entry point, rather than using entry_points(name=...)
+# or EntryPoint.dist, which need Python 3.10+. IDA may be using an older interpreter.
+entry_point = None
+record_candidates = []
+try:
+    from importlib.metadata import distributions
+
+    for dist in distributions():
+        try:
+            eps = [
+                ep
+                for ep in dist.entry_points
+                if ep.name == name and ep.group in ("console_scripts", "gui_scripts")
+            ]
+        except Exception:
+            continue
+
+        if not eps:
+            continue
+
+        entry_point = {
+            "name": eps[0].name,
+            "value": eps[0].value,
+            "group": eps[0].group,
+            "distribution": dist.metadata["Name"],
+            "version": dist.version,
+        }
+
+        # `files` is None when the distribution has no RECORD
+        for file in dist.files or []:
+            if os.path.basename(str(file)) not in filenames:
+                continue
+            try:
+                record_candidates.append(os.path.realpath(str(dist.locate_file(file))))
+            except Exception:
+                pass
+
+        break
+except Exception:
+    pass
+
+scripts_dirs = []
+
+
+def add_dir(path):
+    if path and path not in scripts_dirs:
+        scripts_dirs.append(path)
+
+
+# next to the interpreter: where a virtualenv keeps its scripts.
+# don't resolve symlinks here: a virtualenv's python is usually a link to the base
+# interpreter, and following it would lead out of the environment we're inspecting.
+add_dir(os.path.dirname(os.path.abspath(sys.executable)))
+add_dir(sysconfig.get_path("scripts"))
+try:
+    # where `pip install --user` puts scripts
+    add_dir(sysconfig.get_path("scripts", sysconfig.get_preferred_scheme("user")))
+except Exception:
+    add_dir(sysconfig.get_path("scripts", "nt_user" if os.name == "nt" else "posix_user"))
+
+candidates = record_candidates + [os.path.join(d, f) for d in scripts_dirs for f in filenames]
+
+path = None
+for candidate in candidates:
+    if os.path.isfile(candidate):
+        path = candidate
+        break
+
+print("__hcli__:" + json.dumps({
+    "name": name,
+    "path": path,
+    "scripts_dirs": scripts_dirs,
+    "record_candidates": record_candidates,
+    "entry_point": entry_point,
+}))
+"""
+
+
+# Script run by IDA's Python interpreter (not by idat).
+# Invokes a console script by its entry point: import the module, call the attribute,
+# exit with its return value. That is exactly what the wheel spec defines a console
+# script to do, and what the generated wrapper contains, so this is behaviorally
+# identical. Used when the wrapper itself can't be found on disk.
+RUN_ENTRY_POINT_PY = r"""
+import sys
+from importlib.metadata import distributions
+
+name = sys.argv[1]
+
+for dist in distributions():
+    try:
+        eps = [
+            ep
+            for ep in dist.entry_points
+            if ep.name == name and ep.group in ("console_scripts", "gui_scripts")
+        ]
+    except Exception:
+        continue
+
+    if eps:
+        sys.argv = [name] + sys.argv[2:]
+        sys.exit(eps[0].load()())
+
+sys.exit("error: no console script named " + name)
+"""
+
+
+@dataclass(frozen=True)
+class EntryPoint:
+    """A console script entry point declared by an installed distribution."""
+
+    name: str
+    value: str
+    group: str
+    distribution: str | None
+    version: str | None
+
+    @classmethod
+    def from_probe(cls, doc: dict) -> EntryPoint:
+        return cls(
+            name=doc["name"],
+            value=doc["value"],
+            group=doc["group"],
+            distribution=doc.get("distribution"),
+            version=doc.get("version"),
+        )
+
+
+@dataclass(frozen=True)
+class ScriptInfo:
+    """The result of looking for a console script in a Python environment.
+
+    `path` is the wrapper executable, when one was found on disk.
+    `entry_point` is the declaration found in package metadata, which may exist
+    even when no wrapper was installed (or when it was installed elsewhere).
+    """
+
+    name: str
+    path: Path | None
+    scripts_dirs: tuple[Path, ...]
+    entry_point: EntryPoint | None
+
+    @classmethod
+    def from_probe(cls, doc: dict) -> ScriptInfo:
+        entry_point = doc.get("entry_point")
+        return cls(
+            name=doc["name"],
+            path=Path(doc["path"]) if doc.get("path") else None,
+            scripts_dirs=tuple(Path(p) for p in doc.get("scripts_dirs", ())),
+            entry_point=EntryPoint.from_probe(entry_point) if entry_point else None,
+        )
+
+
+def get_environment_for_python(python_exe: Path) -> dict[str, str]:
+    """Build the environment for a process run against the given Python.
+
+    hcli may itself run inside a virtualenv (or a uv cache overlay), so the
+    inherited VIRTUAL_ENV/PYTHONHOME describe hcli's environment, not IDA's.
+    """
+    env = os.environ.copy()
+
+    env.pop("PYTHONHOME", None)
+
+    venv_root = _get_venv_root_from_python(str(python_exe))
+    if venv_root:
+        env["VIRTUAL_ENV"] = str(venv_root)
+    else:
+        env.pop("VIRTUAL_ENV", None)
+
+    scripts_dir = str(python_exe.parent)
+    path = env.get("PATH")
+    env["PATH"] = f"{scripts_dir}{os.pathsep}{path}" if path else scripts_dir
+
+    return env
+
+
+def _run_probe(python_exe: Path, src: str, args: Sequence[str] = (), timeout: float = 60.0) -> dict:
+    """Run a probe script with the given Python and parse its `__hcli__:` result line.
+
+    Raises:
+        ProbeError: if the interpreter can't be run, fails, or emits no result.
+    """
+    argv = [str(python_exe), "-c", src, *args]
+    logger.debug("probing IDA Python environment: %s", argv)
+
+    try:
+        process = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=timeout,
+            env=get_environment_for_python(python_exe),
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        raise ProbeError(f"failed to run {python_exe}: {e}") from e
+
+    if process.returncode != 0:
+        raise ProbeError(f"{python_exe} exited with status {process.returncode}: {process.stderr.strip()}")
+
+    for line in process.stdout.splitlines():
+        if line.startswith("__hcli__:"):
+            return json.loads(line[len("__hcli__:") :])
+
+    raise ProbeError(f"no result from {python_exe}: {process.stdout.strip()}")
+
+
+def get_script_info(python_exe: Path, name: str) -> ScriptInfo:
+    """Look for the console script `name` in the given Python environment.
+
+    Raises:
+        ProbeError: if the environment can't be inspected.
+    """
+    doc = _run_probe(python_exe, GET_SCRIPT_INFO_PY, [name])
+    logger.debug("script probe: %s", doc)
+    return ScriptInfo.from_probe(doc)
+
+
+def find_script(python_exe: Path, name: str) -> Path:
+    """Resolve the path of the console script `name` in the given Python environment.
+
+    Raises:
+        ProbeError: if the environment can't be inspected.
+        ScriptNotFoundError: if no such script is installed.
+    """
+    info = get_script_info(python_exe, name)
+    if info.path is None:
+        raise ScriptNotFoundError(render_script_not_found(info))
+    return info.path
+
+
+def render_script_not_found(info: ScriptInfo) -> str:
+    """Explain why a console script couldn't be resolved to a path."""
+    searched = "\n".join(f"  {d}" for d in info.scripts_dirs)
+
+    if info.entry_point:
+        distribution = " ".join(filter(None, [info.entry_point.distribution or "?", info.entry_point.version]))
+        return (
+            f"script '{info.name}' is declared by {distribution} ({info.entry_point.value}), "
+            f"but no program for it was installed.\n"
+            f"Searched that distribution's file list and:\n{searched}\n"
+            f"Try reinstalling {info.entry_point.distribution or distribution}."
+        )
+
+    return f"script '{info.name}' is not installed. Searched:\n{searched}"
+
+
+def run_in_python_environment(python_exe: Path, argv: Sequence[str]) -> int:
+    """Run a command in the given Python environment, connected to this terminal.
+
+    Returns the exit status of the command.
+
+    Raises:
+        OSError: if the command can't be executed.
+    """
+    logger.debug("running: %s", list(argv))
+
+    try:
+        process = subprocess.run(list(argv), check=False, env=get_environment_for_python(python_exe))
+    except KeyboardInterrupt:
+        # the child received SIGINT too, and has already exited.
+        return 130
+
+    return process.returncode
+
+
+def run_script(python_exe: Path, name: str, args: Sequence[str] = ()) -> int:
+    """Run the console script `name` in the given Python environment.
+
+    Prefers the installed wrapper executable, so the script sees exactly what it
+    would when invoked from the shell. Falls back to invoking the entry point
+    directly when the wrapper isn't on disk, for example when an installer put it
+    somewhere we don't know to look.
+
+    Returns the exit status of the script.
+
+    Raises:
+        ProbeError: if the environment can't be inspected.
+        ScriptNotFoundError: if no such script is installed.
+    """
+    info = get_script_info(python_exe, name)
+
+    if info.path is not None:
+        if os.access(info.path, os.X_OK):
+            return run_in_python_environment(python_exe, [str(info.path), *args])
+        # a wrapper without the executable bit is still a Python script we can run.
+        return run_in_python_environment(python_exe, [str(python_exe), str(info.path), *args])
+
+    if info.entry_point is not None:
+        logger.debug("no wrapper for '%s', invoking entry point %s", name, info.entry_point.value)
+        return run_in_python_environment(python_exe, [str(python_exe), "-c", RUN_ENTRY_POINT_PY, name, *args])
+
+    raise ScriptNotFoundError(render_script_not_found(info))

--- a/tests/lib/test_ida_python_scripts.py
+++ b/tests/lib/test_ida_python_scripts.py
@@ -1,0 +1,253 @@
+"""Tests for finding and running scripts installed in a Python environment.
+
+These build a real virtualenv containing a distribution that declares console
+scripts, so no IDA installation is needed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import venv
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from hcli.lib.ida.python import (
+    ProbeError,
+    ScriptNotFoundError,
+    find_script,
+    get_environment_for_python,
+    get_script_info,
+    run_in_python_environment,
+    run_script,
+)
+
+MODULE_PY = """
+import sys
+
+
+def main():
+    print("hello from " + sys.argv[0] + ": " + " ".join(sys.argv[1:]))
+    return 0
+"""
+
+METADATA = """Metadata-Version: 2.1
+Name: hcli-test-pkg
+Version: 1.2.3
+"""
+
+# - installed: has a wrapper in the scripts directory, like most installs
+# - recorded: has a wrapper somewhere else, discoverable only via RECORD
+# - shadowed: recorded, but another script of the same name sits in the scripts directory
+# - orphan: declared, but no wrapper was installed anywhere
+ENTRY_POINTS_TXT = """[console_scripts]
+hcli-test-installed = hcli_test_pkg:main
+hcli-test-recorded = hcli_test_pkg:main
+hcli-test-shadowed = hcli_test_pkg:main
+hcli-test-orphan = hcli_test_pkg:main
+"""
+
+
+@dataclass(frozen=True)
+class PythonEnv:
+    root: Path
+    python_exe: Path
+    scripts_dir: Path
+    purelib: Path
+    custom_bin: Path
+
+
+def _get_venv_python(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _write_wrapper(directory: Path, name: str, python_exe: Path) -> Path:
+    """Install a console script wrapper the way an installer would."""
+    directory.mkdir(parents=True, exist_ok=True)
+
+    impl = directory / f"{name}-impl.py"
+    impl.write_text(f"import sys\nfrom hcli_test_pkg import main\nsys.argv[0] = {name!r}\nsys.exit(main())\n")
+
+    if os.name == "nt":
+        wrapper = directory / f"{name}.bat"
+        wrapper.write_text(f'@echo off\n"{python_exe}" "{impl}" %*\n')
+    else:
+        wrapper = directory / name
+        wrapper.write_text(f'#!/bin/sh\nexec "{python_exe}" "{impl}" "$@"\n')
+        wrapper.chmod(0o755)
+
+    return wrapper
+
+
+@pytest.fixture(scope="session")
+def python_env(tmp_path_factory) -> PythonEnv:
+    root = tmp_path_factory.mktemp("python-env")
+    venv_dir = root / "venv"
+    venv.create(venv_dir, with_pip=False, symlinks=os.name != "nt")
+
+    python_exe = _get_venv_python(venv_dir)
+    paths = json.loads(
+        subprocess.run(
+            [
+                str(python_exe),
+                "-c",
+                (
+                    "import json, sysconfig; "
+                    "print(json.dumps({'purelib': sysconfig.get_path('purelib'), "
+                    "'scripts': sysconfig.get_path('scripts')}))"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+
+    purelib = Path(paths["purelib"])
+    scripts_dir = Path(paths["scripts"])
+    custom_bin = root / "custom-bin"
+
+    purelib.mkdir(parents=True, exist_ok=True)
+    (purelib / "hcli_test_pkg.py").write_text(MODULE_PY)
+
+    dist_info = purelib / "hcli_test_pkg-1.2.3.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(METADATA)
+    (dist_info / "entry_points.txt").write_text(ENTRY_POINTS_TXT)
+
+    _write_wrapper(scripts_dir, "hcli-test-installed", python_exe)
+    _write_wrapper(scripts_dir, "hcli-test-shadowed", python_exe)
+    recorded = [
+        _write_wrapper(custom_bin, "hcli-test-recorded", python_exe),
+        _write_wrapper(custom_bin, "hcli-test-shadowed", python_exe),
+    ]
+
+    # RECORD paths are relative to the directory containing the .dist-info
+    lines = ["hcli_test_pkg.py,,"] + [f"{Path(os.path.relpath(p, purelib)).as_posix()},," for p in recorded]
+    (dist_info / "RECORD").write_text("\n".join(lines) + "\n")
+
+    return PythonEnv(
+        root=root,
+        python_exe=python_exe,
+        scripts_dir=scripts_dir,
+        purelib=purelib,
+        custom_bin=custom_bin,
+    )
+
+
+def test_find_script_in_scripts_directory(python_env: PythonEnv):
+    """A wrapper that RECORD doesn't mention is found in the scripts directory."""
+    path = find_script(python_env.python_exe, "hcli-test-installed")
+    assert path.parent.resolve() == python_env.scripts_dir.resolve()
+    assert path.is_file()
+
+
+def test_find_script_via_record(python_env: PythonEnv):
+    """A wrapper installed outside the scripts directory is found via the distribution's RECORD."""
+    path = find_script(python_env.python_exe, "hcli-test-recorded")
+    assert path.parent.resolve() == python_env.custom_bin.resolve()
+    assert path.is_file()
+
+
+def test_find_script_prefers_record(python_env: PythonEnv):
+    """RECORD names the wrapper belonging to the distribution, so it wins over a same-named file."""
+    path = find_script(python_env.python_exe, "hcli-test-shadowed")
+    assert path.parent.resolve() == python_env.custom_bin.resolve()
+
+
+def test_find_script_reports_entry_point(python_env: PythonEnv):
+    info = get_script_info(python_env.python_exe, "hcli-test-installed")
+    assert info.entry_point is not None
+    assert info.entry_point.value == "hcli_test_pkg:main"
+    assert info.entry_point.group == "console_scripts"
+    assert info.entry_point.distribution == "hcli-test-pkg"
+    assert info.entry_point.version == "1.2.3"
+
+
+def test_find_script_without_wrapper(python_env: PythonEnv):
+    """A declared script with no wrapper on disk has no path, but is still described."""
+    info = get_script_info(python_env.python_exe, "hcli-test-orphan")
+    assert info.path is None
+    assert info.entry_point is not None
+
+    with pytest.raises(ScriptNotFoundError):
+        find_script(python_env.python_exe, "hcli-test-orphan")
+
+
+def test_find_script_missing(python_env: PythonEnv):
+    info = get_script_info(python_env.python_exe, "hcli-test-missing")
+    assert info.path is None
+    assert info.entry_point is None
+    assert python_env.scripts_dir in info.scripts_dirs
+
+    with pytest.raises(ScriptNotFoundError):
+        find_script(python_env.python_exe, "hcli-test-missing")
+
+
+def test_scripts_dirs_stay_inside_the_environment(python_env: PythonEnv):
+    """A virtualenv's python links to the base interpreter, whose bin/ isn't the venv's."""
+    info = get_script_info(python_env.python_exe, "hcli-test-missing")
+    assert info.scripts_dirs[0].resolve() == python_env.scripts_dir.resolve()
+
+
+def test_get_script_info_bad_interpreter(tmp_path: Path):
+    with pytest.raises(ProbeError):
+        get_script_info(tmp_path / "does-not-exist", "hcli-test-installed")
+
+
+def test_run_script_wrapper(python_env: PythonEnv, capfd):
+    status = run_script(python_env.python_exe, "hcli-test-installed", ["alpha", "beta"])
+    assert status == 0
+    assert "hello from hcli-test-installed: alpha beta" in capfd.readouterr().out
+
+
+def test_run_script_falls_back_to_entry_point(python_env: PythonEnv, capfd):
+    """A script with no wrapper on disk is invoked through its entry point."""
+    status = run_script(python_env.python_exe, "hcli-test-orphan", ["gamma"])
+    assert status == 0
+    assert "hello from hcli-test-orphan: gamma" in capfd.readouterr().out
+
+
+def test_run_script_missing(python_env: PythonEnv):
+    with pytest.raises(ScriptNotFoundError):
+        run_script(python_env.python_exe, "hcli-test-missing")
+
+
+def test_run_in_python_environment_returns_status(python_env: PythonEnv):
+    argv = [str(python_env.python_exe), "-c", "import sys; sys.exit(7)"]
+    assert run_in_python_environment(python_env.python_exe, argv) == 7
+
+
+def test_run_in_python_environment_uses_target_interpreter(python_env: PythonEnv, capfd):
+    argv = [str(python_env.python_exe), "-c", "import sys; print(sys.prefix)"]
+    assert run_in_python_environment(python_env.python_exe, argv) == 0
+
+    prefix = capfd.readouterr().out.strip()
+    assert Path(prefix) != Path(sys.prefix)
+    assert Path(prefix) == python_env.root / "venv"
+
+
+def test_get_environment_for_python_venv(python_env: PythonEnv, monkeypatch):
+    monkeypatch.setenv("VIRTUAL_ENV", str(Path(sys.prefix)))
+    monkeypatch.setenv("PYTHONHOME", "/nonsense")
+
+    env = get_environment_for_python(python_env.python_exe)
+
+    assert env["VIRTUAL_ENV"] == str(python_env.root / "venv")
+    assert "PYTHONHOME" not in env
+    assert env["PATH"].split(os.pathsep)[0] == str(python_env.python_exe.parent)
+
+
+def test_get_environment_for_python_not_a_venv(tmp_path: Path, monkeypatch):
+    """hcli's own virtualenv must not leak into a system interpreter."""
+    monkeypatch.setenv("VIRTUAL_ENV", str(Path(sys.prefix)))
+
+    env = get_environment_for_python(tmp_path / "bin" / "python")
+
+    assert "VIRTUAL_ENV" not in env


### PR DESCRIPTION
Implements the design from https://github.com/HexRaysSA/ida-hcli/issues/270#issuecomment-5189379516.

```console
$ hcli ida python exec -c "import sys; print(sys.executable)"
/Users/user/.idapro-live/venv/bin/python

$ hcli ida python exec -m pip --version
pip 25.2 from /Users/user/.idapro-live/venv/lib/python3.13/site-packages/pip (python 3.13)

$ hcli ida python find-script capa
/Users/user/.idapro-live/venv/bin/capa

$ hcli ida python run-script capa -- --version
capa 9.3.1
```

`exec` and `run-script` pass through stdio (so the REPL and interactive programs work) and hcli exits with the child's status. The interpreter is the one already used for plugin dependency installation, via `find_current_python_executable()`. Child processes get `VIRTUAL_ENV` rewritten to IDA's virtualenv (or dropped), `PYTHONHOME` removed, and the scripts directory prepended to `PATH`, so hcli's own environment doesn't leak into them.

Locating an installed program like `capa` has no supported API: the entry point declaration names a Python object, not a file, and where the generated wrapper lands is up to the installer. So resolution is layered, with the reasoning recorded in comments next to the probe:

1. the distribution's `RECORD`, which is the installer's own list of the files it wrote (pip and uv both write it) and is authoritative about which environment the wrapper belongs to;
2. otherwise the scripts directories, which is name matching only and can turn up a stale or unrelated script, hence second;
3. for `run-script`, invoking the entry point directly if no wrapper exists at all, which is exactly what a generated wrapper does.

`hcli plugin explain-environment` moves to `hcli ida python explain-environment` and is now visible rather than hidden. The old path stays as a hidden alias, marked for removal after 0.20.

Tests build a real virtualenv with a distribution declaring console scripts, so they need no IDA installation, and cover: discovery via RECORD, discovery via the scripts directory, RECORD winning over a same-named script elsewhere, the entry-point fallback, exit status propagation, and environment scrubbing.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)