### PR TITLE
Add Windows Aarch64 standalone executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
           - { os: ubuntu-latest,    platform: linux,   artifact-name: hcli-linux-x86_64 }
           - { os: ubuntu-24.04-arm, platform: linux,   artifact-name: hcli-linux-aarch64 }
           - { os: windows-latest,   platform: windows, artifact-name: hcli-windows-x86_64 }
+          - { os: windows-11-arm,   platform: windows, artifact-name: hcli-windows-aarch64 }
           - { os: macos-latest,     platform: macos,   artifact-name: hcli-mac-arm64 }
           # Built on the same free arm64 runner as hcli-mac-arm64, but under an x86_64
           # Python via Rosetta 2 emulation, so PyInstaller produces a genuine x86_64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -294,17 +294,6 @@ jobs:
         include:
           - python-version: "3.13"
             os_ida:
-              name: IDA Free 9.4 on macOS (ARM)
-              arch: arm
-              os: macos-latest
-              ida_version: "9.4"
-              slug: "release/9.4/ida-free/ida-free-pc_94_armmac.app.zip"
-              idat_path: ""
-              default_path: "/Applications/IDA Free 9.4.app"
-              supports_idalib: false  # IDA Free doesn't include idalib
-
-          - python-version: "3.13"
-            os_ida:
               name: IDA Pro 9.4 on macOS (ARM)
               arch: arm
               os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,51 @@ jobs:
       matrix:
         python-version: ["3.10", "3.13"]
         os_ida:
+          - name: IDA 9.4 on Linux
+            arch: intel
+            os: ubuntu-latest
+            ida_version: "9.4"
+            slug: "release/9.4/ida-essential/ida-essential_94_x64linux.run"
+            idat_path: "/idat"
+            default_path: "/home/runner/.local/share/applications/IDA Essential 9.4"
+            supports_idalib: true
+
+          - name: IDA 9.4 on Windows
+            arch: intel
+            os: windows-latest
+            ida_version: "9.4"
+            slug: "release/9.4/ida-essential/ida-essential_94_x64win.exe"
+            idat_path: "/idat.exe"
+            default_path: "C:\\Program Files\\IDA Essential 9.4"
+            supports_idalib: true
+
+          - name: IDA 9.4 on macOS (Intel)
+            arch: intel
+            os: macos-latest
+            ida_version: "9.4"
+            slug: "release/9.4/ida-essential/ida-essential_94_x64mac.app.zip"
+            idat_path: "/Contents/MacOS/idat"
+            default_path: "/Applications/IDA Essential 9.4.app"
+            supports_idalib: false  # GHA macos-latest is ARM; x86_64 Python bindings won't load
+
+          - name: IDA 9.4 on macOS (ARM)
+            arch: arm
+            os: macos-latest
+            ida_version: "9.4"
+            slug: "release/9.4/ida-essential/ida-essential_94_armmac.app.zip"
+            idat_path: "/Contents/MacOS/idat"
+            default_path: "/Applications/IDA Essential 9.4.app"
+            supports_idalib: true
+
+          - name: IDA 9.4 on Linux (ARM)
+            arch: arm
+            os: ubuntu-24.04-arm
+            ida_version: "9.4"
+            slug: "release/9.4/ida-essential/ida-essential_94_armlinux.run"
+            idat_path: "/idat"
+            default_path: "/home/runner/.local/share/applications/IDA Essential 9.4"
+            supports_idalib: true
+
           - name: IDA 9.3 on Linux
             arch: intel
             os: ubuntu-latest
@@ -247,6 +292,28 @@ jobs:
           #   default_path: "/Applications/IDA Classroom 9.1.app"
 
         include:
+          - python-version: "3.13"
+            os_ida:
+              name: IDA Free 9.4 on macOS (ARM)
+              arch: arm
+              os: macos-latest
+              ida_version: "9.4"
+              slug: "release/9.4/ida-free/ida-free-pc_94_armmac.app.zip"
+              idat_path: ""
+              default_path: "/Applications/IDA Free 9.4.app"
+              supports_idalib: false  # IDA Free doesn't include idalib
+
+          - python-version: "3.13"
+            os_ida:
+              name: IDA Pro 9.4 on macOS (ARM)
+              arch: arm
+              os: macos-latest
+              ida_version: "9.4"
+              slug: "release/9.4/ida-pro/ida-pro_94_armmac.app.zip"
+              idat_path: "/Contents/MacOS/idat"
+              default_path: "/Applications/IDA Professional 9.4.app"
+              supports_idalib: true
+
           - python-version: "3.13"
             os_ida:
               name: IDA Free 9.3 on macOS (ARM)

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -19,7 +19,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - { os: ubuntu-latest,    install-id: release/9.2/ida-essential/ida-essential_92_x64linux.run }
+          - { os: ubuntu-24.04-arm, install-id: release/9.2/ida-essential/ida-essential_92_arm64linux.run }
+          - { os: macos-latest,     install-id: release/9.2/ida-essential/ida-essential_92_armmac.app.zip }
+          - { os: windows-latest,   install-id: release/9.2/ida-essential/ida-essential_92_x64win.exe }
+          - { os: windows-11-arm,   install-id: release/9.2/ida-essential/ida-essential_92_arm64win.exe }
 
     steps:
       - name: Checkout
@@ -45,24 +50,17 @@ jobs:
         run: |
           hcli --version
 
-      - name: Test IDA installation command (Linux)
-        if: runner.os == 'Linux'
+      - name: Test IDA installation command (Unix)
+        if: runner.os != 'Windows'
         run: |
-          hcli --disable-updates ida install --yes --download-id release/9.2/ida-essential/ida-essential_92_x64linux.run --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --set-default
-        env:
-          HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
-
-      - name: Test IDA installation command (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          hcli --disable-updates ida install --yes --download-id release/9.2/ida-essential/ida-essential_92_armmac.app.zip --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --set-default
+          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --set-default
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
 
       - name: Test IDA installation command (Windows)
         if: runner.os == 'Windows'
         run: |
-          hcli --disable-updates ida install --yes --download-id release/9.2/ida-essential/ida-essential_92_x64win.exe --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --set-default
+          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --set-default
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
 

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest,    install-id: release/9.2/ida-essential/ida-essential_92_x64linux.run }
-          - { os: ubuntu-24.04-arm, install-id: release/9.2/ida-essential/ida-essential_92_arm64linux.run }
-          - { os: macos-latest,     install-id: release/9.2/ida-essential/ida-essential_92_armmac.app.zip }
-          - { os: windows-latest,   install-id: release/9.2/ida-essential/ida-essential_92_x64win.exe }
-          - { os: windows-11-arm,   install-id: release/9.2/ida-essential/ida-essential_92_arm64win.exe }
+          - { os: ubuntu-latest,    install-id: release/9.4/ida-essential/ida-essential_94_x64linux.run }
+          - { os: ubuntu-24.04-arm, install-id: release/9.4/ida-essential/ida-essential_94_arm64linux.run }
+          - { os: macos-latest,     install-id: release/9.4/ida-essential/ida-essential_94_armmac.app.zip }
+          - { os: windows-latest,   install-id: release/9.4/ida-essential/ida-essential_94_x64win.exe }
+          - { os: windows-11-arm,   install-id: release/9.4/ida-essential/ida-essential_94_arm64win.exe }
 
     steps:
       - name: Checkout

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -207,24 +207,20 @@ Please download and install it first:
 function Get-Architecture {
     <#
     .SYNOPSIS
-    Validates system architecture for hcli installation
-    .DESCRIPTION
-    Since hcli only supports x86_64, this function validates the system is 64-bit
-    and returns the appropriate architecture string.
+    Detects system architecture for hcli installation
     #>
     [CmdletBinding()]
     param()
 
     Write-Verbose "Validating system architecture for hcli compatibility..."
 
-    # Simple 64-bit check - sufficient since we only support x86_64
     if (-not [System.Environment]::Is64BitOperatingSystem) {
         throw "Error: hcli requires a 64-bit system. 32-bit systems are not supported."
     }
 
-    # Additional check for ARM64 systems (which report as 64-bit but aren't x86_64)
     if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -or $env:PROCESSOR_ARCHITEW6432 -eq "ARM64") {
-        throw "Error: ARM64 systems are not currently supported. Only x86_64 (64-bit Intel/AMD) systems are supported."
+        Write-Verbose "System validated as ARM64"
+        return "aarch64"
     }
 
     Write-Verbose "System validated as x86_64 compatible"
@@ -392,11 +388,7 @@ function Get-AssetDownloadInfo {
         [string]$Architecture
     )
     
-    # Determine platform name and filename
-    $platform_name = switch ($Architecture) {
-        "x86_64" { "windows" }
-        default { throw "Unsupported architecture for download: $Architecture" }
-    }
+    $platform_name = "windows"
     
     $filename = "$app_name-$platform_name-$Architecture-$Version.exe"
     $releases_url = "$github_api_base/repos/$Repository/releases/tags/v$Version"


### PR DESCRIPTION
## Summary
- Add `windows-11-arm` runner to the release build matrix to produce a native ARM64 Windows binary
- Update the PowerShell installer (`docs/install.ps1`) to detect ARM64 systems and download the correct `hcli-windows-aarch64` asset instead of rejecting them

## Test plan
- [ ] CI passes (lint + tests)
- [ ] Verify `windows-11-arm` runner builds successfully on next release
- [ ] Test installer on a Windows ARM64 machine

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)