### PR TITLE
fix: constrain httpx below 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "click",
     "rich",
     "rich-click",
-    "httpx",
+    "httpx<1",
     "pydantic>=2.11.0",
     "platformdirs",
     "packaging",

--- a/uv.lock
+++ b/uv.lock
@@ -388,7 +388,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click" },
-    { name = "httpx" },
+    { name = "httpx", specifier = "<1" },
     { name = "idapro", specifier = ">=0.0.5" },
     { name = "mkdocs-click", marker = "extra == 'docs'", specifier = ">=0.9.0" },
     { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = ">=0.5.0" },


### PR DESCRIPTION
## Summary

- constrain `httpx` to pre-1.0 releases
- update the lockfile metadata accordingly

## Why

`ida-codemode` currently needs `uvx --prerelease=allow` because its `ida-domain` dependency is a prerelease. That global resolver setting selects `httpx 1.0.dev3` for HCLI 0.19.0. HCLI imports the 0.x exception API (`httpx.ConnectError` and `httpx.ConnectTimeout`), so startup fails before commands can run.

## Verification

- reproduced the 0.19.0 failure with `httpx 1.0.dev3`
- verified an isolated `--prerelease=allow` install from this branch resolves `httpx 0.28.1`
- verified `hcli --version` starts successfully in that environment
- `455 passed, 50 skipped` on Windows
- Ruff format/check passed
- mypy passed using the Linux target platform