### PR TITLE
test: cover nested repository live displays

### DIFF
--- a/tests/lib/test_plugin_bundle_commands.py
+++ b/tests/lib/test_plugin_bundle_commands.py
@@ -5,9 +5,12 @@ import sys
 import zipfile
 from pathlib import Path
 
+import rich.progress
 from click.testing import CliRunner
 
 from hcli.commands.plugin.bundle import bundle
+from hcli.lib.console import stderr_console
+from hcli.lib.ida.plugin.repo.fs import FileSystemPluginRepo
 from hcli.lib.ida.python import PipOptions
 
 TESTS_DIR = Path(__file__).parent.parent
@@ -96,6 +99,33 @@ def test_bundle_create_from_local_zip_no_deps(tmp_path):
         assert plugins[0].name == "plugin1"
     finally:
         repo.close()
+
+
+def test_bundle_create_composes_repository_live_display(monkeypatch, tmp_path):
+    """Rich 14.1+ renders repository progress beneath the command status."""
+    original_get_plugins = FileSystemPluginRepo.get_plugins
+    live_depths: list[int] = []
+
+    def get_plugins_with_progress(self):
+        with rich.progress.Progress(console=stderr_console, transient=True):
+            live_depths.append(len(stderr_console._live_stack))
+            return original_get_plugins(self)
+
+    monkeypatch.setattr(FileSystemPluginRepo, "get_plugins", get_plugins_with_progress)
+
+    out = tmp_path / "output.zip"
+    repo = FileSystemPluginRepo(PLUGIN1_V1.parent)
+    runner = CliRunner()
+    result = runner.invoke(
+        bundle,
+        ["create", "--path", str(out), "--target", "linux-x86_64-cp312", "plugin1==1.0.0"],
+        obj={"pip_options": PipOptions(), "plugin_repo": repo},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert live_depths == [2]
+    assert not stderr_console._live_stack
+    assert out.exists()
 
 
 def test_bundle_create_unknown_target_rejected(tmp_path):

--- a/tests/lib/test_plugin_install.py
+++ b/tests/lib/test_plugin_install.py
@@ -9,7 +9,9 @@ import zipfile
 from pathlib import Path
 
 import pytest
+import rich.progress
 import rich.status
+from click.testing import CliRunner
 from fixtures import *
 from fixtures import (
     PLUGINS_DIR,
@@ -18,6 +20,7 @@ from fixtures import (
     temp_env_var,
 )
 
+from hcli.commands.plugin import plugin as plugin_group
 from hcli.lib.console import stderr_console
 from hcli.lib.ida.plugin.exceptions import (
     BrokenPluginInstallationError,
@@ -38,6 +41,7 @@ from hcli.lib.ida.plugin.install import (
     upgrade_plugin_archive,
     validate_archive_entry,
 )
+from hcli.lib.ida.plugin.repo.fs import FileSystemPluginRepo
 from hcli.lib.ida.python import pip_freeze
 
 logger = logging.getLogger(__name__)
@@ -81,6 +85,30 @@ def test_install_source_plugin_archive_under_an_active_spinner(virtual_ida_envir
     with rich.status.Status("installing plugin", console=stderr_console):
         install_plugin_archive(buf, "plugin1")
 
+    assert is_plugin_installed("plugin1")
+
+
+def test_install_composes_repository_live_display(monkeypatch, virtual_ida_environment):
+    """Rich 14.1+ renders repository progress beneath the command status."""
+    original_get_plugins = FileSystemPluginRepo.get_plugins
+    live_depths: list[int] = []
+
+    def get_plugins_with_progress(self):
+        with rich.progress.Progress(console=stderr_console, transient=True):
+            live_depths.append(len(stderr_console._live_stack))
+            return original_get_plugins(self)
+
+    monkeypatch.setattr(FileSystemPluginRepo, "get_plugins", get_plugins_with_progress)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        plugin_group,
+        ["--repo", str(PLUGINS_DIR), "install", "plugin1==1.0.0"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert live_depths == [2]
+    assert not stderr_console._live_stack
     assert is_plugin_installed("plugin1")
 
 


### PR DESCRIPTION
## Summary

- cover `plugin install` when its status contains a repository-owned `Progress` display
- cover `plugin bundle create` under the same nested-display path
- verify Rich composes both displays on the shared stderr console and clears the live stack afterward

## Context

PR #296 now requires Rich 14.1+, which added supported nested live displays. These tests cover the remaining repository paths where a command-level `Status` wraps repository progress.

## Testing

- full pytest suite
- Ruff format/check
- scoped mypy
