### PR TITLE
fix: pass all arguments through to the program in `ida python` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Honor `$IDAPYTHON_VENV_EXECUTABLE` for plugin dependency management
 
 ### Fixed
+- Pass every argument through to the program in `ida python exec` and `ida python run-script`, so `hcli ida python exec -m pip --help` describes pip (#287)
 - Update uv.lock for better Python 3.14 support
 - Update ida-config.json by default on install
 - Explicitly use encoding="utf-8" everywhere and set PYTHONUTF8=1 for subprocesses

--- a/docs/user-guide/ida-python-environment.md
+++ b/docs/user-guide/ida-python-environment.md
@@ -14,7 +14,7 @@ pip 25.2 from /Users/user/.idapro/venv/lib/python3.13/site-packages/pip (python 
 $ hcli ida python exec -m pip install requests
 ```
 
-With no arguments you get an interactive interpreter, and HCLI exits with whatever status the interpreter returned. HCLI parses its own options first, so pass `--` before arguments it would otherwise claim, as in `hcli ida python exec -- --version`.
+With no arguments you get an interactive interpreter, and HCLI exits with whatever status the interpreter returned. Arguments reach the interpreter untouched, including ones HCLI understands elsewhere, so `hcli ida python exec -m pip --help` describes pip. The exception is a leading `--help`, which describes the HCLI command itself; write `hcli ida python exec -- --help` for the interpreter's.
 
 Packages often install command-line programs, such as `capa` from `flare-capa`. These land in the environment's scripts directory, which usually isn't on your `PATH`:
 
@@ -22,7 +22,7 @@ Packages often install command-line programs, such as `capa` from `flare-capa`. 
 $ hcli ida python find-script capa
 /Users/user/.idapro/venv/bin/capa
 
-$ hcli ida python run-script capa -- --version
+$ hcli ida python run-script capa --version
 capa 9.3.1
 ```
 

--- a/src/hcli/commands/ida/python/exec_python.py
+++ b/src/hcli/commands/ida/python/exec_python.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import rich_click as click
 from rich.markup import escape
 
+from hcli.lib.commands import PassthroughCommand
 from hcli.lib.console import console
 from hcli.lib.ida.python import run_in_python_environment
 
 from ._common import get_python_exe
 
 
-@click.command(context_settings={"ignore_unknown_options": True})
+@click.command(cls=PassthroughCommand, context_settings={"ignore_unknown_options": True})
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def exec_python(ctx: click.Context, args: tuple[str, ...]) -> None:
@@ -23,10 +24,11 @@ def exec_python(ctx: click.Context, args: tuple[str, ...]) -> None:
       hcli ida python exec -m pip install requests
       hcli ida python exec -c "import requests; print('ok')"
       hcli ida python exec script.py --flag
+      hcli ida python exec --version
 
     \b
-    Use `--` for arguments that HCLI would otherwise interpret:
-      hcli ida python exec -- --version
+    `--help` here describes this command; pass it to the interpreter with `--`:
+      hcli ida python exec -- --help
     """
     python_exe = get_python_exe()
 

--- a/src/hcli/commands/ida/python/run_script.py
+++ b/src/hcli/commands/ida/python/run_script.py
@@ -4,13 +4,14 @@ import rich_click as click
 from rich.markup import escape
 
 import hcli.lib.ida.python
+from hcli.lib.commands import PassthroughCommand
 from hcli.lib.console import console
 from hcli.lib.ida.python import ProbeError, ScriptNotFoundError
 
 from ._common import get_python_exe
 
 
-@click.command(context_settings={"ignore_unknown_options": True})
+@click.command(cls=PassthroughCommand, context_settings={"ignore_unknown_options": True})
 @click.argument("name")
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
@@ -26,10 +27,7 @@ def run_script(ctx: click.Context, name: str, args: tuple[str, ...]) -> None:
     \b
     Examples:
       hcli ida python run-script speakeasy -t sample.exe
-
-    \b
-    Use `--` for arguments that HCLI would otherwise interpret:
-      hcli ida python run-script speakeasy -- --help
+      hcli ida python run-script speakeasy --help
     """
     python_exe = get_python_exe()
 

--- a/src/hcli/lib/commands/__init__.py
+++ b/src/hcli/lib/commands/__init__.py
@@ -69,6 +69,41 @@ def enforce_login() -> bool:
     return True
 
 
+class PassthroughCommand(click.RichCommand):
+    """Command class for commands whose arguments belong to another program.
+
+    HCLI parses nothing but a leading `--help`: everything else reaches the
+    program verbatim, including options that HCLI defines elsewhere, so
+    `... exec -m pip --help` describes pip rather than HCLI.
+
+    A `--` where the program's arguments start is HCLI's separator and is
+    dropped, both because it reads well and because older releases required
+    it. Later ones belong to the program. Pass the separator along by
+    doubling it.
+    """
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if not args or args[0] in ctx.help_option_names:
+            return super().parse_args(ctx, args)
+
+        index = self._get_passthrough_index()
+        if index < len(args) and args[index] == "--":
+            args = args[:index] + args[index + 1 :]
+
+        # everything past this `--` is an argument, never an option
+        return super().parse_args(ctx, ["--", *args])
+
+    def _get_passthrough_index(self) -> int:
+        """Report how many arguments HCLI claims before the program's own."""
+        count = 0
+        for param in self.params:
+            if isinstance(param, click.Argument):
+                if param.nargs < 0:
+                    break
+                count += param.nargs
+        return count
+
+
 class BaseCommand(click.RichCommand):
     """Base command class with optional authentication."""
 

--- a/tests/lib/test_passthrough_command.py
+++ b/tests/lib/test_passthrough_command.py
@@ -1,0 +1,77 @@
+"""Tests for commands that hand their arguments to another program."""
+
+from __future__ import annotations
+
+import rich_click as click
+from click.testing import CliRunner
+
+from hcli.lib.commands import PassthroughCommand
+
+
+@click.command(cls=PassthroughCommand)
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def echo_args(args: tuple[str, ...]) -> None:
+    """Docstring for echo-args."""
+    click.echo(repr(list(args)))
+
+
+@click.command(cls=PassthroughCommand)
+@click.argument("name")
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def echo_named_args(name: str, args: tuple[str, ...]) -> None:
+    """Docstring for echo-named-args."""
+    click.echo(f"{name}: {list(args)!r}")
+
+
+def invoke(command: click.Command, argv: list[str]):
+    result = CliRunner().invoke(command, argv)
+    assert result.exit_code == 0, result.output
+    return result.output.strip()
+
+
+def test_options_reach_the_program():
+    assert invoke(echo_args, ["-m", "pip", "--help"]) == "['-m', 'pip', '--help']"
+    assert invoke(echo_args, ["-c", "print(1)"]) == "['-c', 'print(1)']"
+    assert invoke(echo_args, ["script.py", "--flag"]) == "['script.py', '--flag']"
+
+
+def test_hcli_options_reach_the_program():
+    """Options HCLI defines elsewhere aren't HCLI's here."""
+    assert invoke(echo_args, ["--version"]) == "['--version']"
+    assert invoke(echo_args, ["-mpip", "--help"]) == "['-mpip', '--help']"
+
+
+def test_leading_help_describes_the_command():
+    assert "Docstring for echo-args." in invoke(echo_args, ["--help"])
+
+
+def test_separator_is_dropped():
+    """`--` marks where the program's arguments start, so the program doesn't see it."""
+    assert invoke(echo_args, ["--", "--help"]) == "['--help']"
+    assert invoke(echo_args, ["--", "--version"]) == "['--version']"
+
+
+def test_separator_can_be_passed_along():
+    assert invoke(echo_args, ["--", "--", "--version"]) == "['--', '--version']"
+
+
+def test_later_separators_belong_to_the_program():
+    assert invoke(echo_args, ["script.py", "--", "-x"]) == "['script.py', '--', '-x']"
+    assert invoke(echo_named_args, ["capa", "-q", "--", "-x"]) == "capa: ['-q', '--', '-x']"
+
+
+def test_no_arguments():
+    assert invoke(echo_args, []) == "[]"
+
+
+def test_arguments_after_a_required_one():
+    assert invoke(echo_named_args, ["capa", "--version"]) == "capa: ['--version']"
+    assert invoke(echo_named_args, ["capa", "--", "--version"]) == "capa: ['--version']"
+    assert invoke(echo_named_args, ["capa"]) == "capa: []"
+    assert "Docstring for echo-named-args." in invoke(echo_named_args, ["--help"])
+
+
+def test_required_argument_is_still_required():
+    result = CliRunner().invoke(echo_named_args, [])
+    assert result.exit_code != 0
+    assert "NAME" in result.output


### PR DESCRIPTION
`hcli ida python exec -m pip --help` printed HCLI's help instead of pip's:

```
~/Projects/ida-hcli % hcli ida python exec -m pip --help

 Usage: hcli ida python exec [OPTIONS] [ARGS]...
 ...
```

Click's help option is eager and matches anywhere on the command line, and `--help` isn't an *unknown* option, so `ignore_unknown_options` never applied to it.

`PassthroughCommand` (in `hcli.lib.commands`) parses nothing but a leading `--help`; everything else reaches the program verbatim, including options HCLI defines elsewhere. It does this by handing Click a `--` ahead of the arguments, so they can only be parsed as positional. `ida python exec` and `ida python run-script` both use it.

A `--` written where the program's arguments start is still dropped, because earlier releases required it and the docs taught it — `hcli ida python run-script capa -- --version` keeps working. Later `--`s now reach the program, and doubling passes one along.

Verified against a real IDA installation:

```
$ hcli ida python exec -m pip --help
Usage:
  /Users/user/.idapro-live/venv/bin/python -m pip <command> [options]
...
$ hcli ida python exec --version
Python 3.13.5
$ hcli ida python exec -- --version
Python 3.13.5
$ hcli ida python exec --help      # still describes the HCLI command
```

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)