### PR TITLE
Add --json to plugin status/search/explain-environment

### DIFF
--- a/src/hcli/commands/ida/python/explain_environment.py
+++ b/src/hcli/commands/ida/python/explain_environment.py
@@ -4,12 +4,14 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Literal
 
 import rich_click as click
+from pydantic import BaseModel
 from rich.markup import escape
 
 from hcli.env import ENV
-from hcli.lib.console import console
+from hcli.lib.console import console, print_json
 from hcli.lib.ida import (
     MissingCurrentInstallationDirectory,
     detect_binary_arch,
@@ -27,6 +29,7 @@ from hcli.lib.ida.python import (
     GET_PYTHON_INFO_PY,
     PRINT_VERSION_PY,
     PythonNotFoundError,
+    PythonVersionMismatch,
     _derive_python_exe,
     detect_current_python_version,
     find_current_python_executable,
@@ -35,6 +38,435 @@ from hcli.lib.ida.python import (
     get_virtual_env_version,
 )
 from hcli.lib.venv import find_candidate_virtual_envs, is_uv_cache_virtual_env, resolve_user_virtual_env
+
+
+class InstallationEntry(BaseModel):
+    path: str
+    version: str | None = None
+
+
+class KnownInstallationsReport(BaseModel):
+    installations: list[InstallationEntry] = []
+    error: str | None = None
+
+
+class SelectedInstallationReport(BaseModel):
+    install_dir: str | None = None
+    install_dir_source: str | None = None
+    install_dir_error: str | None = None
+    resolved_dir: str | None = None
+    resolved_dir_error: str | None = None
+
+
+class ArchitectureAndVersionReport(BaseModel):
+    ida_binary: str | None = None
+    ida_binary_error: str | None = None
+    binary_arch: str | None = None
+    binary_arch_error: str | None = None
+    platform: str | None = None
+    platform_error: str | None = None
+    ida_version: str | None = None
+    ida_version_source: str | None = None
+    ida_version_error: str | None = None
+
+
+class CandidateVirtualEnv(BaseModel):
+    path: str
+    source: str
+
+
+class IdatProbe(BaseModel):
+    """What IDA's embedded Python reports about itself, via GET_PYTHON_INFO_PY."""
+
+    frozen: bool = False
+    prefix: str
+    base_prefix: str
+    executable: str | None = None
+    virtual_env: str | None = None
+    idapython_venv_executable: str | None = None
+    version_major: int
+    version_minor: int
+
+
+class PythonEnvironmentReport(BaseModel):
+    virtual_env: str | None = None
+    virtual_env_is_uv_cache: bool = False
+    user_virtual_env: str | None = None
+    candidate_virtual_envs: list[CandidateVirtualEnv] = []
+    idapython_venv_executable: str | None = None
+    idapython_venv_executable_exists: bool | None = None
+    python_exe: str | None = None
+    python_exe_source: str | None = None
+    idat_probe: IdatProbe | None = None
+    idat_probe_error: str | None = None
+    derived_exe: str | None = None
+    derived_exe_error: str | None = None
+
+
+class IdaPythonVirtualEnvReport(BaseModel):
+    venv: str
+    home: str | None = None
+    system_site_packages: str | None = None
+    python_version: str | None = None
+
+
+class PythonVersionReport(BaseModel):
+    final_python_exe: str | None = None
+    final_python_exe_error: str | None = None
+    probed_version: str | None = None
+    probed_version_error: str | None = None
+    hcli_interpreter_version: str
+    hcli_interpreter_path: str
+    final_version: str | None = None
+    final_version_error: str | None = None
+
+
+class PythonVersionMismatchEntry(BaseModel):
+    ida_version: str
+    other_version: str
+    other_path: str
+    other_source: str
+
+
+class EnvironmentNote(BaseModel):
+    kind: Literal["diagnostic", "hint", "warning"]
+    text: str
+
+
+class EnvironmentReport(BaseModel):
+    experimental: bool = True
+    known_installations: KnownInstallationsReport
+    selected_installation: SelectedInstallationReport
+    # the sections below need an installation directory, so they're absent when it can't be resolved.
+    architecture_and_version: ArchitectureAndVersionReport | None = None
+    python_environment: PythonEnvironmentReport | None = None
+    idapython_virtualenv: IdaPythonVirtualEnvReport | None = None
+    python_version: PythonVersionReport | None = None
+    python_version_mismatches: list[PythonVersionMismatchEntry] = []
+    python_version_mismatch_error: str | None = None
+    notes: list[EnvironmentNote] = []
+
+
+def collect_known_installations() -> KnownInstallationsReport:
+    report = KnownInstallationsReport()
+
+    try:
+        for path in sorted(find_standard_installations()):
+            version = parse_version_from_ida_pro_py(path) or parse_version_from_dir_name(path) or None
+            report.installations.append(InstallationEntry(path=str(path), version=version))
+    except Exception as e:
+        report.error = str(e)
+
+    return report
+
+
+def collect_selected_installation() -> SelectedInstallationReport:
+    report = SelectedInstallationReport()
+
+    env_install_dir = os.environ.get("HCLI_CURRENT_IDA_INSTALL_DIR") or ENV.HCLI_CURRENT_IDA_INSTALL_DIR
+    if env_install_dir:
+        report.install_dir = str(env_install_dir)
+        report.install_dir_source = "$HCLI_CURRENT_IDA_INSTALL_DIR"
+    else:
+        config_path = get_ida_config_path()
+        try:
+            config = get_ida_config()
+            if config.paths.installation_directory:
+                report.install_dir = str(config.paths.installation_directory)
+                report.install_dir_source = str(config_path)
+            else:
+                report.install_dir_error = f"not configured in {config_path}"
+        except Exception as e:
+            report.install_dir_error = str(e)
+
+    try:
+        report.resolved_dir = str(find_current_ida_install_directory())
+    except MissingCurrentInstallationDirectory as e:
+        report.resolved_dir_error = str(e)
+
+    return report
+
+
+def collect_architecture_and_version(install_dir: Path) -> ArchitectureAndVersionReport:
+    report = ArchitectureAndVersionReport()
+
+    try:
+        ida_binary = find_current_ida_executable()
+        report.ida_binary = str(ida_binary)
+    except Exception as e:
+        report.ida_binary_error = str(e)
+    else:
+        try:
+            report.binary_arch = detect_binary_arch(ida_binary)
+        except Exception as e:
+            report.binary_arch_error = str(e)
+
+    try:
+        report.platform = find_current_ida_platform()
+    except Exception as e:
+        report.platform_error = str(e)
+
+    env_version = os.environ.get("HCLI_CURRENT_IDA_VERSION") or ENV.HCLI_CURRENT_IDA_VERSION
+    if env_version:
+        report.ida_version = env_version
+        report.ida_version_source = "$HCLI_CURRENT_IDA_VERSION"
+    else:
+        sdk_version = parse_version_from_ida_pro_py(install_dir)
+        dir_version = parse_version_from_dir_name(install_dir)
+        if sdk_version:
+            report.ida_version = sdk_version
+            report.ida_version_source = "python/ida_pro.py SDK docstring"
+        elif dir_version:
+            report.ida_version = dir_version
+            report.ida_version_source = "directory name"
+        else:
+            report.ida_version_error = "could not determine"
+
+    return report
+
+
+def collect_python_environment() -> PythonEnvironmentReport:
+    report = PythonEnvironmentReport()
+
+    process_virtual_env = os.environ.get("VIRTUAL_ENV")
+    report.virtual_env = process_virtual_env
+    report.virtual_env_is_uv_cache = process_virtual_env is not None and is_uv_cache_virtual_env(process_virtual_env)
+
+    user_venv = resolve_user_virtual_env()
+    report.user_virtual_env = str(user_venv) if user_venv else None
+
+    report.candidate_virtual_envs = [
+        CandidateVirtualEnv(path=str(candidate.path), source=candidate.source)
+        for candidate in find_candidate_virtual_envs()
+        if not is_uv_cache_virtual_env(candidate.path)
+    ]
+
+    idapython_venv_exe = os.environ.get("IDAPYTHON_VENV_EXECUTABLE") or ENV.IDAPYTHON_VENV_EXECUTABLE
+    if idapython_venv_exe:
+        report.idapython_venv_executable = str(idapython_venv_exe)
+        report.idapython_venv_executable_exists = Path(idapython_venv_exe).is_file()
+
+    env_python = os.environ.get("HCLI_CURRENT_IDA_PYTHON_EXE") or ENV.HCLI_CURRENT_IDA_PYTHON_EXE
+    if env_python:
+        # the interpreter is pinned, so there's nothing for idat to tell us.
+        report.python_exe = str(env_python)
+        report.python_exe_source = "$HCLI_CURRENT_IDA_PYTHON_EXE"
+        return report
+
+    if report.idapython_venv_executable and report.idapython_venv_executable_exists:
+        report.python_exe = report.idapython_venv_executable
+        report.python_exe_source = "$IDAPYTHON_VENV_EXECUTABLE"
+        return report
+
+    try:
+        info = run_py_in_current_idapython(GET_PYTHON_INFO_PY)
+        report.idat_probe = IdatProbe.model_validate(info)
+
+        try:
+            report.derived_exe = str(_derive_python_exe(info))
+        except PythonNotFoundError as e:
+            report.derived_exe_error = str(e)
+    except Exception as e:
+        report.idat_probe_error = f"{type(e).__name__}: {e}"
+
+    return report
+
+
+def collect_idapython_virtualenv(probe: IdatProbe | None) -> IdaPythonVirtualEnvReport | None:
+    ida_venv = probe.virtual_env if probe else None
+    if not ida_venv:
+        return None
+
+    venv_path = Path(ida_venv)
+    report = IdaPythonVirtualEnvReport(venv=str(venv_path))
+
+    pyvenv_cfg = venv_path / "pyvenv.cfg"
+    if pyvenv_cfg.is_file():
+        for line in pyvenv_cfg.read_text().splitlines():
+            if line.startswith("home"):
+                report.home = line.split("=", 1)[1].strip()
+            elif line.startswith("include-system-site-packages"):
+                report.system_site_packages = line.split("=", 1)[1].strip()
+
+    report.python_version = get_virtual_env_version(venv_path)
+
+    return report
+
+
+def collect_python_version() -> PythonVersionReport:
+    report = PythonVersionReport(
+        hcli_interpreter_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+        hcli_interpreter_path=sys.executable,
+    )
+
+    python_exe: Path | None = None
+    try:
+        python_exe = find_current_python_executable()
+        report.final_python_exe = str(python_exe)
+
+        result = subprocess.run(
+            [str(python_exe), "-c", PRINT_VERSION_PY],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+        report.probed_version = result.stdout.strip()
+    except Exception as e:
+        if python_exe is None:
+            report.final_python_exe_error = f"{type(e).__name__}: {e}"
+        else:
+            report.probed_version_error = f"{type(e).__name__}: {e}"
+
+    try:
+        report.final_version = detect_current_python_version()
+    except Exception as e:
+        report.final_version_error = f"{type(e).__name__}: {e}"
+
+    return report
+
+
+def collect_python_version_mismatches(
+    python_environment: PythonEnvironmentReport,
+    python_version: PythonVersionReport,
+) -> tuple[list[PythonVersionMismatchEntry], str | None]:
+    """Find Python environments whose version disagrees with IDA's embedded Python.
+
+    A virtualenv only redirects sys.path; it can't change the Python version IDA
+    runs, which idapyswitch fixed when it registered a libpython. So a venv built
+    for a different version silently can't provide packages to IDA.
+    """
+    probe = python_environment.idat_probe
+    if probe is None:
+        return [], None
+
+    final_python_exe = Path(python_version.final_python_exe) if python_version.final_python_exe else None
+
+    try:
+        mismatches = find_python_version_mismatches(probe.model_dump(), final_python_exe)
+    except Exception as e:
+        return [], f"{type(e).__name__}: {e}"
+
+    return [
+        PythonVersionMismatchEntry(
+            ida_version=mismatch.ida_version,
+            other_version=mismatch.other_version,
+            other_path=str(mismatch.other_path),
+            other_source=mismatch.other_source,
+        )
+        for mismatch in mismatches
+    ], None
+
+
+def collect_notes(
+    python_environment: PythonEnvironmentReport,
+    idapython_virtualenv: IdaPythonVirtualEnvReport | None,
+    python_version: PythonVersionReport,
+) -> list[EnvironmentNote]:
+    notes: list[EnvironmentNote] = []
+
+    process_virtual_env = python_environment.virtual_env
+    is_uv_cache = python_environment.virtual_env_is_uv_cache
+    user_venv = python_environment.user_virtual_env
+    is_hcli_own_venv = bool(process_virtual_env) and os.path.normcase(
+        os.path.abspath(process_virtual_env or "")
+    ) == os.path.normcase(os.path.abspath(sys.prefix))
+
+    if is_uv_cache and user_venv:
+        notes.append(
+            EnvironmentNote(
+                kind="diagnostic",
+                text=f"$VIRTUAL_ENV is a uv cache overlay. Resolved user virtualenv: {user_venv}",
+            )
+        )
+    elif is_uv_cache:
+        notes.append(
+            EnvironmentNote(
+                kind="diagnostic",
+                text=(
+                    "$VIRTUAL_ENV is a uv cache overlay, not your virtualenv. No user virtualenvs were found on $PATH."
+                ),
+            )
+        )
+    elif process_virtual_env and is_hcli_own_venv:
+        notes.append(
+            EnvironmentNote(
+                kind="diagnostic",
+                text=(
+                    f"$VIRTUAL_ENV ({process_virtual_env}) is the HCLI process environment, not the IDA Python "
+                    f"environment. It is not used for plugin installation."
+                ),
+            )
+        )
+    elif process_virtual_env and not idapython_virtualenv:
+        notes.append(
+            EnvironmentNote(
+                kind="diagnostic",
+                text=(
+                    f"$VIRTUAL_ENV is set ({process_virtual_env}) but was not detected inside IDA. "
+                    f"To use this virtualenv with IDA, activate it via idapythonrc.py."
+                ),
+            )
+        )
+
+    if not idapython_virtualenv:
+        notes.append(
+            EnvironmentNote(
+                kind="hint",
+                text=(
+                    "To use a virtualenv with IDA, see: "
+                    "https://community.hex-rays.com/t/using-a-virtualenv-for-idapython/261/5"
+                ),
+            )
+        )
+    if not user_venv and not is_uv_cache and not idapython_virtualenv:
+        notes.append(
+            EnvironmentNote(
+                kind="hint",
+                text="To change IDA's Python, use idapyswitch to point at a different interpreter.",
+            )
+        )
+
+    if python_version.final_version:
+        try:
+            parts = python_version.final_version.split(".")
+            major, minor = int(parts[0]), int(parts[1])
+            if (major, minor) <= (3, 9):
+                notes.append(
+                    EnvironmentNote(
+                        kind="warning",
+                        text=(
+                            f"Python {python_version.final_version} has reached end-of-life. "
+                            "Many IDA plugins may not support it. "
+                            "Consider upgrading to a newer Python and using idapyswitch to point IDA at it."
+                        ),
+                    )
+                )
+        except (ValueError, IndexError):
+            pass
+
+    return notes
+
+
+def collect_environment_report() -> EnvironmentReport:
+    report = EnvironmentReport(
+        known_installations=collect_known_installations(),
+        selected_installation=collect_selected_installation(),
+    )
+
+    if report.selected_installation.resolved_dir is None:
+        return report
+
+    report.architecture_and_version = collect_architecture_and_version(Path(report.selected_installation.resolved_dir))
+    report.python_environment = collect_python_environment()
+    report.idapython_virtualenv = collect_idapython_virtualenv(report.python_environment.idat_probe)
+    report.python_version = collect_python_version()
+    report.python_version_mismatches, report.python_version_mismatch_error = collect_python_version_mismatches(
+        report.python_environment, report.python_version
+    )
+    report.notes = collect_notes(report.python_environment, report.idapython_virtualenv, report.python_version)
+
+    return report
 
 
 def _path(p: object) -> str:
@@ -52,278 +484,216 @@ def _err(key: str, error: str) -> None:
     console.print(f"  [bold]{key}[/bold]: [red]{escape(error)}[/red]")
 
 
-@click.command()
-def explain_environment() -> None:
-    """Show how the current IDA installation and Python version are detected."""
-
-    # --- Known installations ---
-
+def render_known_installations_text(report: KnownInstallationsReport) -> None:
     console.print("[bold]Known IDA installations[/bold]")
-    try:
-        installations = find_standard_installations()
-        if installations:
-            for path in sorted(installations):
-                version = parse_version_from_ida_pro_py(path) or parse_version_from_dir_name(path) or "?"
-                console.print(f"  {_path(path)}  [dim](v{version})[/dim]")
-        else:
-            console.print("  [dim]none found[/dim]")
-    except Exception as e:
-        _err("scan", str(e))
 
-    console.print()
+    for installation in report.installations:
+        console.print(f"  {_path(installation.path)}  [dim](v{installation.version or '?'})[/dim]")
 
-    # --- Selected installation ---
+    if report.error:
+        _err("scan", report.error)
+    elif not report.installations:
+        console.print("  [dim]none found[/dim]")
 
+
+def render_selected_installation_text(report: SelectedInstallationReport) -> None:
     console.print("[bold]Selected installation[/bold]")
 
-    env_install_dir = os.environ.get("HCLI_CURRENT_IDA_INSTALL_DIR") or ENV.HCLI_CURRENT_IDA_INSTALL_DIR
-    if env_install_dir:
-        _kv("install dir", _path(env_install_dir), "$HCLI_CURRENT_IDA_INSTALL_DIR")
-    else:
-        config_path = get_ida_config_path()
-        try:
-            config = get_ida_config()
-            if config.paths.installation_directory:
-                _kv("install dir", _path(config.paths.installation_directory), str(config_path))
-            else:
-                _err("install dir", f"not configured in {config_path}")
-        except Exception as e:
-            _err("install dir", str(e))
+    if report.install_dir:
+        _kv("install dir", _path(report.install_dir), report.install_dir_source)
+    elif report.install_dir_error:
+        _err("install dir", report.install_dir_error)
 
-    try:
-        install_dir = find_current_ida_install_directory()
-        _kv("resolved dir", _path(install_dir))
-    except MissingCurrentInstallationDirectory as e:
-        _err("resolved dir", str(e))
-        console.print()
-        return
+    if report.resolved_dir:
+        _kv("resolved dir", _path(report.resolved_dir))
+    elif report.resolved_dir_error:
+        _err("resolved dir", report.resolved_dir_error)
 
-    console.print()
 
-    # --- Architecture and version ---
-
+def render_architecture_and_version_text(report: ArchitectureAndVersionReport) -> None:
     console.print("[bold]Architecture and version[/bold]")
 
-    try:
-        ida_binary = find_current_ida_executable()
-        _kv("ida binary", _path(ida_binary))
+    if report.ida_binary:
+        _kv("ida binary", _path(report.ida_binary))
+    if report.ida_binary_error:
+        _err("ida binary", report.ida_binary_error)
 
-        arch = detect_binary_arch(ida_binary)
-        _kv("binary arch", arch or "unknown", f"{escape(ida_binary.name)} binary header")
-    except Exception as e:
-        _err("ida binary", str(e))
+    if report.binary_arch_error:
+        _err("binary arch", report.binary_arch_error)
+    elif report.ida_binary:
+        ida_binary_name = escape(Path(report.ida_binary).name)
+        _kv("binary arch", report.binary_arch or "unknown", f"{ida_binary_name} binary header")
 
-    try:
-        platform = find_current_ida_platform()
-        _kv("platform", platform)
-    except Exception as e:
-        _err("platform", str(e))
+    if report.platform:
+        _kv("platform", report.platform)
+    elif report.platform_error:
+        _err("platform", report.platform_error)
 
-    env_version = os.environ.get("HCLI_CURRENT_IDA_VERSION") or ENV.HCLI_CURRENT_IDA_VERSION
-    if env_version:
-        _kv("ida version", env_version, "$HCLI_CURRENT_IDA_VERSION")
-    else:
-        sdk_version = parse_version_from_ida_pro_py(install_dir)
-        dir_version = parse_version_from_dir_name(install_dir)
-        if sdk_version:
-            _kv("ida version", sdk_version, "python/ida_pro.py SDK docstring")
-        elif dir_version:
-            _kv("ida version", dir_version, "directory name")
-        else:
-            _err("ida version", "could not determine")
+    if report.ida_version:
+        _kv("ida version", report.ida_version, report.ida_version_source)
+    elif report.ida_version_error:
+        _err("ida version", report.ida_version_error)
 
-    console.print()
 
-    # --- Python detection ---
-
+def render_python_environment_text(report: PythonEnvironmentReport) -> None:
     console.print("[bold]Python environment[/bold]")
 
-    process_virtual_env = os.environ.get("VIRTUAL_ENV")
-    is_uv_cache = process_virtual_env is not None and is_uv_cache_virtual_env(process_virtual_env)
-    if process_virtual_env and is_uv_cache:
-        _kv("$VIRTUAL_ENV", f"{_path(process_virtual_env)}  [dim](uv cache)[/dim]")
-    elif process_virtual_env:
-        _kv("$VIRTUAL_ENV", _path(process_virtual_env))
+    if report.virtual_env and report.virtual_env_is_uv_cache:
+        _kv("$VIRTUAL_ENV", f"{_path(report.virtual_env)}  [dim](uv cache)[/dim]")
+    elif report.virtual_env:
+        _kv("$VIRTUAL_ENV", _path(report.virtual_env))
     else:
         _kv("$VIRTUAL_ENV", "not set")
 
-    user_venv = resolve_user_virtual_env()
-    if user_venv:
-        _kv("user virtualenv", _path(user_venv), "resolved from $PATH")
+    if report.user_virtual_env:
+        _kv("user virtualenv", _path(report.user_virtual_env), "resolved from $PATH")
 
-    path_venvs = find_candidate_virtual_envs()
-    non_uv_candidates = [c for c in path_venvs if not is_uv_cache_virtual_env(c.path)]
-    if non_uv_candidates:
-        for candidate in non_uv_candidates:
-            _kv("  candidate venv", f"{_path(candidate.path)}  [dim](via {candidate.source})[/dim]")
+    for candidate in report.candidate_virtual_envs:
+        _kv("  candidate venv", f"{_path(candidate.path)}  [dim](via {candidate.source})[/dim]")
 
-    idapython_venv_exe = os.environ.get("IDAPYTHON_VENV_EXECUTABLE") or ENV.IDAPYTHON_VENV_EXECUTABLE
-    if idapython_venv_exe:
-        exists = Path(idapython_venv_exe).is_file()
-        if exists:
-            _kv("$IDAPYTHON_VENV_EXECUTABLE", _path(idapython_venv_exe))
+    if report.idapython_venv_executable:
+        if report.idapython_venv_executable_exists:
+            _kv("$IDAPYTHON_VENV_EXECUTABLE", _path(report.idapython_venv_executable))
         else:
-            _kv("$IDAPYTHON_VENV_EXECUTABLE", f"{_path(idapython_venv_exe)}  [red](not found)[/red]")
+            _kv("$IDAPYTHON_VENV_EXECUTABLE", f"{_path(report.idapython_venv_executable)}  [red](not found)[/red]")
     else:
         _kv("$IDAPYTHON_VENV_EXECUTABLE", "not set")
 
-    info: dict | None = None
-    env_python = os.environ.get("HCLI_CURRENT_IDA_PYTHON_EXE") or ENV.HCLI_CURRENT_IDA_PYTHON_EXE
-    if env_python:
-        _kv("python exe", _path(env_python), "$HCLI_CURRENT_IDA_PYTHON_EXE")
-    elif idapython_venv_exe and Path(idapython_venv_exe).is_file():
-        _kv("python exe", _path(idapython_venv_exe), "$IDAPYTHON_VENV_EXECUTABLE")
-    else:
-        _kv("HCLI_CURRENT_IDA_PYTHON_EXE", "not set")
+    if report.python_exe:
+        _kv("python exe", _path(report.python_exe), report.python_exe_source)
+        return
 
-        try:
-            info = run_py_in_current_idapython(GET_PYTHON_INFO_PY)
-            console.print("  [bold]idat probe[/bold]: [green]success[/green]")
-            _kv("  sys.prefix", _path(info["prefix"]))
-            _kv("  sys.base_prefix", _path(info["base_prefix"]))
-            _kv("  sys.executable", _path(info.get("executable")))
-            _kv("  $VIRTUAL_ENV", _path(info.get("virtual_env")))
-            _kv("  $IDAPYTHON_VENV_EXECUTABLE", _path(info.get("idapython_venv_executable")))
-            _kv("  sys.version_info", f"{info['version_major']}.{info['version_minor']}")
+    _kv("HCLI_CURRENT_IDA_PYTHON_EXE", "not set")
 
-            try:
-                derived = _derive_python_exe(info)
-                _kv("derived exe", _path(derived))
-            except PythonNotFoundError as e:
-                _err("derived exe", str(e))
+    if report.idat_probe_error:
+        _err("idat probe", report.idat_probe_error)
+        return
 
-        except Exception as e:
-            _err("idat probe", f"{type(e).__name__}: {e}")
+    probe = report.idat_probe
+    if probe is None:
+        return
 
-    console.print()
+    console.print("  [bold]idat probe[/bold]: [green]success[/green]")
+    _kv("  sys.prefix", _path(probe.prefix))
+    _kv("  sys.base_prefix", _path(probe.base_prefix))
+    _kv("  sys.executable", _path(probe.executable))
+    _kv("  $VIRTUAL_ENV", _path(probe.virtual_env))
+    _kv("  $IDAPYTHON_VENV_EXECUTABLE", _path(probe.idapython_venv_executable))
+    _kv("  sys.version_info", f"{probe.version_major}.{probe.version_minor}")
 
-    # --- IDAPython virtualenv ---
+    if report.derived_exe:
+        _kv("derived exe", _path(report.derived_exe))
+    elif report.derived_exe_error:
+        _err("derived exe", report.derived_exe_error)
 
+
+def render_idapython_virtualenv_text(report: IdaPythonVirtualEnvReport | None, ida_python_version: str | None) -> None:
     console.print("[bold]IDAPython virtualenv[/bold]")
 
-    ida_venv = info.get("virtual_env") if info else None
-
-    if ida_venv:
-        venv_path = Path(ida_venv)
-        _kv("venv", _path(venv_path), "activated by idapythonrc.py")
-        pyvenv_cfg = venv_path / "pyvenv.cfg"
-        if pyvenv_cfg.is_file():
-            for line in pyvenv_cfg.read_text().splitlines():
-                if line.startswith("home"):
-                    _kv("  home", line.split("=", 1)[1].strip())
-                elif line.startswith("include-system-site-packages"):
-                    _kv("  system site-packages", line.split("=", 1)[1].strip())
-
-        venv_version = get_virtual_env_version(venv_path)
-        if venv_version:
-            ida_python_version = f"{info['version_major']}.{info['version_minor']}" if info else None
-            style = "yellow" if ida_python_version and venv_version != ida_python_version else "green"
-            _kv("  python version", f"[{style}]{venv_version}[/{style}]")
-        else:
-            _err("  python version", "could not determine")
-    else:
+    if report is None:
         console.print("  [dim]none detected[/dim]")
+        return
 
-    console.print()
+    _kv("venv", _path(report.venv), "activated by idapythonrc.py")
+    if report.home is not None:
+        _kv("  home", report.home)
+    if report.system_site_packages is not None:
+        _kv("  system site-packages", report.system_site_packages)
 
-    # --- Final Python version ---
+    if report.python_version:
+        style = "yellow" if ida_python_version and report.python_version != ida_python_version else "green"
+        _kv("  python version", f"[{style}]{report.python_version}[/{style}]")
+    else:
+        _err("  python version", "could not determine")
 
+
+def render_python_version_text(report: PythonVersionReport) -> None:
     console.print("[bold]Python version[/bold]")
 
-    final_python_exe: Path | None = None
-    try:
-        final_python_exe = find_current_python_executable()
-        _kv("final python exe", _path(final_python_exe))
+    if report.final_python_exe:
+        _kv("final python exe", _path(report.final_python_exe))
 
-        result = subprocess.run(
-            [str(final_python_exe), "-c", PRINT_VERSION_PY],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=10,
-        )
-        _kv("probed version", result.stdout.strip(), f"running {escape(final_python_exe.name)}")
-    except Exception as e:
-        _err("probed version", f"{type(e).__name__}: {e}")
+    if report.probed_version:
+        exe_name = escape(Path(report.final_python_exe or "").name)
+        _kv("probed version", report.probed_version, f"running {exe_name}")
+    elif report.final_python_exe_error or report.probed_version_error:
+        _err("probed version", report.final_python_exe_error or report.probed_version_error or "")
 
-    interpreter_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    _kv("HCLI interpreter", interpreter_version, _path(sys.executable))
+    _kv("HCLI interpreter", report.hcli_interpreter_version, _path(report.hcli_interpreter_path))
 
-    try:
-        final = detect_current_python_version()
-        style = "green" if final != interpreter_version else "yellow"
-        _kv("final version", f"[{style}]{final}[/{style}]")
-    except Exception as e:
-        _err("final version", f"{type(e).__name__}: {e}")
+    if report.final_version:
+        style = "green" if report.final_version != report.hcli_interpreter_version else "yellow"
+        _kv("final version", f"[{style}]{report.final_version}[/{style}]")
+    elif report.final_version_error:
+        _err("final version", report.final_version_error)
 
-    console.print()
-    is_hcli_own_venv = process_virtual_env and os.path.normcase(
-        os.path.abspath(process_virtual_env)
-    ) == os.path.normcase(os.path.abspath(sys.prefix))
 
-    if is_uv_cache and user_venv:
-        console.print(
-            f"[dim]Note: $VIRTUAL_ENV is a uv cache overlay. Resolved user virtualenv: {escape(str(user_venv))}[/dim]",
-            highlight=False,
-        )
-        console.print()
-    elif is_uv_cache:
-        console.print(
-            "[dim]Note: $VIRTUAL_ENV is a uv cache overlay, not your virtualenv. "
-            "No user virtualenvs were found on $PATH.[/dim]",
-            highlight=False,
-        )
-        console.print()
-    elif process_virtual_env and is_hcli_own_venv:
-        console.print(
-            f"[dim]Note: $VIRTUAL_ENV ({escape(process_virtual_env)}) "
-            f"is the HCLI process environment, not the IDA Python environment. "
-            f"It is not used for plugin installation.[/dim]",
-            highlight=False,
-        )
-        console.print()
-    elif process_virtual_env and not ida_venv:
-        console.print(
-            f"[dim]Note: $VIRTUAL_ENV is set ({escape(process_virtual_env)}) "
-            f"but was not detected inside IDA. "
-            f"To use this virtualenv with IDA, activate it via idapythonrc.py.[/dim]",
-            highlight=False,
-        )
-        console.print()
+def render_python_version_mismatches_text(report: EnvironmentReport) -> None:
+    if report.python_version_mismatch_error:
+        _err("version mismatch check", report.python_version_mismatch_error)
 
-    if not ida_venv:
-        console.print(
-            "[dim]To use a virtualenv with IDA, see: "
-            "https://community.hex-rays.com/t/using-a-virtualenv-for-idapython/261/5[/dim]",
-            highlight=False,
-        )
-    if not user_venv and not is_uv_cache and not ida_venv:
-        console.print("[dim]To change IDA's Python, use idapyswitch to point at a different interpreter.[/dim]")
-
-    # A virtualenv only redirects sys.path; it can't change the Python version IDA
-    # runs, which idapyswitch fixed when it registered a libpython. So a venv built
-    # for a different version silently can't provide packages to IDA.
-    if info:
-        try:
-            mismatches = find_python_version_mismatches(info, final_python_exe)
-        except Exception as e:
-            mismatches = []
-            _err("version mismatch check", f"{type(e).__name__}: {e}")
-
-        if mismatches:
-            console.print()
-            console.print(format_python_version_mismatch_warning(mismatches), highlight=False)
-
-    try:
-        final_version = detect_current_python_version()
-        parts = final_version.split(".")
-        major, minor = int(parts[0]), int(parts[1])
-        if (major, minor) <= (3, 9):
-            console.print()
-            console.print(
-                f"[bold yellow]Warning:[/bold yellow] Python {final_version} has reached end-of-life. "
-                "Many IDA plugins may not support it. "
-                "Consider upgrading to a newer Python and using idapyswitch to point IDA at it.",
+    if report.python_version_mismatches:
+        mismatches = [
+            PythonVersionMismatch(
+                ida_version=entry.ida_version,
+                other_version=entry.other_version,
+                other_path=Path(entry.other_path),
+                other_source=entry.other_source,
             )
-    except Exception:
-        pass
+            for entry in report.python_version_mismatches
+        ]
+        console.print(format_python_version_mismatch_warning(mismatches), highlight=False)
+        console.print()
+
+
+def render_notes_text(notes: list[EnvironmentNote]) -> None:
+    for note in notes:
+        if note.kind == "warning":
+            console.print(f"[bold yellow]Warning:[/bold yellow] {escape(note.text)}", highlight=False)
+            console.print()
+        elif note.kind == "diagnostic":
+            console.print(f"[dim]Note: {escape(note.text)}[/dim]", highlight=False)
+            console.print()
+        else:
+            console.print(f"[dim]{escape(note.text)}[/dim]", highlight=False)
+
+
+def render_environment_report_text(report: EnvironmentReport) -> None:
+    render_known_installations_text(report.known_installations)
+    console.print()
+    render_selected_installation_text(report.selected_installation)
+    console.print()
+
+    if report.architecture_and_version is None or report.python_environment is None or report.python_version is None:
+        return
+
+    render_architecture_and_version_text(report.architecture_and_version)
+    console.print()
+    render_python_environment_text(report.python_environment)
+    console.print()
+
+    probe = report.python_environment.idat_probe
+    ida_python_version = f"{probe.version_major}.{probe.version_minor}" if probe else None
+    render_idapython_virtualenv_text(report.idapython_virtualenv, ida_python_version)
+    console.print()
+    render_python_version_text(report.python_version)
+    console.print()
+    render_notes_text([note for note in report.notes if note.kind != "warning"])
+    render_python_version_mismatches_text(report)
+    render_notes_text([note for note in report.notes if note.kind == "warning"])
+
+
+def render_environment_report_json(report: EnvironmentReport) -> None:
+    print_json(report.model_dump(mode="json"))
+
+
+@click.command()
+@click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
+def explain_environment(json_output: bool) -> None:
+    """Show how the current IDA installation and Python version are detected. (experimental)"""
+    report = collect_environment_report()
+
+    if json_output:
+        render_environment_report_json(report)
+    else:
+        render_environment_report_text(report)

--- a/src/hcli/commands/ida/python/explain_environment.py
+++ b/src/hcli/commands/ida/python/explain_environment.py
@@ -42,32 +42,32 @@ from hcli.lib.venv import find_candidate_virtual_envs, is_uv_cache_virtual_env, 
 
 class InstallationEntry(BaseModel):
     path: str
-    version: str | None = None
+    version: str | None
 
 
 class KnownInstallationsReport(BaseModel):
-    installations: list[InstallationEntry] = []
-    error: str | None = None
+    installations: list[InstallationEntry]
+    error: str | None
 
 
 class SelectedInstallationReport(BaseModel):
-    install_dir: str | None = None
-    install_dir_source: str | None = None
-    install_dir_error: str | None = None
-    resolved_dir: str | None = None
-    resolved_dir_error: str | None = None
+    install_dir: str | None
+    install_dir_source: str | None
+    install_dir_error: str | None
+    resolved_dir: str | None
+    resolved_dir_error: str | None
 
 
 class ArchitectureAndVersionReport(BaseModel):
-    ida_binary: str | None = None
-    ida_binary_error: str | None = None
-    binary_arch: str | None = None
-    binary_arch_error: str | None = None
-    platform: str | None = None
-    platform_error: str | None = None
-    ida_version: str | None = None
-    ida_version_source: str | None = None
-    ida_version_error: str | None = None
+    ida_binary: str | None
+    ida_binary_error: str | None
+    binary_arch: str | None
+    binary_arch_error: str | None
+    platform: str | None
+    platform_error: str | None
+    ida_version: str | None
+    ida_version_source: str | None
+    ida_version_error: str | None
 
 
 class CandidateVirtualEnv(BaseModel):
@@ -89,36 +89,36 @@ class IdatProbe(BaseModel):
 
 
 class PythonEnvironmentReport(BaseModel):
-    virtual_env: str | None = None
-    virtual_env_is_uv_cache: bool = False
-    user_virtual_env: str | None = None
-    candidate_virtual_envs: list[CandidateVirtualEnv] = []
-    idapython_venv_executable: str | None = None
-    idapython_venv_executable_exists: bool | None = None
-    python_exe: str | None = None
-    python_exe_source: str | None = None
-    idat_probe: IdatProbe | None = None
-    idat_probe_error: str | None = None
-    derived_exe: str | None = None
-    derived_exe_error: str | None = None
+    virtual_env: str | None
+    virtual_env_is_uv_cache: bool
+    user_virtual_env: str | None
+    candidate_virtual_envs: list[CandidateVirtualEnv]
+    idapython_venv_executable: str | None
+    idapython_venv_executable_exists: bool | None
+    python_exe: str | None
+    python_exe_source: str | None
+    idat_probe: IdatProbe | None
+    idat_probe_error: str | None
+    derived_exe: str | None
+    derived_exe_error: str | None
 
 
 class IdaPythonVirtualEnvReport(BaseModel):
     venv: str
-    home: str | None = None
-    system_site_packages: str | None = None
-    python_version: str | None = None
+    home: str | None
+    system_site_packages: str | None
+    python_version: str | None
 
 
 class PythonVersionReport(BaseModel):
-    final_python_exe: str | None = None
-    final_python_exe_error: str | None = None
-    probed_version: str | None = None
-    probed_version_error: str | None = None
+    final_python_exe: str | None
+    final_python_exe_error: str | None
+    probed_version: str | None
+    probed_version_error: str | None
     hcli_interpreter_version: str
     hcli_interpreter_path: str
-    final_version: str | None = None
-    final_version_error: str | None = None
+    final_version: str | None
+    final_version_error: str | None
 
 
 class PythonVersionMismatchEntry(BaseModel):
@@ -138,138 +138,179 @@ class EnvironmentReport(BaseModel):
     known_installations: KnownInstallationsReport
     selected_installation: SelectedInstallationReport
     # the sections below need an installation directory, so they're absent when it can't be resolved.
-    architecture_and_version: ArchitectureAndVersionReport | None = None
-    python_environment: PythonEnvironmentReport | None = None
-    idapython_virtualenv: IdaPythonVirtualEnvReport | None = None
-    python_version: PythonVersionReport | None = None
-    python_version_mismatches: list[PythonVersionMismatchEntry] = []
-    python_version_mismatch_error: str | None = None
-    notes: list[EnvironmentNote] = []
+    architecture_and_version: ArchitectureAndVersionReport | None
+    python_environment: PythonEnvironmentReport | None
+    idapython_virtualenv: IdaPythonVirtualEnvReport | None
+    python_version: PythonVersionReport | None
+    python_version_mismatches: list[PythonVersionMismatchEntry]
+    python_version_mismatch_error: str | None
+    notes: list[EnvironmentNote]
 
 
 def collect_known_installations() -> KnownInstallationsReport:
-    report = KnownInstallationsReport()
+    installations: list[InstallationEntry] = []
+    error: str | None = None
 
     try:
         for path in sorted(find_standard_installations()):
             version = parse_version_from_ida_pro_py(path) or parse_version_from_dir_name(path) or None
-            report.installations.append(InstallationEntry(path=str(path), version=version))
+            installations.append(InstallationEntry(path=str(path), version=version))
     except Exception as e:
-        report.error = str(e)
+        error = str(e)
 
-    return report
+    return KnownInstallationsReport(installations=installations, error=error)
 
 
 def collect_selected_installation() -> SelectedInstallationReport:
-    report = SelectedInstallationReport()
+    install_dir: str | None = None
+    install_dir_source: str | None = None
+    install_dir_error: str | None = None
 
     env_install_dir = os.environ.get("HCLI_CURRENT_IDA_INSTALL_DIR") or ENV.HCLI_CURRENT_IDA_INSTALL_DIR
     if env_install_dir:
-        report.install_dir = str(env_install_dir)
-        report.install_dir_source = "$HCLI_CURRENT_IDA_INSTALL_DIR"
+        install_dir = str(env_install_dir)
+        install_dir_source = "$HCLI_CURRENT_IDA_INSTALL_DIR"
     else:
         config_path = get_ida_config_path()
         try:
             config = get_ida_config()
             if config.paths.installation_directory:
-                report.install_dir = str(config.paths.installation_directory)
-                report.install_dir_source = str(config_path)
+                install_dir = str(config.paths.installation_directory)
+                install_dir_source = str(config_path)
             else:
-                report.install_dir_error = f"not configured in {config_path}"
+                install_dir_error = f"not configured in {config_path}"
         except Exception as e:
-            report.install_dir_error = str(e)
+            install_dir_error = str(e)
 
+    resolved_dir: str | None = None
+    resolved_dir_error: str | None = None
     try:
-        report.resolved_dir = str(find_current_ida_install_directory())
+        resolved_dir = str(find_current_ida_install_directory())
     except MissingCurrentInstallationDirectory as e:
-        report.resolved_dir_error = str(e)
+        resolved_dir_error = str(e)
 
-    return report
+    return SelectedInstallationReport(
+        install_dir=install_dir,
+        install_dir_source=install_dir_source,
+        install_dir_error=install_dir_error,
+        resolved_dir=resolved_dir,
+        resolved_dir_error=resolved_dir_error,
+    )
 
 
 def collect_architecture_and_version(install_dir: Path) -> ArchitectureAndVersionReport:
-    report = ArchitectureAndVersionReport()
+    ida_binary: str | None = None
+    ida_binary_error: str | None = None
+    binary_arch: str | None = None
+    binary_arch_error: str | None = None
 
     try:
-        ida_binary = find_current_ida_executable()
-        report.ida_binary = str(ida_binary)
+        ida_binary_path = find_current_ida_executable()
+        ida_binary = str(ida_binary_path)
     except Exception as e:
-        report.ida_binary_error = str(e)
+        ida_binary_error = str(e)
     else:
         try:
-            report.binary_arch = detect_binary_arch(ida_binary)
+            binary_arch = detect_binary_arch(ida_binary_path)
         except Exception as e:
-            report.binary_arch_error = str(e)
+            binary_arch_error = str(e)
 
+    platform: str | None = None
+    platform_error: str | None = None
     try:
-        report.platform = find_current_ida_platform()
+        platform = find_current_ida_platform()
     except Exception as e:
-        report.platform_error = str(e)
+        platform_error = str(e)
+
+    ida_version: str | None = None
+    ida_version_source: str | None = None
+    ida_version_error: str | None = None
 
     env_version = os.environ.get("HCLI_CURRENT_IDA_VERSION") or ENV.HCLI_CURRENT_IDA_VERSION
     if env_version:
-        report.ida_version = env_version
-        report.ida_version_source = "$HCLI_CURRENT_IDA_VERSION"
+        ida_version = env_version
+        ida_version_source = "$HCLI_CURRENT_IDA_VERSION"
     else:
         sdk_version = parse_version_from_ida_pro_py(install_dir)
         dir_version = parse_version_from_dir_name(install_dir)
         if sdk_version:
-            report.ida_version = sdk_version
-            report.ida_version_source = "python/ida_pro.py SDK docstring"
+            ida_version = sdk_version
+            ida_version_source = "python/ida_pro.py SDK docstring"
         elif dir_version:
-            report.ida_version = dir_version
-            report.ida_version_source = "directory name"
+            ida_version = dir_version
+            ida_version_source = "directory name"
         else:
-            report.ida_version_error = "could not determine"
+            ida_version_error = "could not determine"
 
-    return report
+    return ArchitectureAndVersionReport(
+        ida_binary=ida_binary,
+        ida_binary_error=ida_binary_error,
+        binary_arch=binary_arch,
+        binary_arch_error=binary_arch_error,
+        platform=platform,
+        platform_error=platform_error,
+        ida_version=ida_version,
+        ida_version_source=ida_version_source,
+        ida_version_error=ida_version_error,
+    )
 
 
 def collect_python_environment() -> PythonEnvironmentReport:
-    report = PythonEnvironmentReport()
-
     process_virtual_env = os.environ.get("VIRTUAL_ENV")
-    report.virtual_env = process_virtual_env
-    report.virtual_env_is_uv_cache = process_virtual_env is not None and is_uv_cache_virtual_env(process_virtual_env)
 
     user_venv = resolve_user_virtual_env()
-    report.user_virtual_env = str(user_venv) if user_venv else None
 
-    report.candidate_virtual_envs = [
+    candidate_virtual_envs = [
         CandidateVirtualEnv(path=str(candidate.path), source=candidate.source)
         for candidate in find_candidate_virtual_envs()
         if not is_uv_cache_virtual_env(candidate.path)
     ]
 
     idapython_venv_exe = os.environ.get("IDAPYTHON_VENV_EXECUTABLE") or ENV.IDAPYTHON_VENV_EXECUTABLE
-    if idapython_venv_exe:
-        report.idapython_venv_executable = str(idapython_venv_exe)
-        report.idapython_venv_executable_exists = Path(idapython_venv_exe).is_file()
+    idapython_venv_executable = str(idapython_venv_exe) if idapython_venv_exe else None
+    idapython_venv_executable_exists = Path(idapython_venv_exe).is_file() if idapython_venv_exe else None
+
+    python_exe: str | None = None
+    python_exe_source: str | None = None
+    idat_probe: IdatProbe | None = None
+    idat_probe_error: str | None = None
+    derived_exe: str | None = None
+    derived_exe_error: str | None = None
 
     env_python = os.environ.get("HCLI_CURRENT_IDA_PYTHON_EXE") or ENV.HCLI_CURRENT_IDA_PYTHON_EXE
     if env_python:
         # the interpreter is pinned, so there's nothing for idat to tell us.
-        report.python_exe = str(env_python)
-        report.python_exe_source = "$HCLI_CURRENT_IDA_PYTHON_EXE"
-        return report
-
-    if report.idapython_venv_executable and report.idapython_venv_executable_exists:
-        report.python_exe = report.idapython_venv_executable
-        report.python_exe_source = "$IDAPYTHON_VENV_EXECUTABLE"
-        return report
-
-    try:
-        info = run_py_in_current_idapython(GET_PYTHON_INFO_PY)
-        report.idat_probe = IdatProbe.model_validate(info)
-
+        python_exe = str(env_python)
+        python_exe_source = "$HCLI_CURRENT_IDA_PYTHON_EXE"
+    elif idapython_venv_executable and idapython_venv_executable_exists:
+        python_exe = idapython_venv_executable
+        python_exe_source = "$IDAPYTHON_VENV_EXECUTABLE"
+    else:
         try:
-            report.derived_exe = str(_derive_python_exe(info))
-        except PythonNotFoundError as e:
-            report.derived_exe_error = str(e)
-    except Exception as e:
-        report.idat_probe_error = f"{type(e).__name__}: {e}"
+            info = run_py_in_current_idapython(GET_PYTHON_INFO_PY)
+            idat_probe = IdatProbe.model_validate(info)
 
-    return report
+            try:
+                derived_exe = str(_derive_python_exe(info))
+            except PythonNotFoundError as e:
+                derived_exe_error = str(e)
+        except Exception as e:
+            idat_probe_error = f"{type(e).__name__}: {e}"
+
+    return PythonEnvironmentReport(
+        virtual_env=process_virtual_env,
+        virtual_env_is_uv_cache=process_virtual_env is not None and is_uv_cache_virtual_env(process_virtual_env),
+        user_virtual_env=str(user_venv) if user_venv else None,
+        candidate_virtual_envs=candidate_virtual_envs,
+        idapython_venv_executable=idapython_venv_executable,
+        idapython_venv_executable_exists=idapython_venv_executable_exists,
+        python_exe=python_exe,
+        python_exe_source=python_exe_source,
+        idat_probe=idat_probe,
+        idat_probe_error=idat_probe_error,
+        derived_exe=derived_exe,
+        derived_exe_error=derived_exe_error,
+    )
 
 
 def collect_idapython_virtualenv(probe: IdatProbe | None) -> IdaPythonVirtualEnvReport | None:
@@ -278,31 +319,35 @@ def collect_idapython_virtualenv(probe: IdatProbe | None) -> IdaPythonVirtualEnv
         return None
 
     venv_path = Path(ida_venv)
-    report = IdaPythonVirtualEnvReport(venv=str(venv_path))
 
+    home: str | None = None
+    system_site_packages: str | None = None
     pyvenv_cfg = venv_path / "pyvenv.cfg"
     if pyvenv_cfg.is_file():
         for line in pyvenv_cfg.read_text().splitlines():
             if line.startswith("home"):
-                report.home = line.split("=", 1)[1].strip()
+                home = line.split("=", 1)[1].strip()
             elif line.startswith("include-system-site-packages"):
-                report.system_site_packages = line.split("=", 1)[1].strip()
+                system_site_packages = line.split("=", 1)[1].strip()
 
-    report.python_version = get_virtual_env_version(venv_path)
-
-    return report
+    return IdaPythonVirtualEnvReport(
+        venv=str(venv_path),
+        home=home,
+        system_site_packages=system_site_packages,
+        python_version=get_virtual_env_version(venv_path),
+    )
 
 
 def collect_python_version() -> PythonVersionReport:
-    report = PythonVersionReport(
-        hcli_interpreter_version=f"{sys.version_info.major}.{sys.version_info.minor}",
-        hcli_interpreter_path=sys.executable,
-    )
+    final_python_exe: str | None = None
+    final_python_exe_error: str | None = None
+    probed_version: str | None = None
+    probed_version_error: str | None = None
 
     python_exe: Path | None = None
     try:
         python_exe = find_current_python_executable()
-        report.final_python_exe = str(python_exe)
+        final_python_exe = str(python_exe)
 
         result = subprocess.run(
             [str(python_exe), "-c", PRINT_VERSION_PY],
@@ -311,19 +356,30 @@ def collect_python_version() -> PythonVersionReport:
             check=True,
             timeout=10,
         )
-        report.probed_version = result.stdout.strip()
+        probed_version = result.stdout.strip()
     except Exception as e:
         if python_exe is None:
-            report.final_python_exe_error = f"{type(e).__name__}: {e}"
+            final_python_exe_error = f"{type(e).__name__}: {e}"
         else:
-            report.probed_version_error = f"{type(e).__name__}: {e}"
+            probed_version_error = f"{type(e).__name__}: {e}"
 
+    final_version: str | None = None
+    final_version_error: str | None = None
     try:
-        report.final_version = detect_current_python_version()
+        final_version = detect_current_python_version()
     except Exception as e:
-        report.final_version_error = f"{type(e).__name__}: {e}"
+        final_version_error = f"{type(e).__name__}: {e}"
 
-    return report
+    return PythonVersionReport(
+        final_python_exe=final_python_exe,
+        final_python_exe_error=final_python_exe_error,
+        probed_version=probed_version,
+        probed_version_error=probed_version_error,
+        hcli_interpreter_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+        hcli_interpreter_path=sys.executable,
+        final_version=final_version,
+        final_version_error=final_version_error,
+    )
 
 
 def collect_python_version_mismatches(
@@ -449,24 +505,42 @@ def collect_notes(
 
 
 def collect_environment_report() -> EnvironmentReport:
-    report = EnvironmentReport(
-        known_installations=collect_known_installations(),
-        selected_installation=collect_selected_installation(),
+    known_installations = collect_known_installations()
+    selected_installation = collect_selected_installation()
+
+    if selected_installation.resolved_dir is None:
+        return EnvironmentReport(
+            known_installations=known_installations,
+            selected_installation=selected_installation,
+            architecture_and_version=None,
+            python_environment=None,
+            idapython_virtualenv=None,
+            python_version=None,
+            python_version_mismatches=[],
+            python_version_mismatch_error=None,
+            notes=[],
+        )
+
+    architecture_and_version = collect_architecture_and_version(Path(selected_installation.resolved_dir))
+    python_environment = collect_python_environment()
+    idapython_virtualenv = collect_idapython_virtualenv(python_environment.idat_probe)
+    python_version = collect_python_version()
+    python_version_mismatches, python_version_mismatch_error = collect_python_version_mismatches(
+        python_environment, python_version
     )
+    notes = collect_notes(python_environment, idapython_virtualenv, python_version)
 
-    if report.selected_installation.resolved_dir is None:
-        return report
-
-    report.architecture_and_version = collect_architecture_and_version(Path(report.selected_installation.resolved_dir))
-    report.python_environment = collect_python_environment()
-    report.idapython_virtualenv = collect_idapython_virtualenv(report.python_environment.idat_probe)
-    report.python_version = collect_python_version()
-    report.python_version_mismatches, report.python_version_mismatch_error = collect_python_version_mismatches(
-        report.python_environment, report.python_version
+    return EnvironmentReport(
+        known_installations=known_installations,
+        selected_installation=selected_installation,
+        architecture_and_version=architecture_and_version,
+        python_environment=python_environment,
+        idapython_virtualenv=idapython_virtualenv,
+        python_version=python_version,
+        python_version_mismatches=python_version_mismatches,
+        python_version_mismatch_error=python_version_mismatch_error,
+        notes=notes,
     )
-    report.notes = collect_notes(report.python_environment, report.idapython_virtualenv, report.python_version)
-
-    return report
 
 
 def _path(p: object) -> str:

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -169,8 +169,11 @@ plugin.add_command(get_plugin_status, name="status")
 
 
 @click.command(name="list", hidden=True)
+@click.argument("plugins", nargs=-1)
+@click.option("--skip-upgrade-check", is_flag=True, default=False)
+@click.option("--json", "json_output", is_flag=True, default=False)
 @click.pass_context
-def _plugin_status_alias(ctx) -> None:
+def _plugin_status_alias(ctx, plugins: tuple[str, ...], skip_upgrade_check: bool, json_output: bool) -> None:
     """Show installed plugins and their upgrade status (alias for 'status')."""
     ctx.forward(get_plugin_status)
 
@@ -189,8 +192,9 @@ plugin.add_command(bundle, name="bundle")
 
 # Backwards-compat alias. Remove after 0.20.
 @click.command(name="explain-environment", hidden=True)
+@click.option("--json", "json_output", is_flag=True, default=False)
 @click.pass_context
-def _explain_environment_alias(ctx) -> None:
+def _explain_environment_alias(ctx, json_output: bool) -> None:
     """Show how the current IDA installation and Python version are detected.
 
     Moved to `hcli ida python explain-environment`.

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from typing import Any
 
 import rich.table
 import rich_click as click
 import semantic_version
+from pydantic import BaseModel
 
-from hcli.lib.console import console
+from hcli.lib.console import console, print_json
 from hcli.lib.ida import (
     FailedToDetectIDAVersion,
     MissingCurrentInstallationDirectory,
@@ -21,6 +23,7 @@ from hcli.lib.ida import (
 from hcli.lib.ida.plugin import (
     ALL_IDA_VERSIONS,
     ALL_PLATFORMS,
+    IDAMetadataDescriptor,
     IdaVersion,
     Platform,
     parse_ida_version,
@@ -36,6 +39,7 @@ from hcli.lib.ida.plugin.reference import (
 from hcli.lib.ida.plugin.repo import (
     BasePluginRepo,
     Plugin,
+    PluginArchiveLocation,
     get_latest_compatible_plugin_metadata,
     get_latest_plugin_metadata,
     get_plugin_by_name,
@@ -44,6 +48,57 @@ from hcli.lib.ida.plugin.repo import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class VersionEntry(BaseModel):
+    version: str
+    compatible: bool
+    currently_installed: bool
+    upgradable: bool
+
+
+class DownloadLocationEntry(BaseModel):
+    ida_versions: str
+    platforms: str
+    url: str
+
+
+class PluginNameQueryResult(BaseModel):
+    plugin: dict[str, Any]
+    installed_version: str | None
+    versions: list[VersionEntry]
+
+
+class PluginExactVersionQueryResult(BaseModel):
+    plugin: dict[str, Any]
+    download_locations: list[DownloadLocationEntry]
+
+
+class PluginVersionRangeQueryResult(BaseModel):
+    plugin: dict[str, Any]
+    installed_version: str | None
+    versions: list[VersionEntry]
+
+
+class KeywordMatchEntry(BaseModel):
+    name: str
+    version: str
+    repository: str | None
+    compatible: bool
+    installed: bool
+    installed_version: str | None
+    upgradable: bool
+
+
+class KeywordQueryResult(BaseModel):
+    query: str | None
+    results: list[KeywordMatchEntry]
+
+
+class AmbiguityErrorResult(BaseModel):
+    error: str
+    name: str
+    candidates: list[str]
 
 
 def does_plugin_match_query(query: str, plugin: Plugin) -> bool:
@@ -98,7 +153,15 @@ def find_installed_matching(
     return find_installed_plugin_in(installed_records, plugin.name, host=plugin.host)
 
 
-def render_ambiguity_error(err: AmbiguousPluginReferenceError) -> None:
+def collect_ambiguity_error(err: AmbiguousPluginReferenceError) -> AmbiguityErrorResult:
+    return AmbiguityErrorResult(
+        error="ambiguous plugin reference",
+        name=err.name,
+        candidates=[format_qualified_plugin_reference(ref) for ref in err.candidate_refs],
+    )
+
+
+def render_ambiguity_error_text(err: AmbiguousPluginReferenceError) -> None:
     """Render the user-facing message for an ambiguous bare-name query."""
     console.print(f"[red]Error[/red]: plugin name '{err.name}' is ambiguous")
     console.print("Choose one of:")
@@ -106,50 +169,81 @@ def render_ambiguity_error(err: AmbiguousPluginReferenceError) -> None:
         console.print(f"  {format_qualified_plugin_reference(ref)}")
 
 
-def output_plugin_metadata(metadata) -> None:
-    metadata_dict = metadata.plugin.model_dump()
+def collect_plugin_metadata(metadata: IDAMetadataDescriptor) -> dict[str, Any]:
+    metadata_dict = metadata.plugin.model_dump(mode="json")
     del metadata_dict["platforms"]
     metadata_dict["idaVersions"] = render_ida_versions(metadata_dict["idaVersions"])
+    return metadata_dict
 
-    for key, value in sorted(metadata_dict.items()):
+
+def render_plugin_metadata_text(plugin: dict[str, Any]) -> None:
+    for key, value in sorted(plugin.items()):
         console.print(f"{key}: {value}")
     console.print()
 
 
-def output_plugin_versions_table(
+def collect_version_entries(
     plugin: Plugin,
     versions: Sequence[str],
     current_version: str,
     current_platform: str,
-    title: str,
     installed_records: list[InstalledPluginRecord],
-) -> None:
-    table = rich.table.Table(show_header=False, box=None)
-    table.add_column("version", style="default")
-    table.add_column("status")
+) -> tuple[list[VersionEntry], str | None]:
+    """Build per-version compatibility/install status entries for `plugin`.
 
+    Returns (entries, installed_version), where installed_version is the
+    version string currently installed, or None if this specific repository
+    plugin (name+host) isn't installed.
+    """
     installed_record = find_installed_matching(plugin, installed_records)
     existing_version = None
     if installed_record is not None:
         existing_version = parse_plugin_version(installed_record.version)
 
+    entries: list[VersionEntry] = []
     for version in versions:
         locations = plugin.versions[version]
         metadata = locations[0].metadata
         is_compatible = is_compatible_plugin_version(plugin, version, locations, current_platform, current_version)
 
-        status = ""
+        currently_installed = False
+        upgradable = False
         if installed_record is not None and existing_version is not None:
             if parse_plugin_version(metadata.plugin.version) == existing_version:
-                status = "[green]currently installed[/green]"
-
+                currently_installed = True
             if parse_plugin_version(metadata.plugin.version) > existing_version and is_compatible:
-                status = f"[yellow]upgradable[/yellow] from {existing_version}"
+                upgradable = True
 
-        elif not is_compatible:
+        entries.append(
+            VersionEntry(
+                version=version,
+                compatible=is_compatible,
+                currently_installed=currently_installed,
+                upgradable=upgradable,
+            )
+        )
+
+    return entries, (installed_record.version if installed_record is not None else None)
+
+
+def render_plugin_versions_text(entries: list[VersionEntry], installed_version: str | None, title: str) -> None:
+    table = rich.table.Table(show_header=False, box=None)
+    table.add_column("version", style="default")
+    table.add_column("status")
+
+    for entry in entries:
+        status = ""
+        # An installed version takes precedence: never show "incompatible" for
+        # an old/uninstalled version once something is installed, mirroring
+        # what a user cares about (their own upgrade path, not every release).
+        if installed_version is not None:
+            if entry.currently_installed:
+                status = "[green]currently installed[/green]"
+            elif entry.upgradable:
+                status = f"[yellow]upgradable[/yellow] from {installed_version}"
+        elif not entry.compatible:
             status = "[grey69]incompatible[/grey69]"
-
-        table.add_row(version, status)
+        table.add_row(entry.version, status)
 
     console.print(title)
     console.print(table)
@@ -164,26 +258,34 @@ def get_matching_versions(plugin: Plugin, version_spec: str) -> list[str]:
     ]
 
 
-def handle_plugin_name_query(
+def get_all_versions_newest_first(plugin: Plugin) -> list[str]:
+    return [
+        version
+        for version, _ in sorted(plugin.versions.items(), key=lambda p: parse_plugin_version(p[0]), reverse=True)
+    ]
+
+
+def collect_plugin_name_query_result(
     plugins: list[Plugin],
     ref: PluginReference,
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-):
+) -> PluginNameQueryResult:
     plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
-    output_plugin_metadata(get_latest_plugin_metadata(plugin))
-    output_plugin_versions_table(
-        plugin,
-        [
-            version
-            for version, _ in sorted(plugin.versions.items(), key=lambda p: parse_plugin_version(p[0]), reverse=True)
-        ],
-        current_version,
-        current_platform,
-        "available versions:",
-        installed_records,
+    entries, installed_version = collect_version_entries(
+        plugin, get_all_versions_newest_first(plugin), current_version, current_platform, installed_records
     )
+    return PluginNameQueryResult(
+        plugin=collect_plugin_metadata(get_latest_plugin_metadata(plugin)),
+        installed_version=installed_version,
+        versions=entries,
+    )
+
+
+def render_plugin_name_query_text(result: PluginNameQueryResult) -> None:
+    render_plugin_metadata_text(result.plugin)
+    render_plugin_versions_text(result.versions, result.installed_version, "available versions:")
 
 
 def render_ida_versions(versions: Sequence[IdaVersion]) -> str:
@@ -206,23 +308,41 @@ def render_platforms(platforms: Sequence[Platform]) -> str:
     return ", ".join(sorted(platforms))
 
 
-def handle_plugin_exact_version_query(plugin: Plugin, version: str):
+def collect_download_locations(locations: list[PluginArchiveLocation]) -> list[DownloadLocationEntry]:
+    return [
+        DownloadLocationEntry(
+            ida_versions=render_ida_versions(location.metadata.plugin.ida_versions),
+            platforms=render_platforms(location.metadata.plugin.platforms),
+            url=location.url,
+        )
+        for location in locations
+    ]
+
+
+def collect_plugin_exact_version_query_result(plugin: Plugin, version: str) -> PluginExactVersionQueryResult:
     if version not in plugin.versions:
         raise KeyError(f"version {version} not found for plugin {plugin.name}")
 
     locations = plugin.versions[version]
     metadata = locations[0].metadata
-    output_plugin_metadata(metadata)
+    return PluginExactVersionQueryResult(
+        plugin=collect_plugin_metadata(metadata),
+        download_locations=collect_download_locations(locations),
+    )
+
+
+def render_plugin_exact_version_query_text(result: PluginExactVersionQueryResult) -> None:
+    render_plugin_metadata_text(result.plugin)
 
     table = rich.table.Table(show_header=False, box=None)
     table.add_column("IDA version spec", style="default")
     table.add_column("IDA platforms", style="default")
     table.add_column("URL")
 
-    for location in locations:
+    for location in result.download_locations:
         table.add_row(
-            "IDA: " + render_ida_versions(location.metadata.plugin.ida_versions),
-            "platforms: " + render_platforms(location.metadata.plugin.platforms),
+            "IDA: " + location.ida_versions,
+            "platforms: " + location.platforms,
             "URL: " + location.url,
         )
 
@@ -230,103 +350,153 @@ def handle_plugin_exact_version_query(plugin: Plugin, version: str):
     console.print(table)
 
 
-def handle_plugin_version_range_query(
+def collect_plugin_version_range_query_result(
     plugin: Plugin,
     ref: PluginReference,
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-):
+) -> PluginVersionRangeQueryResult:
     matching_versions = get_matching_versions(plugin, ref.version_spec)
     if not matching_versions:
         raise KeyError(f"no versions matching {ref.version_spec!r} found for plugin {plugin.name!r}")
 
-    output_plugin_metadata(plugin.versions[matching_versions[0]][0].metadata)
-    output_plugin_versions_table(
-        plugin, matching_versions, current_version, current_platform, "matching versions:", installed_records
+    entries, installed_version = collect_version_entries(
+        plugin, matching_versions, current_version, current_platform, installed_records
+    )
+    return PluginVersionRangeQueryResult(
+        plugin=collect_plugin_metadata(plugin.versions[matching_versions[0]][0].metadata),
+        installed_version=installed_version,
+        versions=entries,
     )
 
 
-def handle_plugin_spec_query(
+def render_plugin_version_range_query_text(result: PluginVersionRangeQueryResult) -> None:
+    render_plugin_metadata_text(result.plugin)
+    render_plugin_versions_text(result.versions, result.installed_version, "matching versions:")
+
+
+def collect_plugin_spec_query_result(
     plugins: list[Plugin],
     ref: PluginReference,
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-):
+) -> PluginExactVersionQueryResult | PluginVersionRangeQueryResult:
     plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
 
     if ref.version_spec.startswith("=="):
         version = ref.version_spec[2:]
         if not version:
             raise ValueError(f"invalid plugin version: {ref.version_spec!r}")
-        handle_plugin_exact_version_query(plugin, version)
-        return
+        return collect_plugin_exact_version_query_result(plugin, version)
 
-    handle_plugin_version_range_query(plugin, ref, current_version, current_platform, installed_records)
+    return collect_plugin_version_range_query_result(plugin, ref, current_version, current_platform, installed_records)
 
 
-def handle_keyword_query(
+def render_plugin_spec_query_text(result: PluginExactVersionQueryResult | PluginVersionRangeQueryResult) -> None:
+    if isinstance(result, PluginExactVersionQueryResult):
+        render_plugin_exact_version_query_text(result)
+    else:
+        render_plugin_version_range_query_text(result)
+
+
+def collect_keyword_matches(
     plugins: list[Plugin],
     query: str,
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
-):
-    table = rich.table.Table(show_header=False, box=None)
-    table.add_column("name", style="blue")
-    table.add_column("version", style="default")
-    table.add_column("status")
-    table.add_column("repo", style="grey69")
-    has_matches = False
+) -> list[KeywordMatchEntry]:
+    matches: list[KeywordMatchEntry] = []
 
     for plugin in sorted(plugins, key=lambda p: p.name.lower()):
         if not does_plugin_match_query(query or "", plugin):
             continue
 
-        has_matches = True
         latest_metadata = get_latest_plugin_metadata(plugin)
 
         if not is_compatible_plugin(plugin, current_platform, current_version):
-            table.add_row(
-                f"[grey69]{latest_metadata.plugin.name} (incompatible)[/grey69]",
-                f"[grey69]{latest_metadata.plugin.version}[/grey69]",
-                "",
-                latest_metadata.plugin.urls.repository,
+            matches.append(
+                KeywordMatchEntry(
+                    name=latest_metadata.plugin.name,
+                    version=latest_metadata.plugin.version,
+                    repository=latest_metadata.plugin.urls.repository,
+                    compatible=False,
+                    installed=False,
+                    installed_version=None,
+                    upgradable=False,
+                )
             )
+            continue
 
-        else:
-            latest_compatible_metadata = get_latest_compatible_plugin_metadata(
-                plugin, current_platform, current_version
+        latest_compatible_metadata = get_latest_compatible_plugin_metadata(plugin, current_platform, current_version)
+        installed_record = find_installed_matching(plugin, installed_records)
+        installed_version = installed_record.version if installed_record is not None else None
+        upgradable = installed_version is not None and parse_plugin_version(
+            latest_compatible_metadata.plugin.version
+        ) > parse_plugin_version(installed_version)
+
+        matches.append(
+            KeywordMatchEntry(
+                name=latest_metadata.plugin.name,
+                version=latest_metadata.plugin.version,
+                repository=latest_metadata.plugin.urls.repository,
+                compatible=True,
+                installed=installed_record is not None,
+                installed_version=installed_version,
+                upgradable=upgradable,
             )
+        )
 
-            installed_record = find_installed_matching(plugin, installed_records)
-            is_upgradable = False
-            existing_version: str | None = None
-            if installed_record is not None:
-                existing_version = installed_record.version
-                if parse_plugin_version(latest_compatible_metadata.plugin.version) > parse_plugin_version(
-                    existing_version
-                ):
-                    is_upgradable = True
+    return matches
 
-            status = ""
-            if is_upgradable:
-                status = f"[yellow]upgradable[/yellow] from {existing_version}"
-            elif installed_record is not None:
-                status = "installed"
 
-            table.add_row(
-                f"[blue]{latest_metadata.plugin.name}[/blue]",
-                latest_metadata.plugin.version,
-                status,
-                latest_metadata.plugin.urls.repository,
-            )
+def collect_keyword_query_result(
+    plugins: list[Plugin],
+    query: str,
+    current_version: str,
+    current_platform: str,
+    installed_records: list[InstalledPluginRecord],
+) -> KeywordQueryResult:
+    return KeywordQueryResult(
+        query=query or None,
+        results=collect_keyword_matches(plugins, query, current_version, current_platform, installed_records),
+    )
 
-    if has_matches:
-        console.print(table)
-    else:
+
+def render_keyword_query_text(result: KeywordQueryResult) -> None:
+    matches = result.results
+
+    if not matches:
         console.print("[grey69]No plugins found[/grey69]")
+        return
+
+    table = rich.table.Table(show_header=False, box=None)
+    table.add_column("name", style="blue")
+    table.add_column("version", style="default")
+    table.add_column("status")
+    table.add_column("repo", style="grey69")
+
+    for match in matches:
+        if not match.compatible:
+            table.add_row(
+                f"[grey69]{match.name} (incompatible)[/grey69]",
+                f"[grey69]{match.version}[/grey69]",
+                "",
+                match.repository,
+            )
+            continue
+
+        status = ""
+        if match.upgradable:
+            status = f"[yellow]upgradable[/yellow] from {match.installed_version}"
+        elif match.installed:
+            status = "installed"
+
+        table.add_row(f"[blue]{match.name}[/blue]", match.version, status, match.repository)
+
+    console.print(table)
 
 
 def _has_exact_name_match(plugins: list[Plugin], name: str) -> bool:
@@ -334,56 +504,100 @@ def _has_exact_name_match(plugins: list[Plugin], name: str) -> bool:
     return any(p.name.lower() == wanted for p in plugins)
 
 
+def resolve_query_reference(plugins: list[Plugin], query: str | None) -> PluginReference | None:
+    """Parse `query` as a qualified plugin reference, or None to fall back to keyword search.
+
+    A qualified query (with a host) is always an exact plugin query. An
+    unqualified query is only an exact plugin query if it exactly matches a
+    known bare name case-insensitively; otherwise it's a keyword/substring
+    search. Parse failures (malformed version spec, etc.) also fall back to
+    keyword search so unusual user input still works.
+    """
+    if not query:
+        return None
+
+    try:
+        ref = parse_plugin_reference(query)
+    except ValueError:
+        return None
+
+    if ref.host is None and not _has_exact_name_match(plugins, ref.name):
+        return None
+
+    return ref
+
+
+def _dump_result(result: BaseModel) -> dict[str, Any]:
+    return result.model_dump(mode="json")
+
+
 @click.command()
 @click.argument("query", required=False)
+@click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
 @click.pass_context
-def search_plugins(ctx, query: str | None = None) -> None:
+def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> None:
     """Search for plugins by name, keyword, category, or author."""
     try:
         current_platform = find_current_ida_platform()
         current_version = find_current_ida_version()
 
-        console.print(f"[grey69]current platform:[/grey69] {current_platform}")
-        console.print(f"[grey69]current version:[/grey69] {current_version}")
-        console.print()
+        if not json_output:
+            console.print(f"[grey69]current platform:[/grey69] {current_platform}")
+            console.print(f"[grey69]current version:[/grey69] {current_version}")
+            console.print()
 
         plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
         plugins: list[Plugin] = plugin_repo.get_plugins()
         installed_records = get_installed_plugin_records()
 
-        if not query:
-            handle_keyword_query(plugins, "", current_version, current_platform, installed_records)
-            return
+        ref = resolve_query_reference(plugins, query)
 
-        # Try to parse the query as a qualified reference. If parsing fails
-        # (malformed version spec, etc.) fall back to keyword search so the
-        # substring path continues to work for unusual user input.
-        try:
-            ref = parse_plugin_reference(query)
-        except ValueError:
-            handle_keyword_query(plugins, query, current_version, current_platform, installed_records)
-            return
-
-        # A qualified query (with a host) is always an exact plugin query.
-        # An unqualified query is only an exact plugin query if it exactly
-        # matches a known bare name case-insensitively; otherwise fall back
-        # to keyword/substring search.
-        if ref.host is None and not _has_exact_name_match(plugins, ref.name):
-            handle_keyword_query(plugins, query, current_version, current_platform, installed_records)
+        if ref is None:
+            keyword_result = collect_keyword_query_result(
+                plugins, query or "", current_version, current_platform, installed_records
+            )
+            if json_output:
+                print_json(_dump_result(keyword_result))
+            else:
+                render_keyword_query_text(keyword_result)
             return
 
         try:
             if ref.version_spec:
-                handle_plugin_spec_query(plugins, ref, current_version, current_platform, installed_records)
+                spec_result = collect_plugin_spec_query_result(
+                    plugins, ref, current_version, current_platform, installed_records
+                )
+                if json_output:
+                    print_json(_dump_result(spec_result))
+                else:
+                    render_plugin_spec_query_text(spec_result)
             else:
-                handle_plugin_name_query(plugins, ref, current_version, current_platform, installed_records)
+                name_result = collect_plugin_name_query_result(
+                    plugins, ref, current_version, current_platform, installed_records
+                )
+                if json_output:
+                    print_json(_dump_result(name_result))
+                else:
+                    render_plugin_name_query_text(name_result)
+
         except AmbiguousPluginReferenceError as e:
-            # ``get_plugin_by_name`` does not know the user's version spec;
-            # attach it here so candidate suggestions render ``name==1.2.3@repo``.
+            # get_plugin_by_name does not know the user's version spec; attach
+            # it here so candidate suggestions render name==1.2.3@repo.
             if ref.version_spec and not e.version_spec:
                 e = AmbiguousPluginReferenceError(e.name, e.candidates, ref.version_spec)
-            render_ambiguity_error(e)
+
+            if json_output:
+                print_json(_dump_result(collect_ambiguity_error(e)))
+                ctx.exit(1)
+
+            render_ambiguity_error_text(e)
             raise click.Abort()
+
+        except (KeyError, ValueError) as e:
+            if not json_output:
+                raise
+            print_json({"error": str(e)})
+            ctx.exit(1)
 
     except MissingCurrentInstallationDirectory:
         explain_missing_current_installation_directory(console)
@@ -394,6 +608,9 @@ def search_plugins(ctx, query: str | None = None) -> None:
         raise click.Abort()
 
     except click.Abort:
+        raise
+
+    except click.exceptions.Exit:
         raise
 
     except Exception as e:

--- a/src/hcli/commands/plugin/status.py
+++ b/src/hcli/commands/plugin/status.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 import rich.table
 import rich_click as click
+from pydantic import BaseModel
 
 from hcli.env import ENV
-from hcli.lib.console import console
+from hcli.lib.console import console, print_json
 from hcli.lib.ida import (
     FailedToDetectIDAVersion,
     MissingCurrentInstallationDirectory,
@@ -20,6 +22,8 @@ from hcli.lib.ida import (
 from hcli.lib.ida.plugin import parse_plugin_version
 from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError
 from hcli.lib.ida.plugin.install import (
+    InstalledPluginRecord,
+    find_installed_plugin_in,
     get_installed_legacy_plugins,
     get_installed_minimal_plugins,
     get_installed_plugin_records,
@@ -30,79 +34,239 @@ from hcli.lib.ida.plugin.repo import BasePluginRepo
 logger = logging.getLogger(__name__)
 
 
-@click.command()
-@click.pass_context
-def get_plugin_status(ctx) -> None:
-    """Show installed plugins and their upgrade status."""
-    plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
+class InstalledPluginStatusEntry(BaseModel):
+    name: str
+    version: str
+    installed: Literal[True] = True
+    kind: Literal["installed"] = "installed"
+    upgrade_checked: bool
+    in_repository: bool | None
+    upgradable_to: str | None
+
+
+class NotFoundPluginStatusEntry(BaseModel):
+    name: str
+    installed: Literal[False] = False
+
+
+class IncompatiblePluginStatusEntry(BaseModel):
+    name: str
+    version: str | None
+    installed: Literal[True] = True
+    kind: Literal["incompatible"] = "incompatible"
+    path: str
+
+
+class LegacyPluginStatusEntry(BaseModel):
+    name: str
+    version: None = None
+    installed: Literal[True] = True
+    kind: Literal["legacy"] = "legacy"
+    path: str
+
+
+PluginStatusEntry = (
+    InstalledPluginStatusEntry | NotFoundPluginStatusEntry | IncompatiblePluginStatusEntry | LegacyPluginStatusEntry
+)
+
+
+class StatusReport(BaseModel):
+    plugins: list[PluginStatusEntry]
+
+
+def _collect_installed_entry(
+    plugin_repo: BasePluginRepo,
+    record: InstalledPluginRecord,
+    current_platform: str,
+    current_ida_version: str,
+    skip_upgrade_check: bool,
+) -> InstalledPluginStatusEntry:
+    if skip_upgrade_check:
+        return InstalledPluginStatusEntry(
+            name=record.name,
+            version=record.version,
+            upgrade_checked=False,
+            in_repository=None,
+            upgradable_to=None,
+        )
+
     try:
-        current_platform = find_current_ida_platform()
-        current_ida_version = find_current_ida_version()
+        location = plugin_repo.find_compatible_plugin_from_spec(
+            record.name, current_platform, current_ida_version, host=record.host
+        )
+        latest_version = location.metadata.plugin.version
+        return InstalledPluginStatusEntry(
+            name=record.name,
+            version=record.version,
+            upgrade_checked=True,
+            in_repository=True,
+            upgradable_to=(
+                latest_version if parse_plugin_version(latest_version) > parse_plugin_version(record.version) else None
+            ),
+        )
+    except (ValueError, KeyError, AmbiguousPluginReferenceError):
+        return InstalledPluginStatusEntry(
+            name=record.name,
+            version=record.version,
+            upgrade_checked=True,
+            in_repository=False,
+            upgradable_to=None,
+        )
 
-        table = rich.table.Table(show_header=False, box=None)
-        table.add_column("name", style="blue")
-        table.add_column("version", style="default")
-        table.add_column("status")
 
-        for record in get_installed_plugin_records():
-            status = ""
-            try:
-                # Anchor the repository lookup on the installed plugin's host so a
-                # colliding plugin name in the repository does not raise ambiguity
-                # or pick the wrong variant.
-                location = plugin_repo.find_compatible_plugin_from_spec(
-                    record.name, current_platform, current_ida_version, host=record.host
-                )
-                if parse_plugin_version(location.metadata.plugin.version) > parse_plugin_version(record.version):
-                    status = f"upgradable to [yellow]{location.metadata.plugin.version}[/yellow]"
-            except (ValueError, KeyError, AmbiguousPluginReferenceError):
-                # AmbiguousPluginReferenceError should not escape this command.
-                # The installed plugin's own metadata carries its host, so
-                # anchoring on that host above should normally resolve the
-                # collision; if it does not, treat the plugin as absent from
-                # the repository rather than crashing status.
-                status = "[yellow]not found in repository[/yellow]"
+def _render_status_row(table: rich.table.Table, entry: PluginStatusEntry) -> None:
+    if isinstance(entry, IncompatiblePluginStatusEntry):
+        table.add_row(
+            f"[grey69](incompatible)[/grey69] [blue]{entry.name}[/blue]",
+            entry.version or "",
+            f"[grey69]found at: $IDAPLUGINS/[/grey69]{entry.path}",
+        )
+        return
 
-            table.add_row(record.name, record.version, status)
+    if isinstance(entry, LegacyPluginStatusEntry):
+        table.add_row(
+            f"[grey69](legacy)[/grey69] [blue]{entry.name}[/blue]",
+            "",
+            f"[grey69]found at: $IDAPLUGINS/[/grey69]{entry.path}",
+        )
+        return
 
-        has_incompatible_plugins = False
+    if isinstance(entry, NotFoundPluginStatusEntry):
+        return
+
+    if not entry.upgrade_checked:
+        status = "[dim]skipped[/dim]"
+    elif not entry.in_repository:
+        status = "[yellow]not found in repository[/yellow]"
+    elif entry.upgradable_to:
+        status = f"upgradable to [yellow]{entry.upgradable_to}[/yellow]"
+    else:
+        status = ""
+
+    table.add_row(entry.name, entry.version, status)
+
+
+def collect_status_report(
+    plugin_repo: BasePluginRepo,
+    plugins: tuple[str, ...],
+    skip_upgrade_check: bool,
+) -> StatusReport:
+    current_platform = find_current_ida_platform()
+    current_ida_version = find_current_ida_version()
+
+    all_records = get_installed_plugin_records()
+
+    not_found_names: list[str] = []
+    if plugins:
+        installed_records = []
+        for name in plugins:
+            record = find_installed_plugin_in(all_records, name)
+            if record is None:
+                not_found_names.append(name)
+            else:
+                installed_records.append(record)
+    else:
+        installed_records = all_records
+
+    entries: list[PluginStatusEntry] = [
+        _collect_installed_entry(plugin_repo, record, current_platform, current_ida_version, skip_upgrade_check)
+        for record in installed_records
+    ]
+
+    entries.extend(NotFoundPluginStatusEntry(name=name) for name in not_found_names)
+
+    if not plugins:
         plugin_directory = get_plugins_directory()
         for path, metadata in get_installed_minimal_plugins():
             plugin_path = path.parent.relative_to(plugin_directory)
-            table.add_row(
-                f"[grey69](incompatible)[/grey69] [blue]{metadata.plugin.name}[/blue]",
-                metadata.plugin.version or "",
-                f"[grey69]found at: $IDAPLUGINS/[/grey69]{plugin_path}/",
+            entries.append(
+                IncompatiblePluginStatusEntry(
+                    name=metadata.plugin.name,
+                    version=metadata.plugin.version or None,
+                    path=f"{plugin_path}/",
+                )
             )
-            has_incompatible_plugins = True
 
-        has_legacy_plugins = False
         for path in get_installed_legacy_plugins():
-            plugin_path = path.parent.relative_to(plugin_directory)
-            table.add_row(
-                f"[grey69](legacy)[/grey69] [blue]{path.name}[/blue]",
-                "",
-                f"[grey69]found at: $IDAPLUGINS/[/grey69]{path.name}",
+            entries.append(
+                LegacyPluginStatusEntry(
+                    name=path.name,
+                    path=path.name,
+                )
             )
-            has_legacy_plugins = True
 
-        if table.row_count:
-            console.print(table)
+    return StatusReport(plugins=entries)
+
+
+def render_status_report_text(report: StatusReport, plugins_filter: tuple[str, ...]) -> None:
+    table = rich.table.Table(show_header=False, box=None)
+    table.add_column("name", style="blue")
+    table.add_column("version", style="default")
+    table.add_column("status")
+
+    not_found_names: list[str] = []
+    has_incompatible = False
+    has_legacy = False
+
+    for entry in report.plugins:
+        if isinstance(entry, NotFoundPluginStatusEntry):
+            not_found_names.append(entry.name)
+            continue
+        if isinstance(entry, IncompatiblePluginStatusEntry):
+            has_incompatible = True
+        elif isinstance(entry, LegacyPluginStatusEntry):
+            has_legacy = True
+        _render_status_row(table, entry)
+
+    if table.row_count:
+        console.print(table)
+    elif not plugins_filter:
+        console.print("[grey69]No plugins found[/grey69]")
+
+    for name in not_found_names:
+        console.print(f"[red]Not installed[/red]: {name}")
+
+    if has_incompatible:
+        console.print()
+        console.print("[yellow]Incompatible plugins[/yellow] don't work with this version of hcli.")
+        console.print(
+            f"[dim]They might be broken or outdated. Try using `{ENV.HCLI_BINARY_NAME} plugin lint /path/to/plugin`.[/dim]"
+        )
+
+    if has_legacy:
+        console.print()
+        console.print("[yellow]Legacy plugins[/yellow] are old, single-file plugins.")
+        console.print("They aren't managed by hcli. Try finding an updated version in the plugin repository.")
+
+
+def render_status_report_json(report: StatusReport) -> None:
+    print_json(report.model_dump(mode="json"))
+
+
+@click.command()
+@click.argument("plugins", nargs=-1)
+@click.option(
+    "--skip-upgrade-check",
+    is_flag=True,
+    default=False,
+    help="skip the per-plugin upgrade check against the plugin repository",
+)
+@click.option("--json", "json_output", is_flag=True, default=False, help="output machine-readable JSON")
+@click.pass_context
+def get_plugin_status(ctx, plugins: tuple[str, ...], skip_upgrade_check: bool, json_output: bool) -> None:
+    """Show installed plugins and their upgrade status.
+
+    If one or more PLUGINS are given, show status for just those plugins,
+    and exit with a non-zero status if any of them isn't installed.
+    """
+    plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
+    try:
+        report = collect_status_report(plugin_repo, plugins, skip_upgrade_check)
+
+        if json_output:
+            render_status_report_json(report)
         else:
-            console.print("[grey69]No plugins found[/grey69]")
-
-        if has_incompatible_plugins:
-            console.print()
-            console.print("[yellow]Incompatible plugins[/yellow] don't work with this version of hcli.")
-            console.print(
-                f"[dim]They might be broken or outdated. Try using `{ENV.HCLI_BINARY_NAME} plugin lint /path/to/plugin`.[/dim]"
-            )
-
-        if has_legacy_plugins:
-            # TODO: suggest plugins in the repo, by maintaining a translation list from filename to package name
-            console.print()
-            console.print("[yellow]Legacy plugins[/yellow] are old, single-file plugins.")
-            console.print("They aren't managed by hcli. Try finding an updated version in the plugin repository.")
+            render_status_report_text(report, plugins)
 
     except MissingCurrentInstallationDirectory:
         explain_missing_current_installation_directory(console)
@@ -116,3 +280,7 @@ def get_plugin_status(ctx) -> None:
         logger.debug("error: %s", e, exc_info=True)
         console.print(f"[red]Error[/red]: {e}")
         raise click.Abort()
+
+    has_not_found = any(isinstance(e, NotFoundPluginStatusEntry) for e in report.plugins)
+    if has_not_found:
+        ctx.exit(1)

--- a/src/hcli/lib/console.py
+++ b/src/hcli/lib/console.py
@@ -1,5 +1,7 @@
+import json
 import sys
 from collections.abc import Mapping
+from typing import Any
 
 import rich_click as click
 from rich.console import Console
@@ -45,3 +47,15 @@ def _sync_console_streams():
 
 
 _sync_console_streams()
+
+
+def print_json(data: Any) -> None:
+    """Print `data` as JSON via `console`, not `click.echo`.
+
+    `click.echo` resolves its output stream independently of `console`, so it
+    isn't covered by `_sync_console_streams` and can write to a stale stdout
+    handle under Click's pytest CliRunner integration (see #190). Markup and
+    highlighting are disabled so JSON's own brackets aren't parsed as Rich
+    markup, and soft_wrap avoids Rich reflowing long lines.
+    """
+    console.print(json.dumps(data, indent=2), markup=False, highlight=False, soft_wrap=True)

--- a/tests/lib/test_plugin_collisions.py
+++ b/tests/lib/test_plugin_collisions.py
@@ -487,6 +487,176 @@ def test_status_does_not_crash_on_colliding_name(tmp_path, virtual_ida_environme
     assert "3.0.0" in result.output
 
 
+def test_status_named_plugin_installed(virtual_ida_environment):
+    """`status <name>` shows just that plugin and exits 0 when it's installed."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1"])
+    assert result.exit_code == 0, result.output
+    assert "plugin1" in result.output
+
+
+def test_status_named_plugin_not_installed(virtual_ida_environment):
+    """`status <name>` exits non-zero and reports absence when not installed."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "does-not-exist"])
+    assert result.exit_code != 0
+    assert "does-not-exist" in result.output
+
+
+def test_status_skip_upgrade_check(virtual_ida_environment):
+    """`status --skip-upgrade-check` reports installed plugins without querying the repo for upgrades."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    # sanity check: without the flag, status detects the newer version available in PLUGINS_DIR
+    online_result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1"])
+    assert online_result.exit_code == 0, online_result.output
+    assert "upgradable to" in online_result.output
+
+    skip_result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--skip-upgrade-check"])
+    assert skip_result.exit_code == 0, skip_result.output
+    assert "plugin1" in skip_result.output
+    assert "upgradable to" not in skip_result.output
+    assert "skipped" in skip_result.output
+
+
+def test_status_json_installed_plugin(virtual_ida_environment):
+    """`status <name> --json` reports upgrade info as structured JSON."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.output)
+    assert payload["plugins"] == [
+        {
+            "name": "plugin1",
+            "version": "1.0.0",
+            "installed": True,
+            "kind": "installed",
+            "upgrade_checked": True,
+            "in_repository": True,
+            "upgradable_to": "6.0.0",
+        }
+    ]
+
+
+def test_status_json_not_installed_plugin(virtual_ida_environment):
+    """`status <name> --json` reports a missing plugin and exits non-zero."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "does-not-exist", "--json"])
+    assert result.exit_code != 0
+
+    payload = json.loads(result.output)
+    assert payload["plugins"] == [{"name": "does-not-exist", "installed": False}]
+
+
+def test_status_json_skip_upgrade_check(virtual_ida_environment):
+    """`status <name> --json --skip-upgrade-check` marks the upgrade check as skipped."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "--skip-upgrade-check", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.output)
+    assert payload["plugins"] == [
+        {
+            "name": "plugin1",
+            "version": "1.0.0",
+            "installed": True,
+            "kind": "installed",
+            "upgrade_checked": False,
+            "in_repository": None,
+            "upgradable_to": None,
+        }
+    ]
+
+
+def test_search_json_keyword_query(virtual_ida_environment):
+    """`search --json` (no query) reports the full plugin listing as JSON."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "search", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.output)
+    assert payload["query"] is None
+    names = {entry["name"] for entry in payload["results"]}
+    assert "plugin1" in names
+
+
+def test_search_json_exact_name_query(virtual_ida_environment):
+    """`search <name> --json` reports plugin metadata and versions as JSON."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "search", "plugin1", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.output)
+    assert payload["plugin"]["name"] == "plugin1"
+    assert payload["installed_version"] is None
+    assert any(v["version"] == "4.0.0" for v in payload["versions"])
+
+
+def test_search_json_ambiguous_reference(tmp_path):
+    """`search <name> --json` reports an ambiguity error as JSON and exits non-zero."""
+    repo_dir = _build_colliding_repo_dir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(repo_dir), "search", "shared", "--json"])
+    assert result.exit_code != 0
+
+    payload = json.loads(result.output)
+    assert payload["error"] == "ambiguous plugin reference"
+    assert payload["name"] == "shared"
+    assert len(payload["candidates"]) == 2
+
+
+def test_status_multiple_plugins_all_installed(virtual_ida_environment):
+    """`status <name1> <name2>` shows both plugins and exits 0 when both are installed."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "zydisinfo==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "zydisinfo"])
+    assert result.exit_code == 0, result.output
+    assert "plugin1" in result.output
+    assert "zydisinfo" in result.output
+
+
+def test_status_multiple_plugins_partially_installed(virtual_ida_environment):
+    """`status <name1> <name2>` exits non-zero and reports only the missing one when mixed."""
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(plugin_group, ["--repo", str(PLUGINS_DIR), "status", "plugin1", "does-not-exist"])
+    assert result.exit_code != 0
+    assert "plugin1" in result.output
+    assert "Not installed" in result.output
+    assert "does-not-exist" in result.output
+
+
 def test_upgrade_not_installed_fails(tmp_path, virtual_ida_environment):
     """Upgrade must fail cleanly when the plugin is not installed."""
     repo_dir = _build_colliding_repo_dir_with_v2(tmp_path)


### PR DESCRIPTION
## Summary

Add `--json` flag to `plugin status`, `plugin search`, and `ida python explain-environment` for machine-readable output. Also add `--skip-upgrade-check` and positional `PLUGINS` filter to `plugin status` for headless/scripted use cases.

All three commands are refactored into a collect/render pattern: Pydantic models capture the data, separate functions render it as either Rich text or JSON. The text output is unchanged.

### `plugin status`

- `hcli plugin status [PLUGINS...] [--json] [--skip-upgrade-check]`
- Filter to specific plugins by name; exits non-zero if any aren't installed
- `--skip-upgrade-check` skips the per-plugin repository query (useful offline or for speed)
- JSON output uses discriminated union types (`kind: "installed" | "incompatible" | "legacy"`, or `installed: false` for not-found)

### `plugin search`

- `hcli plugin search [QUERY] [--json]`
- JSON shape depends on query type: keyword search → `KeywordQueryResult`, exact name → `PluginNameQueryResult`, version spec → `PluginExactVersionQueryResult` or `PluginVersionRangeQueryResult`
- Ambiguity and lookup errors render as JSON with non-zero exit when `--json` is active

### `ida python explain-environment`

- `hcli ida python explain-environment [--json]`
- Full environment report as a single JSON object (installations, architecture, Python detection, virtualenv, version mismatches, notes)

### Other

- New `print_json` helper in `lib/console.py` routes JSON through Rich's console to stay compatible with Click's CliRunner stream capture (#190)
- `plugin list` and `plugin explain-environment` backward-compat aliases forward the new parameters
- 170 lines of new tests covering `--json`, `--skip-upgrade-check`, positional plugin filtering, and ambiguity errors

Supersedes #268.