### PR TITLE
style: fix lint violations reported by ruff 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,14 @@ ignore = [
     "TRY300",   # try-consider-else — stylistic preference, not a bug
     "S110",     # try-except-pass — intentional best-effort patterns in CLI
     "LOG015",   # root-logger-call — acceptable in CLI application context
+    "ASYNC240", # blocking-path-in-async — hcli runs one asyncio task per command and
+                # has no trio/anyio path API; cheap stat calls are fine here
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# click uses a literal \b (U+0008) on its own line to mark a paragraph it must not
+# rewrap, so these command docstrings cannot be turned into raw strings.
+"src/hcli/commands/**/*.py" = ["D301"]
 
 [tool.mypy]
 check_untyped_defs = true

--- a/src/hcli/commands/download.py
+++ b/src/hcli/commands/download.py
@@ -86,7 +86,7 @@ async def select_asset(nodes: list[TreeNode], current_path: str = "") -> Asset |
             return None
         elif selected_node.type == "file":
             # File selected - return the asset key
-            return selected_node.asset if selected_node.asset else None
+            return selected_node.asset or None
 
         return None
 

--- a/src/hcli/commands/login.py
+++ b/src/hcli/commands/login.py
@@ -65,7 +65,7 @@ async def login(force: bool, name: str | None) -> None:
 
     elif selected == "Email (OTP)":
         # Email OTP login
-        email = await safe_ask_async(questionary.text("Email address", default=current_email if current_email else ""))
+        email = await safe_ask_async(questionary.text("Email address", default=current_email or ""))
 
         try:
             console.print(f"[blue]Sending OTP to {email}...[/blue]")

--- a/src/hcli/commands/share/list.py
+++ b/src/hcli/commands/share/list.py
@@ -128,7 +128,7 @@ async def perform_download_action(selected_files: list[Asset]) -> None:
             console.print(f"\n[blue]Downloading {file.filename}...[/blue]")
 
             # Get download URL
-            file_info = await asset.get_shared_file_by_code(file.code if file.code else "", file.version)
+            file_info = await asset.get_shared_file_by_code(file.code or "", file.version)
 
             if not file_info:
                 console.print(f"[red]✗ Failed to get download info for {file.filename}[/red]")

--- a/src/hcli/lib/api/common.py
+++ b/src/hcli/lib/api/common.py
@@ -205,7 +205,7 @@ class APIClient:
 
         # Create cache path using XDG_CACHE_HOME with "downloads" key
         # Use the full asset_key if provided, otherwise fall back to filename
-        cache_key = asset_key if asset_key else filename
+        cache_key = asset_key or filename
         cache_path = get_cache_directory("downloads") / cache_key
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         target_path = target_dir / filename

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -69,7 +69,7 @@ class IdaProduct:
         product_part = match.group(1)  # like: pro, home-pc, essential
         version_major = int(match.group(2)[0])  # like: 9
         version_minor = int(match.group(2)[1])  # like: 1
-        suffix = match.group(3) if match.group(3) else None  # like: sp1
+        suffix = match.group(3) or None  # like: sp1
 
         product_mapping = {
             "pro": "IDA Professional",
@@ -286,10 +286,10 @@ def _dedupe_paths(paths: list[Path]) -> list[Path]:
 
 
 def _find_windows_registry_installations() -> list[_WindowsRegistryInstallation]:
-    """Read IDA installation metadata from the Add/Remove Programs registry under HKLM.
+    r"""Read IDA installation metadata from the Add/Remove Programs registry under HKLM.
 
     The installer writes a key per install under
-    ``HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\IDA <edition> <version>``.
+    ``HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\IDA <edition> <version>``.
     """
     try:
         import winreg as _winreg  # type: ignore[import-not-found]
@@ -380,8 +380,7 @@ def _find_linux_installs_from_desktop_files() -> list[Path]:
     xdg = os.environ.get("XDG_DATA_HOME")
     if xdg:
         search_dirs.append(Path(xdg) / "applications")
-    search_dirs.append(get_user_home_dir() / ".local" / "share" / "applications")
-    search_dirs.append(Path("/usr/share/applications"))
+    search_dirs.extend((get_user_home_dir() / ".local" / "share" / "applications", Path("/usr/share/applications")))
 
     for app_dir in search_dirs:
         if not app_dir.exists():
@@ -562,7 +561,7 @@ def accept_eula(install_dir: Path) -> None:
 
 
 def install_ida(installer: Path, install_dir: Path):
-    """
+    r"""
     Install IDA Pro from an installer.
 
     Args:
@@ -570,7 +569,7 @@ def install_ida(installer: Path, install_dir: Path):
       install_dir: path to the installation directory, which should not already exist.
 
     Installation directory should look like:
-      - %Program Files%\\IDA Professional 9.1\\
+      - %Program Files%\IDA Professional 9.1\
       - /Applications/IDA Professional 9.1.app/
       - /opt/ida-9.1/
       - /tmp/ida-9.1/
@@ -767,9 +766,7 @@ class PluginRepositoryConfig(BaseModel):
 class SettingsConfig(BaseModel):
     model_config = ConfigDict(serialize_by_alias=True)  # type: ignore
 
-    plugin_repository: PluginRepositoryConfig = Field(
-        alias="plugin-repository", default_factory=lambda: PluginRepositoryConfig()
-    )
+    plugin_repository: PluginRepositoryConfig = Field(alias="plugin-repository", default_factory=PluginRepositoryConfig)
 
 
 class PluginConfig(BaseModel):
@@ -784,8 +781,8 @@ class IDAConfigJson(BaseModel):
     model_config = ConfigDict(serialize_by_alias=True)  # type: ignore
 
     version: Literal[1] | None = Field(alias="Version", default=1)
-    paths: PathsConfig = Field(alias="Paths", default_factory=lambda: PathsConfig())
-    settings: SettingsConfig = Field(alias="Settings", default_factory=lambda: SettingsConfig())
+    paths: PathsConfig = Field(alias="Paths", default_factory=PathsConfig)
+    settings: SettingsConfig = Field(alias="Settings", default_factory=SettingsConfig)
     # from plugin name to config.
     # NOTE: keyed by bare plugin name for now. Two plugins with the same bare
     # name but different repository URLs will share the same settings entry;

--- a/src/hcli/lib/ida/launcher.py
+++ b/src/hcli/lib/ida/launcher.py
@@ -185,7 +185,7 @@ class IDALauncher:
             # e.g., /Applications/IDA.app/Contents/MacOS/ida -> /Applications/IDA.app
             ida_bin_str = str(ida_bin)
             if "/Contents/MacOS/" in ida_bin_str:
-                return Path(ida_bin_str.split("/Contents/MacOS/")[0])
+                return Path(ida_bin_str.split("/Contents/MacOS/", maxsplit=1)[0])
         # Linux/Windows: binary is directly in the install dir
         return ida_bin.parent
 
@@ -244,7 +244,7 @@ class IDALauncher:
         if sys.platform == "darwin":
             ida_bin_str = str(ida_bin)
             if "/Contents/MacOS/" in ida_bin_str:
-                app_bundle = ida_bin_str.split("/Contents/MacOS/")[0]
+                app_bundle = ida_bin_str.split("/Contents/MacOS/", maxsplit=1)[0]
                 if app_bundle.endswith(".app"):
                     cmd = ["open", "-n", "-a", app_bundle, "--args", str(idb_path)]
                 else:
@@ -313,7 +313,7 @@ class IDALauncher:
             # e.g., /Applications/IDA.app/Contents/MacOS/ida -> /Applications/IDA.app
             ida_bin_str = str(ida_bin)
             if "/Contents/MacOS/" in ida_bin_str:
-                app_bundle = ida_bin_str.split("/Contents/MacOS/")[0]
+                app_bundle = ida_bin_str.split("/Contents/MacOS/", maxsplit=1)[0]
                 if app_bundle.endswith(".app"):
                     # Use -n to force a new instance, --args to pass the IDB path
                     cmd = ["open", "-n", "-a", app_bundle, "--args", str(idb_path)]

--- a/src/hcli/lib/venv.py
+++ b/src/hcli/lib/venv.py
@@ -46,8 +46,7 @@ def _get_uv_cache_dirs() -> list[Path]:
     home = Path.home()
     system = platform.system()
     if system == "Darwin":
-        dirs.append(home / "Library" / "Caches" / "uv")
-        dirs.append(home / ".cache" / "uv")
+        dirs.extend((home / "Library" / "Caches" / "uv", home / ".cache" / "uv"))
     elif system == "Windows":
         local_app_data = os.environ.get("LOCALAPPDATA")
         if local_app_data:
@@ -93,10 +92,7 @@ def _has_uv_internal_parent(path: Path) -> bool:
     ephemeral environments regardless of where the cache root is
     (``~/.cache/uv/``, ``$TMPDIR``, ``--no-cache`` temp dirs, etc.).
     """
-    for parent in path.resolve().parents:
-        if parent.name in _UV_INTERNAL_DIRS:
-            return True
-    return False
+    return any(parent.name in _UV_INTERNAL_DIRS for parent in path.resolve().parents)
 
 
 def is_uv_cache_virtual_env(virtual_env: str | Path) -> bool:

--- a/src/hcli/main.py
+++ b/src/hcli/main.py
@@ -72,17 +72,29 @@ def _get_status_section() -> str:
                 ver = f" {version}" if version else ""
                 lines.append(f"  IDA:   [green]IDA{ver}[/green] at {path}")
             else:
-                lines.append(f"  IDA:   [red]Not found[/red] at {path}")
-                lines.append(f"         → {ENV.HCLI_BINARY_NAME} ida install -d ida-pro:latest -y")
+                lines.extend(
+                    (
+                        f"  IDA:   [red]Not found[/red] at {path}",
+                        f"         → {ENV.HCLI_BINARY_NAME} ida install -d ida-pro:latest -y",
+                    )
+                )
         elif not instances:
-            lines.append("  IDA:   [yellow]Not installed[/yellow]")
-            lines.append(f"         → {ENV.HCLI_BINARY_NAME} ida install -d ida-pro:latest -l LICENSE_ID -y")
-            lines.append(f"         [dim]Find your license ID with: {ENV.HCLI_BINARY_NAME} license list[/dim]")
-            lines.append("         [dim]Installing also activates idalib for Python (import idapro).[/dim]")
+            lines.extend(
+                (
+                    "  IDA:   [yellow]Not installed[/yellow]",
+                    f"         → {ENV.HCLI_BINARY_NAME} ida install -d ida-pro:latest -l LICENSE_ID -y",
+                    f"         [dim]Find your license ID with: {ENV.HCLI_BINARY_NAME} license list[/dim]",
+                    "         [dim]Installing also activates idalib for Python (import idapro).[/dim]",
+                )
+            )
         else:
             valid = sum(1 for p in instances.values() if Path(p).exists() and is_ida_dir(Path(p)))
-            lines.append(f"  IDA:   [yellow]{len(instances)} instance(s), no default set[/yellow] ({valid} valid)")
-            lines.append(f"         → {ENV.HCLI_BINARY_NAME} ida switch")
+            lines.extend(
+                (
+                    f"  IDA:   [yellow]{len(instances)} instance(s), no default set[/yellow] ({valid} valid)",
+                    f"         → {ENV.HCLI_BINARY_NAME} ida switch",
+                )
+            )
 
         # -- idalib (from ida-config.json, independent of hcli default) --
         try:

--- a/tests/lib/test_ke.py
+++ b/tests/lib/test_ke.py
@@ -217,10 +217,10 @@ class TestDownloadFileDiskGuard:
                 return_value=SimpleNamespace(total=0, used=0, free=1024),  # only 1 KB free
             ),
             patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env,
-            pytest.raises(click.ClickException, match="disk space"),
         ):
             mock_env.HCLI_KE_MAX_DOWNLOAD_MB = 0
-            ke_url_handler._download_file(_client(_stream_cm(b"x" * 4096)), "https://h/a/download", dest, None)
+            with pytest.raises(click.ClickException, match="disk space"):
+                ke_url_handler._download_file(_client(_stream_cm(b"x" * 4096)), "https://h/a/download", dest, None)
 
         assert not dest.exists()  # partial file removed
 
@@ -230,10 +230,11 @@ class TestDownloadFileDiskGuard:
         dest = tmp_path / "cached.i64"
         dest.write_bytes(b"GOOD CACHED COPY")
 
-        with patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env, pytest.raises(click.ClickException):
+        with patch("hcli.lib.ida.handler.ke_url_handler.ENV") as mock_env:
             mock_env.HCLI_KE_MAX_DOWNLOAD_MB = 0
             client = _client(_stream_cm(b"", status=500))  # transient server failure
-            ke_url_handler._download_file(client, "https://h/a/download", dest, None)
+            with pytest.raises(click.ClickException):
+                ke_url_handler._download_file(client, "https://h/a/download", dest, None)
 
         assert dest.read_bytes() == b"GOOD CACHED COPY"  # untouched
         assert not (tmp_path / "cached.i64.part").exists()  # partial cleaned up


### PR DESCRIPTION
Ruff 0.16 enables a larger preview rule set than 0.15, which surfaced 47
new findings in src/ and tests/. Formatting was already clean.

Fixed in code:
- FURB110: `x if x else y` -> `x or y` (5 sites)
- FURB113: consecutive `list.append()` -> `list.extend()` (5 sites)
- PLC0207: `split(sep)[0]` -> `split(sep, maxsplit=1)[0]` (3 sites)
- PLW0108: `default_factory=lambda: T()` -> `default_factory=T` (3 sites)
- SIM110: membership loop -> `any(...)` in `_has_uv_internal_parent`
- PT012: hoist mock setup out of `pytest.raises()` blocks (2 tests)
- D301: raw docstrings for the two that escape Windows paths

Suppressed with a rationale in pyproject.toml:
- ASYNC240: hcli runs a single asyncio task per command and has no
  trio/anyio path API; the flagged calls are cheap stat/resolve calls.
- D301 under src/hcli/commands/: click uses a literal \b (U+0008) on its
  own line to mark paragraphs it must not rewrap, so those command
  docstrings cannot become raw strings without breaking --help output.

Verified: ruff 0.16.5 format --check, check, and check --select I all
pass, as do the same gates on 0.15.8; mypy is clean; the plugin schema is
unchanged and the test suite shows no new failures.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AcULGFRgrktuiduhRjYdAg