### PR TITLE
Align GHA workflows with IDA best practices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           bash .github/scripts/retry.sh 5 20 \
-            uv run hcli --disable-updates ida install --download-id "ida-pro:latest" --license-id "${{ secrets.IDA_LICENSE_ID }}" --set-default --accept-eula --yes
+            uv run hcli --disable-updates ida install --download-id "ida-pro:latest" --license-id "${IDA_LICENSE_ID}" --install-dir="${{ runner.temp }}/app/ida" --set-default --accept-eula --yes
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
@@ -53,6 +53,7 @@ jobs:
         run: uv run pytest -v --log-cli-level=DEBUG tests/
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
+          HCLI_INSTALL_DIR: ${{ runner.temp }}/app/ida
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUTF8: "1"
           PYTHONIOENCODING: "UTF-8"
@@ -378,7 +379,7 @@ jobs:
         shell: bash
         run: |
           bash .github/scripts/retry.sh 5 20 \
-            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${{ secrets.IDA_LICENSE_ID }}" --set-default --yes
+            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${IDA_LICENSE_ID}" --accept-eula --set-default --yes
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
@@ -403,7 +404,7 @@ jobs:
         shell: bash
         run: |
           bash .github/scripts/retry.sh 5 20 \
-            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${{ secrets.IDA_LICENSE_ID }}" --install-dir "${{ runner.temp }}/app/ida-${{ matrix.os_ida.ida_version }}/" --set-default --yes
+            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${IDA_LICENSE_ID}" --install-dir "${{ runner.temp }}/app/ida-${{ matrix.os_ida.ida_version }}/" --accept-eula --set-default --yes
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -53,16 +53,18 @@ jobs:
       - name: Test IDA installation command (Unix)
         if: runner.os != 'Windows'
         run: |
-          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --set-default
+          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --accept-eula --set-default
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
+          IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
 
       - name: Test IDA installation command (Windows)
         if: runner.os == 'Windows'
         run: |
-          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --set-default
+          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --accept-eula --set-default
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
+          IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
 
       - name: Verify IDA installation (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- Add `--accept-eula` to all IDA install commands (was missing from matrix installs and test_install.yml)
- Add `--install-dir` to basic-test so IDA installs to `runner.temp` instead of system default
- Add `HCLI_INSTALL_DIR` env var to basic-test's pytest step so tests find the install
- Add `IDA_LICENSE_ID` env var to test_install.yml steps (skill recommends providing secrets as env vars)
- Use shell env var `${IDA_LICENSE_ID}` instead of `${{ secrets }}` in bash commands for cleaner separation

## Test plan
- [ ] basic-test job passes (IDA installs to explicit dir, tests find it via HCLI_INSTALL_DIR)
- [ ] Matrix test jobs pass (--accept-eula doesn't break existing installs)
- [ ] test_install.yml jobs pass on next release/manual trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)