### PR TITLE
fix: require rich>=14.1 so nested spinners don't abort commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ authors = [
 
 dependencies = [
     "click",
-    "rich",
+    # 14.1 made nested live displays a no-op instead of raising
+    # LiveError("Only one live display may be active at once"): hcli layers
+    # command-level spinners over library functions that show their own.
+    "rich>=14.1",
     "rich-click",
     "httpx<1",
     "pydantic>=2.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,7 @@ authors = [
 
 dependencies = [
     "click",
-    # 14.1 made nested live displays a no-op instead of raising
-    # LiveError("Only one live display may be active at once"): hcli layers
-    # command-level spinners over library functions that show their own.
+    # <14.1 cannot nest live displays, like Status widgets
     "rich>=14.1",
     "rich-click",
     "httpx<1",

--- a/src/hcli/commands/share/delete.py
+++ b/src/hcli/commands/share/delete.py
@@ -5,7 +5,7 @@ from rich.prompt import Confirm
 
 from hcli.lib.api.asset import SHARED, asset
 from hcli.lib.commands import async_command, auth_command
-from hcli.lib.console import console
+from hcli.lib.console import console, stderr_console
 
 
 @auth_command(help="Delete shared file by code.")
@@ -22,8 +22,8 @@ async def delete(code: str, force: bool) -> None:
     """
 
     try:
-        console.status("[bold blue]Getting file information...")
-        file = await asset.get_shared_file_by_code(code)
+        with stderr_console.status("[bold blue]Getting file information..."):
+            file = await asset.get_shared_file_by_code(code)
 
         if file is None:
             console.print(f"[yellow]File not found {code}.[/yellow]")
@@ -39,8 +39,8 @@ async def delete(code: str, force: bool) -> None:
             console.print("[yellow]Deletion cancelled.[/yellow]")
             return
 
-        console.status(f"[bold red]Deleting {file.filename} [{file.code}]...[/bold red]")
-        await asset.delete_file_by_key(SHARED, file.key)
+        with stderr_console.status(f"[bold red]Deleting {file.filename} [{file.code}]...[/bold red]"):
+            await asset.delete_file_by_key(SHARED, file.key)
         console.print(f"[green]✓ Deleted: {code}[/green]")
 
     except Exception as e:

--- a/src/hcli/commands/share/get.py
+++ b/src/hcli/commands/share/get.py
@@ -7,7 +7,7 @@ import rich_click as click
 from hcli.lib.api.asset import asset
 from hcli.lib.api.common import get_api_client
 from hcli.lib.commands import async_command, auth_command
-from hcli.lib.console import console
+from hcli.lib.console import console, stderr_console
 
 
 @auth_command()
@@ -38,7 +38,7 @@ async def get(shortcode: str, output_dir: Path | None, output_file: Path | None,
 
     try:
         # Get file information
-        with console.status("[bold blue]Getting file information..."):
+        with stderr_console.status("[bold blue]Getting file information..."):
             file_info = await asset.get_shared_file_by_code(shortcode)
 
         if not file_info:

--- a/src/hcli/commands/share/list.py
+++ b/src/hcli/commands/share/list.py
@@ -12,7 +12,7 @@ from hcli.commands.common import safe_ask_async
 from hcli.lib.api.asset import SHARED, Asset, asset
 from hcli.lib.api.common import get_api_client
 from hcli.lib.commands import async_command, auth_command
-from hcli.lib.console import console
+from hcli.lib.console import console, stderr_console
 from hcli.lib.constants import cli
 
 
@@ -30,7 +30,7 @@ async def list_shares(limit: int, offset: int, interactive: bool) -> None:
 
     try:
         # Get shared files
-        with console.status("[bold blue]Loading shared files..."):
+        with stderr_console.status("[bold blue]Loading shared files..."):
             from hcli.lib.api.asset import PagingFilter
 
             filter_params = PagingFilter(limit=limit, offset=offset)

--- a/src/hcli/lib/api/common.py
+++ b/src/hcli/lib/api/common.py
@@ -16,7 +16,7 @@ from rich.progress import (
 from hcli import __version__
 from hcli.env import ENV
 from hcli.lib.auth import get_auth_service
-from hcli.lib.console import console
+from hcli.lib.console import console, stderr_console
 from hcli.lib.constants.auth import CredentialType
 from hcli.lib.util.cache import get_cache_directory
 from hcli.lib.util.io import NoSpaceError, check_free_space
@@ -149,7 +149,7 @@ class APIClient:
                 DownloadColumn(),
                 TransferSpeedColumn(),
                 TimeRemainingColumn(),
-                console=console,
+                console=stderr_console,
             ) as progress,
         ):
             task = progress.add_task(f"Uploading {file_path}", total=file_size)
@@ -261,7 +261,7 @@ class APIClient:
                 DownloadColumn(),
                 TransferSpeedColumn(),
                 TimeRemainingColumn(),
-                console=console,
+                console=stderr_console,
             ) as progress:
                 download_task = progress.add_task(
                     f"Downloading {filename}",

--- a/src/hcli/lib/ida/plugin/repo/github.py
+++ b/src/hcli/lib/ida/plugin/repo/github.py
@@ -932,7 +932,7 @@ class GithubPluginRepo(BasePluginRepo):
         index = PluginArchiveIndex()
 
         for owner, repo, tag_name, asset, date in rich.progress.track(
-            assets, description="Fetching plugin assests", transient=True, console=stderr_console
+            assets, description="Fetching plugin assets", transient=True, console=stderr_console
         ):
             logger.debug(m("fetching release asset: %s", asset.download_url, owner=owner, repo=repo, tag=tag_name))
             try:

--- a/tests/lib/test_plugin_install.py
+++ b/tests/lib/test_plugin_install.py
@@ -9,6 +9,7 @@ import zipfile
 from pathlib import Path
 
 import pytest
+import rich.status
 from fixtures import *
 from fixtures import (
     PLUGINS_DIR,
@@ -17,6 +18,7 @@ from fixtures import (
     temp_env_var,
 )
 
+from hcli.lib.console import stderr_console
 from hcli.lib.ida.plugin.exceptions import (
     BrokenPluginInstallationError,
     PluginAlreadyInstalledError,
@@ -66,6 +68,20 @@ def test_install_source_plugin_archive(virtual_ida_environment):
     assert (plugin_directory / "plugin1.py").exists()
 
     assert ("plugin1", "1.0.0") in get_installed_plugins()
+
+
+def test_install_source_plugin_archive_under_an_active_spinner(virtual_ida_environment):
+    """`hcli plugin install` wraps the install in its own spinner, and the install
+    starts more of its own. rich before 14.1 aborted the command there with
+    `Only one live display may be active at once`.
+    """
+    plugin_path = PLUGINS_DIR / "plugin1" / "plugin1-v1.0.0.zip"
+    buf = plugin_path.read_bytes()
+
+    with rich.status.Status("installing plugin", console=stderr_console):
+        install_plugin_archive(buf, "plugin1")
+
+    assert is_plugin_installed("plugin1")
 
 
 def test_install_binary_plugin_archive(virtual_ida_environment):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -408,7 +408,7 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.10.0" },
     { name = "python-semantic-release", marker = "extra == 'dev'", specifier = ">=10.3.1" },
     { name = "questionary" },
-    { name = "rich" },
+    { name = "rich", specifier = ">=14.1" },
     { name = "rich-click" },
     { name = "semantic-version", specifier = ">=2.10.0" },
     { name = "taskipy", marker = "extra == 'dev'", specifier = ">=1.14.1" },


### PR DESCRIPTION
A user hit this on every `hcli plugin install`:

```
hcli plugin install https://github.com/HexRaysSA/ida-codemode-mcp
Error: Only one live display may be active at once
Aborted.
```

## Cause

A rich `Console` renders at most one live display at a time. `commands/plugin/install.py` opens an `installing plugin` spinner, then `install_plugin_archive` opens its own for `finding IDA installation` on the same console. rich before 14.1 raises `LiveError` there; 14.1 added a live stack that makes the inner display a silent no-op instead. `rich` was unpinned, so anyone who resolved <= 14.0 crashed on every non-editable install — the GitHub URL in the report is incidental.

Two more nestings exist, both reachable with `--repo github`: the `fetching plugin` spinner and `plugin bundle`'s `resolving ...` spinner each wrap `GithubPluginRepo.get_plugins()`, which draws a progress bar.

## Fix

`rich>=14.1`, plus a regression test that installs a plugin under an active spinner. Verified load-bearing: the test fails with the reported `LiveError` against rich 14.0.0 and passes on 14.3.2.

## Two unrelated bugs found while auditing

- `share delete` called `console.status(...)` with no `with` block, so neither of its spinners ever rendered.
- The upload/download progress bars in `lib/api/common.py` drew on the **stdout** console, which is reserved for command output. Moved to stderr, along with the `share get`/`share list`/`share delete` spinners so one command doesn't split progress across both streams.
- Typo in a progress bar description: `assests` -> `assets`.

## Worth knowing

With rich 14.1+ the nested spinners silently don't render, so `install_plugin_archive`'s `finding IDA installation` and `installing Python dependencies: ...` messages are invisible whenever the command already has a spinner up — which is always. Those inner spinners are now dead weight; removing them or demoting them to `logger.info` would be a reasonable follow-up.

## Verification

`just lint` clean. 473 passed / 8 skipped / 0 failed (integration excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)