### PR TITLE
Skip VCS packages when installing plugin dependencies

### DIFF
--- a/src/hcli/lib/ida/plugin/install.py
+++ b/src/hcli/lib/ida/plugin/install.py
@@ -62,6 +62,23 @@ from hcli.lib.util.io import NoSpaceError
 
 logger = logging.getLogger(__name__)
 
+_VCS_PREFIXES = ("git+", "hg+", "svn+", "bzr+")
+
+
+def is_vcs_or_url_dependency(dependency: str) -> bool:
+    """Whether a dependency spec resolves via VCS clone or direct URL download.
+
+    Unlike plain "name>=1.0" requirements, pip can't cheaply confirm these are
+    already satisfied (e.g. a git branch ref has no stable version to check against),
+    so pip re-fetches them - clones, submodules and all - on every invocation.
+    """
+    dependency = dependency.strip()
+    target = dependency
+    if " @ " in dependency:
+        _, _, target = dependency.partition(" @ ")
+        target = target.strip()
+    return target.startswith(_VCS_PREFIXES) or "://" in target
+
 
 def get_plugins_directory() -> Path:
     """$IDAUSR/plugins/<name>"""
@@ -476,7 +493,10 @@ def validate_can_install_python_dependencies(
                 continue
 
             existing_deps = get_python_dependencies_from_plugin_directory(existing_plugin_path, existing_metadata)
-            all_python_dependencies.extend(existing_deps)
+            # Other plugins' VCS/URL deps are excluded: pip can't cheaply verify
+            # they're already satisfied and would re-fetch them (clone, submodules
+            # and all) on every unrelated plugin install.
+            all_python_dependencies.extend(dep for dep in existing_deps if not is_vcs_or_url_dependency(dep))
 
         all_python_dependencies.extend(python_dependencies)
 
@@ -711,7 +731,10 @@ def _install_plugin_archive(
             for existing_plugin_path in get_installed_plugin_paths():
                 existing_metadata = get_metadata_from_plugin_directory(existing_plugin_path)
                 existing_deps = get_python_dependencies_from_plugin_directory(existing_plugin_path, existing_metadata)
-                all_python_dependencies.extend(existing_deps)
+                # Other plugins' VCS/URL deps are excluded: pip can't cheaply verify
+                # they're already satisfied and would re-fetch them (clone, submodules
+                # and all) on every unrelated plugin install.
+                all_python_dependencies.extend(dep for dep in existing_deps if not is_vcs_or_url_dependency(dep))
 
             logger.debug("installing new python dependencies: %s", python_dependencies)
             all_python_dependencies.extend(python_dependencies)
@@ -826,7 +849,10 @@ def install_plugin_directory_editable(source_dir: Path, name: str, pip_options: 
                 if existing_metadata.plugin.name == metadata.plugin.name:
                     continue
                 existing_deps = get_python_dependencies_from_plugin_directory(existing_plugin_path, existing_metadata)
-                all_python_dependencies.extend(existing_deps)
+                # Other plugins' VCS/URL deps are excluded: pip can't cheaply verify
+                # they're already satisfied and would re-fetch them (clone, submodules
+                # and all) on every unrelated plugin install.
+                all_python_dependencies.extend(dep for dep in existing_deps if not is_vcs_or_url_dependency(dep))
             all_python_dependencies.extend(python_dependencies)
 
         resolved = resolve_current_python()

--- a/src/hcli/lib/ida/python.py
+++ b/src/hcli/lib/ida/python.py
@@ -381,21 +381,30 @@ def _raise_for_known_pip_errors(error_text: str, python_exe: Path) -> None:
         )
 
 
+PIP_INSTALL_TIMEOUT = 300.0
+
+
 def verify_pip_can_install_packages(
     python_exe: Path,
     packages: list[str],
     pip_options: PipOptions = PIP_OPTIONS_DEFAULT,
+    timeout: float = PIP_INSTALL_TIMEOUT,
 ):
     """Check if the given Python packages (e.g., "foo>=v1.0,<3") can be installed.
 
     Raises:
-        CantInstallPackagesError: if pip dry-run fails.
+        CantInstallPackagesError: if pip dry-run fails or times out.
     """
-    process = subprocess.run(
-        [str(python_exe), "-m", "pip", "install", "--dry-run"] + pip_options.build_args() + packages,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        process = subprocess.run(
+            [str(python_exe), "-m", "pip", "install", "--dry-run"] + pip_options.build_args() + packages,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise CantInstallPackagesError(f"pip dry-run install timed out after {timeout:.0f}s") from e
     stdout, stderr = process.stdout, process.stderr
     if process.returncode != 0:
         logger.debug("can't install packages")
@@ -411,17 +420,23 @@ def pip_install_packages(
     python_exe: Path,
     packages: list[str],
     pip_options: PipOptions = PIP_OPTIONS_DEFAULT,
+    timeout: float = PIP_INSTALL_TIMEOUT,
 ):
     """Install the given Python packages (e.g., "foo>=v1.0,<3").
 
     Raises:
-        CantInstallPackagesError: if pip install fails.
+        CantInstallPackagesError: if pip install fails or times out.
     """
-    process = subprocess.run(
-        [str(python_exe), "-m", "pip", "install"] + pip_options.build_args() + packages,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        process = subprocess.run(
+            [str(python_exe), "-m", "pip", "install"] + pip_options.build_args() + packages,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise CantInstallPackagesError(f"pip install timed out after {timeout:.0f}s") from e
     stdout, stderr = process.stdout, process.stderr
     if process.returncode != 0:
         logger.debug("can't install packages")

--- a/tests/lib/test_plugin_install.py
+++ b/tests/lib/test_plugin_install.py
@@ -34,6 +34,7 @@ from hcli.lib.ida.plugin.install import (
     get_trash_directory,
     install_plugin_archive,
     is_plugin_installed,
+    is_vcs_or_url_dependency,
     sweep_trash,
     uninstall_plugin,
     upgrade_plugin_archive,
@@ -155,6 +156,68 @@ def test_plugin_python_dependencies(virtual_ida_environment_with_venv):
 
     freeze = pip_freeze(Path(os.environ["HCLI_CURRENT_IDA_PYTHON_EXE"]))
     assert "packaging==25.0" in freeze
+
+
+@pytest.mark.parametrize(
+    "dependency,expected",
+    [
+        ("packaging==25.0", False),
+        ("packaging>=1.0,<3", False),
+        ("git+https://github.com/HexRaysSA/speakeasy.git@gdb-improvements", True),
+        ("hg+https://example.com/repo@tip", True),
+        ("speakeasy @ git+https://github.com/HexRaysSA/speakeasy.git@gdb-improvements", True),
+        ("some-pkg @ https://example.com/some-pkg-1.0.whl", True),
+        ("https://example.com/some-pkg-1.0.whl", True),
+    ],
+)
+def test_is_vcs_or_url_dependency(dependency: str, expected: bool):
+    assert is_vcs_or_url_dependency(dependency) is expected
+
+
+def test_installing_a_plugin_does_not_refetch_another_plugins_vcs_dependency(
+    virtual_ida_environment_with_venv, monkeypatch
+):
+    """Merging in other installed plugins' deps is for conflict detection only.
+
+    VCS/URL deps can't be cheaply checked for "already satisfied" (e.g. a git
+    branch ref has no stable version), so pip re-fetches them - clone,
+    submodules and all - on every unrelated plugin install unless we exclude
+    them from the merge.
+    """
+    existing_plugin_dir = get_plugin_directory("existing-plugin")
+    existing_plugin_dir.mkdir(parents=True)
+    (existing_plugin_dir / "existing_plugin.py").write_text("# plugin code")
+    (existing_plugin_dir / "ida-plugin.json").write_text(
+        json.dumps(
+            {
+                "IDAMetadataDescriptorVersion": 1,
+                "plugin": {
+                    "name": "existing-plugin",
+                    "version": "1.0.0",
+                    "entryPoint": "existing_plugin.py",
+                    "pythonDependencies": ["git+https://github.com/HexRaysSA/speakeasy.git@gdb-improvements"],
+                },
+            }
+        )
+    )
+
+    installed_packages: list[list[str]] = []
+    monkeypatch.setattr(
+        "hcli.lib.ida.plugin.install.verify_pip_can_install_packages",
+        lambda python_exe, packages, pip_options=None: installed_packages.append(list(packages)),
+    )
+    monkeypatch.setattr(
+        "hcli.lib.ida.plugin.install.pip_install_packages",
+        lambda python_exe, packages, pip_options=None: installed_packages.append(list(packages)),
+    )
+
+    plugin_path = PLUGINS_DIR / "plugin1" / "plugin1-v3.0.0.zip"
+    buf = plugin_path.read_bytes()
+    install_plugin_archive(buf, "plugin1")
+
+    for packages in installed_packages:
+        assert "packaging==25.0" in packages
+        assert not any(is_vcs_or_url_dependency(p) for p in packages)
 
 
 def test_plugin_python_dependencies_rejects_externally_managed_python_without_running_pip(


### PR DESCRIPTION
## What happened

`hcli plugin install -e .` hung for over an hour with no visible output. `HCLI_DEBUG=1` showed the `idat` Python-info probe complete normally (its `SystemExit`/exit code 1 is expected — the probe script calls `sys.exit()` on purpose after writing its result), so the freeze was happening later, silently, inside our own pip invocation.

`pstree` during the hang showed the real cause:

```
hcli plugin install -e .
└─ pip install ida-codemode==0.5.2 ... git+https://github.com/HexRaysSA/speakeasy.git@gdb-improvements ...
   └─ git submodule update --init --recursive
      └─ git submodule--helper clone ... https://github.com/mandiant/capa-testfiles
         └─ git-remote-https origin https://github.com/mandiant/capa-testfiles
```

The `speakeasy` dependency wasn't even declared by the plugin being installed — it came from `one-click-debugging`, a *different*, already-installed plugin. `git+https://github.com/HexRaysSA/speakeasy.git@gdb-improvements` pulls in a submodule pointing at `mandiant/capa-testfiles`, a large malware-sample test-data repo, and pip re-clones it (submodules and all) on every single plugin install, not just when `one-click-debugging` itself is installed or updated.

## Root cause

Installing a plugin merges the declared Python dependencies of *every other already-installed plugin* into one `pip install`/`pip install --dry-run` call (`validate_can_install_python_dependencies`, `_install_plugin_archive`, `install_plugin_directory_editable`) so pip's resolver can catch cross-plugin version conflicts before anything breaks in the shared environment. That's fine for ordinary `name>=1.0` requirements — pip confirms those are already satisfied in milliseconds. It's not fine for VCS/URL dependencies: there's no stable version to check a git branch ref against, so pip has to re-fetch the repo to find out, on every unrelated plugin install, indefinitely — and there was no timeout guarding that call, so a slow/huge clone (or any other pip stall) just hung forever with zero feedback.

## Fix

- Added `is_vcs_or_url_dependency()` and excluded other plugins' VCS/URL deps from the merged dependency list. The plugin actually being installed still gets its own VCS deps installed normally; only the *other*, already-installed plugins' git/URL requirements are skipped, since re-verifying them buys nothing but cost and risk.
- Added a 300s timeout and `stdin=subprocess.DEVNULL` to the two `subprocess.run` calls in `pip_install_packages`/`verify_pip_can_install_packages`, which previously had neither (every sibling subprocess call in that module already had a timeout). Any future pip stall now fails with a clear `CantInstallPackagesError` instead of hanging silently.
