### PR TITLE
Named plugin repositories, with authenticated access to private plugins

### DIFF
--- a/docs/reference/plugin-repository-architecture.md
+++ b/docs/reference/plugin-repository-architecture.md
@@ -5,6 +5,9 @@
 1. **User-facing portal showcasing the plugins** - The [plugins.hex-rays.com](https://plugins.hex-rays.com/) is a web interface to the collection of available IDA Pro plugins.
 2. **JSON Index** - The new plugin repository publishes a JSON document within [github.com/HexRaysSA/plugin-repository](https://github.com/HexRaysSA/plugin-repository). This file is the index of all available plugins, their versions and metadata, and download URLs.
 3. **GitHub Actions** - GitHub Actions runs regularly to update the JSON document with plugins discovered across GitHub. The raw index data is available [here](https://raw.githubusercontent.com/HexRaysSA/plugin-repository/refs/heads/v1/plugin-repository.json).
+4. **Named repositories** - hcli reads its repositories from `.Settings.plugin-repositories` in `ida-config.json` and merges them client-side, so it always knows which repository served a plugin. Two are shipped and reserved: `community` (`https://community.plugins.hex-rays.com/plugin-repository.json`, anonymous) and `hexrays` (`https://hexrays.plugins.hex-rays.com/plugin-repository.json`, which requires `hcli login` and serves only the private plugins your account is entitled to). Manage the rest with `hcli plugin repo list | add | remove | set-default`.
+
+    A reference may name a repository: `hcli plugin install hexrays/<name>`. Without a prefix it resolves in the repository named by `.Settings.default-plugin-repository` (`community` by default), while `hcli plugin search` spans every configured repository and reports any it could not reach.
 
 
 ## How It Works

--- a/docs/schemas/ida-plugin.json
+++ b/docs/schemas/ida-plugin.json
@@ -413,9 +413,10 @@
     "URLs": {
       "properties": {
         "repository": {
-          "description": "URL of the GitHub repository containing the source code for the plugin.",
+          "description": "Canonical URL identifying the plugin: the GitHub repository containing its source code, or, for plugins distributed through the Hex-Rays portal, its page there.",
           "examples": [
-            "https://github.com/org/project"
+            "https://github.com/org/project",
+            "https://plugins.hex-rays.com/org/repo/name"
           ],
           "title": "Repository",
           "type": "string"
@@ -430,7 +431,7 @@
             }
           ],
           "default": null,
-          "description": "URL of a website describing the plugin, if different from the GitHub repo.",
+          "description": "URL of a website describing the plugin, if different from the repository.",
           "title": "Homepage"
         }
       },

--- a/src/hcli/__init__.py
+++ b/src/hcli/__init__.py
@@ -1,1 +1,4 @@
 __version__ = "0.23.0"
+
+# User-Agent for hcli's HTTP clients, so servers can identify hcli traffic.
+USER_AGENT = f"hcli/{__version__}"

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -11,7 +11,9 @@ import hcli.lib.ida.plugin.repo.file
 import hcli.lib.ida.plugin.repo.fs
 import hcli.lib.ida.plugin.repo.github
 from hcli.lib.console import console
-from hcli.lib.ida import get_ida_config
+from hcli.lib.ida import get_default_plugin_repository_name, get_plugin_repositories
+from hcli.lib.ida.plugin.reference import PluginReference
+from hcli.lib.ida.plugin.repo.aggregate import AggregatePluginRepo
 from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo, is_plugin_bundle_zip
 from hcli.lib.ida.python import PipOptions
 
@@ -96,16 +98,20 @@ def plugin(
     plugin_repo: hcli.lib.ida.plugin.repo.BasePluginRepo
     try:
         if repo is None:
-            config = get_ida_config()
-
-            url = config.settings.plugin_repository.url
-            if not url:
+            repositories = get_plugin_repositories()
+            if not repositories:
                 console.print(
-                    "[red]Missing plugin repository URL[/red]. Provide this in ida-config.json (.Settings.plugin-repository.url)"
+                    "[red]No plugin repositories configured[/red]. "
+                    "Provide these in ida-config.json (.Settings.plugin-repositories)"
                 )
                 raise click.Abort()
 
-            plugin_repo = hcli.lib.ida.plugin.repo.file.JSONFilePluginRepo.from_url(url)
+            # Repositories are fetched lazily, so building the aggregate costs
+            # nothing until a command actually looks something up.
+            aggregate = AggregatePluginRepo(repositories)
+            ctx.obj["plugin_repos"] = aggregate
+            ctx.obj["default_plugin_repo"] = get_default_plugin_repository_name()
+            plugin_repo = aggregate
 
         elif repo == "github":
             try:
@@ -155,19 +161,54 @@ def plugin(
         if repo == "github":
             console.print("[red]Cannot connect to GitHub - network unavailable.[/red]")
         elif repo is None:
-            config = get_ida_config()
-            url = config.settings.plugin_repository.url
-            console.print(f"[red]Cannot connect to plugin repository at {url} - network unavailable.[/red]")
+            console.print("[red]Cannot connect to the plugin repositories - network unavailable.[/red]")
         else:
             console.print("[red]Cannot connect to plugin repository - network unavailable.[/red]")
         console.print("Please check your internet connection.")
         raise click.Abort()
 
     ctx.obj["plugin_repo"] = plugin_repo
+    ctx.obj.setdefault("plugin_repos", None)
 
     if offline and not pip_find_links and not isinstance(plugin_repo, PluginBundleRepo):
         console.print("[red]--offline requires --pip-find-links or a plugin bundle repository[/red]")
         raise click.Abort()
+
+
+def repo_for_reference(ctx: click.Context, ref: PluginReference) -> hcli.lib.ida.plugin.repo.BasePluginRepo:
+    """The repository a reference should be resolved against.
+
+    Unprefixed references resolve in the default repository; a "repo/" prefix
+    resolves in that repository alone. Under an explicit --repo there is only
+    one repository to search, so a prefix has nothing to select and is refused
+    rather than silently ignored.
+    """
+    aggregate: AggregatePluginRepo | None = ctx.obj.get("plugin_repos")
+
+    if aggregate is None:
+        if ref.repo:
+            console.print(
+                f"[red]Cannot use the repository prefix '{ref.repo}/' with --repo[/red]: "
+                f"--repo already selects the only repository searched."
+            )
+            raise click.Abort()
+        return ctx.obj["plugin_repo"]
+
+    name = ref.repo or ctx.obj["default_plugin_repo"]
+    if name not in aggregate.repositories:
+        if ref.repo:
+            known = ", ".join(sorted(aggregate.repositories)) or "none"
+            console.print(f"[red]Unknown plugin repository '{ref.repo}'[/red]. Configured: {known}")
+        else:
+            console.print(
+                f"[red]The default plugin repository '{name}' is not configured[/red]. "
+                f"Fix .Settings.default-plugin-repository in ida-config.json."
+            )
+        raise click.Abort()
+
+    # A named scope is a request for THAT repository: if it cannot be reached,
+    # that is the answer, not a quietly smaller search.
+    return hcli.lib.ida.plugin.repo.file.JSONFilePluginRepo(aggregate.get_plugins_in(name))
 
 
 plugin.add_command(get_plugin_status, name="status")

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -11,7 +11,7 @@ import hcli.lib.ida.plugin.repo.file
 import hcli.lib.ida.plugin.repo.fs
 import hcli.lib.ida.plugin.repo.github
 from hcli.lib.console import console
-from hcli.lib.ida import get_default_plugin_repository_name, get_plugin_repositories
+from hcli.lib.ida import get_default_plugin_repository_name, get_ida_config, get_plugin_repositories
 from hcli.lib.ida.plugin.reference import PluginReference
 from hcli.lib.ida.plugin.repo.aggregate import AggregatePluginRepo
 from hcli.lib.ida.plugin.repo.bundle import PluginBundleRepo, is_plugin_bundle_zip
@@ -98,7 +98,9 @@ def plugin(
     plugin_repo: hcli.lib.ida.plugin.repo.BasePluginRepo
     try:
         if repo is None:
-            repositories = get_plugin_repositories()
+            # One read of ida-config.json for both the map and the default.
+            ida_config = get_ida_config()
+            repositories = get_plugin_repositories(ida_config)
             if not repositories:
                 console.print(
                     "[red]No plugin repositories configured[/red]. "
@@ -110,7 +112,7 @@ def plugin(
             # nothing until a command actually looks something up.
             aggregate = AggregatePluginRepo(repositories)
             ctx.obj["plugin_repos"] = aggregate
-            ctx.obj["default_plugin_repo"] = get_default_plugin_repository_name()
+            ctx.obj["default_plugin_repo"] = get_default_plugin_repository_name(ida_config)
             plugin_repo = aggregate
 
         elif repo == "github":
@@ -208,7 +210,15 @@ def repo_for_reference(ctx: click.Context, ref: PluginReference) -> hcli.lib.ida
 
     # A named scope is a request for THAT repository: if it cannot be reached,
     # that is the answer, not a quietly smaller search.
-    return hcli.lib.ida.plugin.repo.file.JSONFilePluginRepo(aggregate.get_plugins_in(name))
+    plugins = aggregate.get_plugins_in(name)
+
+    # The survey path reports these through the search result; on this path
+    # there is no result to carry them, so say it here rather than drop a
+    # plugin silently.
+    for note in aggregate.notes():
+        console.print(f"[yellow]Warning:[/yellow] repository {note}")
+
+    return hcli.lib.ida.plugin.repo.file.JSONFilePluginRepo(plugins)
 
 
 plugin.add_command(get_plugin_status, name="status")

--- a/src/hcli/commands/plugin/__init__.py
+++ b/src/hcli/commands/plugin/__init__.py
@@ -210,7 +210,18 @@ def repo_for_reference(ctx: click.Context, ref: PluginReference) -> hcli.lib.ida
 
     # A named scope is a request for THAT repository: if it cannot be reached,
     # that is the answer, not a quietly smaller search.
-    plugins = aggregate.get_plugins_in(name)
+    try:
+        plugins = aggregate.get_plugins_in(name)
+    except (httpx.ConnectError, httpx.TimeoutException):
+        # The group callback used to catch this when it did the fetching. The
+        # fetch moved here, and httpx connection errors often stringify to "",
+        # so without this the user gets a bare "Error:".
+        console.print(
+            f"[red]Cannot connect to plugin repository '{name}' at "
+            f"{aggregate.repositories[name].url} - network unavailable.[/red]"
+        )
+        console.print("Please check your internet connection.")
+        raise click.Abort()
 
     # The survey path reports these through the search result; on this path
     # there is no result to carry them, so say it here rather than drop a

--- a/src/hcli/commands/plugin/install.py
+++ b/src/hcli/commands/plugin/install.py
@@ -184,11 +184,16 @@ def install_plugin(
 
         else:
             logger.info("finding plugin in repository")
-            plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
             try:
                 ref = parse_plugin_reference(plugin_spec)
             except ValueError as e:
                 raise click.BadParameter(f"invalid plugin reference: {plugin_spec!r}: {e}")
+
+            from hcli.commands.plugin import repo_for_reference
+
+            # Installing is a choice, not a survey: resolve in exactly one
+            # repository -- the one named by the prefix, else the default.
+            plugin_repo: BasePluginRepo = repo_for_reference(ctx, ref)
 
             # reconstruct the plugin_spec for repo lookup without the @host suffix
             bare_spec = ref.name + ref.version_spec
@@ -370,6 +375,11 @@ def install_plugin(
         console.print(f"Only one plugin with the bare name '{e.requested_name}' can be installed at a time.")
         console.print("Uninstall the existing plugin first, then install the other qualified plugin.")
         raise click.Abort()
+
+    except click.Abort:
+        # Already reported by whoever raised it; re-wrapping would print a
+        # second, empty "Error:" line.
+        raise
 
     except Exception as e:
         logger.debug("error: %s", e, exc_info=True)

--- a/src/hcli/commands/plugin/repo.py
+++ b/src/hcli/commands/plugin/repo.py
@@ -14,6 +14,7 @@ from hcli.lib.ida import (
     COMMUNITY_REPO_NAME,
     PLUGIN_REPOSITORY_NAME_RE,
     RESERVED_PLUGIN_REPOSITORIES,
+    IDAConfigJson,
     PluginRepositoryConfig,
     get_default_plugin_repository_name,
     get_ida_config,
@@ -31,8 +32,8 @@ def repo(ctx) -> None:
     """Manage plugin repositories."""
 
 
-def _save_repositories(repos: dict[str, PluginRepositoryConfig], default: str | None) -> None:
-    config = get_ida_config()
+def _save_repositories(config: IDAConfigJson, repos: dict[str, PluginRepositoryConfig], default: str | None) -> None:
+    """Write back the config already in hand, rather than re-reading it."""
     config.settings.plugin_repositories = repos
     if default is not None:
         config.settings.default_plugin_repository = default
@@ -43,8 +44,9 @@ def _save_repositories(repos: dict[str, PluginRepositoryConfig], default: str | 
 @click.pass_context
 def list_repos(ctx) -> None:
     """List the configured plugin repositories."""
-    repos = get_plugin_repositories()
-    default = get_default_plugin_repository_name()
+    config = get_ida_config()
+    repos = get_plugin_repositories(config)
+    default = get_default_plugin_repository_name(config)
 
     table = rich.table.Table(show_header=True, box=None)
     table.add_column("name", style="blue")
@@ -85,7 +87,7 @@ def add_repo(ctx, name: str, url: str) -> None:
     repos = dict(config.settings.plugin_repositories)
     existing = repos.get(name)
     repos[name] = PluginRepositoryConfig(url=url)
-    _save_repositories(repos, None)
+    _save_repositories(config, repos, None)
 
     verb = "updated" if existing else "added"
     console.print(f"{verb} plugin repository '{name}' -> {url}")
@@ -115,9 +117,9 @@ def remove_repo(ctx, name: str) -> None:
             f"[yellow]'{name}' was the default repository[/yellow]; unprefixed installs now use "
             f"'{COMMUNITY_REPO_NAME}'."
         )
-        _save_repositories(repos, COMMUNITY_REPO_NAME)
+        _save_repositories(config, repos, COMMUNITY_REPO_NAME)
     else:
-        _save_repositories(repos, None)
+        _save_repositories(config, repos, None)
 
     console.print(f"removed plugin repository '{name}'")
 
@@ -127,13 +129,13 @@ def remove_repo(ctx, name: str) -> None:
 @click.pass_context
 def set_default_repo(ctx, name: str) -> None:
     """Set the repository used for references with no repo/ prefix."""
-    repos = get_plugin_repositories()
+    config = get_ida_config()
+    repos = get_plugin_repositories(config)
     if name not in repos:
         known = ", ".join(sorted(repos)) or "none"
         console.print(f"[red]No such plugin repository '{name}'[/red]. Configured: {known}")
         raise click.Abort()
 
-    config = get_ida_config()
     config.settings.default_plugin_repository = name
     set_ida_config(config)
     console.print(f"default plugin repository is now '{name}'")

--- a/src/hcli/commands/plugin/repo.py
+++ b/src/hcli/commands/plugin/repo.py
@@ -3,19 +3,140 @@
 from __future__ import annotations
 
 import logging
+from urllib.parse import urlparse
 
+import rich.table
 import rich_click as click
+from rich.markup import escape
 
 from hcli.lib.console import console
+from hcli.lib.ida import (
+    COMMUNITY_REPO_NAME,
+    PLUGIN_REPOSITORY_NAME_RE,
+    RESERVED_PLUGIN_REPOSITORIES,
+    PluginRepositoryConfig,
+    get_default_plugin_repository_name,
+    get_ida_config,
+    get_plugin_repositories,
+    set_ida_config,
+)
 from hcli.lib.ida.plugin.repo.file import JSONFilePluginRepo
 
 logger = logging.getLogger(__name__)
 
 
-@click.group(hidden=True)
+@click.group()
 @click.pass_context
 def repo(ctx) -> None:
     """Manage plugin repositories."""
+
+
+def _save_repositories(repos: dict[str, PluginRepositoryConfig], default: str | None) -> None:
+    config = get_ida_config()
+    config.settings.plugin_repositories = repos
+    if default is not None:
+        config.settings.default_plugin_repository = default
+    set_ida_config(config)
+
+
+@repo.command(name="list")
+@click.pass_context
+def list_repos(ctx) -> None:
+    """List the configured plugin repositories."""
+    repos = get_plugin_repositories()
+    default = get_default_plugin_repository_name()
+
+    table = rich.table.Table(show_header=True, box=None)
+    table.add_column("name", style="blue")
+    table.add_column("url", style="grey69")
+    table.add_column("")
+
+    for name in sorted(repos):
+        entry = repos[name]
+        tags = []
+        if name == default:
+            tags.append("default")
+        if entry.reserved:
+            tags.append("reserved")
+        table.add_row(name, entry.url, " ".join(tags))
+
+    console.print(table)
+
+
+@repo.command(name="add")
+@click.argument("name")
+@click.argument("url")
+@click.pass_context
+def add_repo(ctx, name: str, url: str) -> None:
+    """Add a plugin repository."""
+    if name in RESERVED_PLUGIN_REPOSITORIES:
+        console.print(f"[red]'{name}' is a reserved repository[/red] and always resolves to its Hex-Rays URL.")
+        raise click.Abort()
+    if not PLUGIN_REPOSITORY_NAME_RE.match(name):
+        console.print(
+            f"[red]Invalid repository name '{name}'[/red]: must match {escape(PLUGIN_REPOSITORY_NAME_RE.pattern)}"
+        )
+        raise click.Abort()
+    if urlparse(url).scheme not in ("https", "file"):
+        console.print(f"[red]Invalid repository url '{url}'[/red]: must be https:// or file://")
+        raise click.Abort()
+
+    config = get_ida_config()
+    repos = dict(config.settings.plugin_repositories)
+    existing = repos.get(name)
+    repos[name] = PluginRepositoryConfig(url=url)
+    _save_repositories(repos, None)
+
+    verb = "updated" if existing else "added"
+    console.print(f"{verb} plugin repository '{name}' -> {url}")
+
+
+@repo.command(name="remove")
+@click.argument("name")
+@click.pass_context
+def remove_repo(ctx, name: str) -> None:
+    """Remove a plugin repository."""
+    if name in RESERVED_PLUGIN_REPOSITORIES:
+        console.print(f"[red]'{name}' is a reserved repository[/red] and cannot be removed.")
+        raise click.Abort()
+
+    config = get_ida_config()
+    repos = dict(config.settings.plugin_repositories)
+    if name not in repos:
+        console.print(f"[red]No such plugin repository '{name}'[/red].")
+        raise click.Abort()
+
+    del repos[name]
+    default = config.settings.default_plugin_repository
+    # Leaving the default pointing at a repository that no longer exists would
+    # turn every unprefixed install into a confusing "plugin not found".
+    if default == name:
+        console.print(
+            f"[yellow]'{name}' was the default repository[/yellow]; unprefixed installs now use "
+            f"'{COMMUNITY_REPO_NAME}'."
+        )
+        _save_repositories(repos, COMMUNITY_REPO_NAME)
+    else:
+        _save_repositories(repos, None)
+
+    console.print(f"removed plugin repository '{name}'")
+
+
+@repo.command(name="set-default")
+@click.argument("name")
+@click.pass_context
+def set_default_repo(ctx, name: str) -> None:
+    """Set the repository used for references with no repo/ prefix."""
+    repos = get_plugin_repositories()
+    if name not in repos:
+        known = ", ".join(sorted(repos)) or "none"
+        console.print(f"[red]No such plugin repository '{name}'[/red]. Configured: {known}")
+        raise click.Abort()
+
+    config = get_ida_config()
+    config.settings.default_plugin_repository = name
+    set_ida_config(config)
+    console.print(f"default plugin repository is now '{name}'")
 
 
 @repo.command()

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import rich.table
@@ -84,6 +84,9 @@ class KeywordMatchEntry(BaseModel):
     name: str
     version: str
     repository: str | None
+    # Which configured repository served this plugin. None under --repo, where
+    # there is only one and naming it would be noise.
+    repo: str | None = None
     compatible: bool
     installed: bool
     installed_version: str | None
@@ -93,6 +96,9 @@ class KeywordMatchEntry(BaseModel):
 class KeywordQueryResult(BaseModel):
     query: str | None
     results: list[KeywordMatchEntry]
+    # Repositories that could not be consulted for this search, as short
+    # human-readable reasons. Additive: absent means nothing was skipped.
+    skipped: list[str] = []
 
 
 class AmbiguityErrorResult(BaseModel):
@@ -407,6 +413,7 @@ def collect_keyword_matches(
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
+    repo_of: Callable[[Plugin], str | None] | None = None,
 ) -> list[KeywordMatchEntry]:
     matches: list[KeywordMatchEntry] = []
 
@@ -415,6 +422,7 @@ def collect_keyword_matches(
             continue
 
         latest_metadata = get_latest_plugin_metadata(plugin)
+        repo = repo_of(plugin) if repo_of is not None else None
 
         if not is_compatible_plugin(plugin, current_platform, current_version):
             matches.append(
@@ -422,6 +430,7 @@ def collect_keyword_matches(
                     name=latest_metadata.plugin.name,
                     version=latest_metadata.plugin.version,
                     repository=latest_metadata.plugin.urls.repository,
+                    repo=repo,
                     compatible=False,
                     installed=False,
                     installed_version=None,
@@ -442,6 +451,7 @@ def collect_keyword_matches(
                 name=latest_metadata.plugin.name,
                 version=latest_metadata.plugin.version,
                 repository=latest_metadata.plugin.urls.repository,
+                repo=repo,
                 compatible=True,
                 installed=installed_record is not None,
                 installed_version=installed_version,
@@ -458,18 +468,36 @@ def collect_keyword_query_result(
     current_version: str,
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
+    repo_of: Callable[[Plugin], str | None] | None = None,
+    skipped: list[str] | None = None,
 ) -> KeywordQueryResult:
     return KeywordQueryResult(
         query=query or None,
-        results=collect_keyword_matches(plugins, query, current_version, current_platform, installed_records),
+        results=collect_keyword_matches(
+            plugins, query, current_version, current_platform, installed_records, repo_of=repo_of
+        ),
+        skipped=skipped or [],
     )
 
 
-def render_keyword_query_text(result: KeywordQueryResult) -> None:
+def _display_name(match: KeywordMatchEntry, default_repo: str | None) -> str:
+    """The string a user must type to install this result.
+
+    A plugin from the default repository installs by bare name; anything else
+    needs its "repo/" prefix, so showing the prefix here is not decoration, it
+    is the command.
+    """
+    if match.repo and match.repo != default_repo:
+        return f"{match.repo}/{match.name}"
+    return match.name
+
+
+def render_keyword_query_text(result: KeywordQueryResult, default_repo: str | None = None) -> None:
     matches = result.results
 
     if not matches:
         console.print("[grey69]No plugins found[/grey69]")
+        _render_skipped(result)
         return
 
     table = rich.table.Table(show_header=False, box=None)
@@ -479,9 +507,10 @@ def render_keyword_query_text(result: KeywordQueryResult) -> None:
     table.add_column("repo", style="grey69")
 
     for match in matches:
+        label = _display_name(match, default_repo)
         if not match.compatible:
             table.add_row(
-                f"[grey69]{match.name} (incompatible)[/grey69]",
+                f"[grey69]{label} (incompatible)[/grey69]",
                 f"[grey69]{match.version}[/grey69]",
                 "",
                 match.repository,
@@ -494,9 +523,21 @@ def render_keyword_query_text(result: KeywordQueryResult) -> None:
         elif match.installed:
             status = "installed"
 
-        table.add_row(f"[blue]{match.name}[/blue]", match.version, status, match.repository)
+        table.add_row(f"[blue]{label}[/blue]", match.version, status, match.repository)
 
     console.print(table)
+    _render_skipped(result)
+
+
+def _render_skipped(result: KeywordQueryResult) -> None:
+    """Say which repositories did not contribute, after the results.
+
+    Silence would misrepresent an incomplete search as an empty one -- the
+    common case being a logged-out user, for whom the private repository simply
+    is not there.
+    """
+    for reason in result.skipped:
+        console.print(f"[grey69]repository skipped -- {reason}[/grey69]")
 
 
 def _has_exact_name_match(plugins: list[Plugin], name: str) -> bool:
@@ -547,19 +588,33 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
             console.print()
 
         plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
+        aggregate = ctx.obj.get("plugin_repos")
+        default_repo = ctx.obj.get("default_plugin_repo")
+
+        # Searching is a survey: it spans every configured repository, ignoring
+        # the default, and reports the ones it could not reach rather than
+        # failing on them.
         plugins: list[Plugin] = plugin_repo.get_plugins()
+        repo_of = aggregate.repo_of if aggregate is not None else None
+        skipped = [f.describe() for f in aggregate.failures()] if aggregate is not None else []
         installed_records = get_installed_plugin_records()
 
         ref = resolve_query_reference(plugins, query)
 
         if ref is None:
             keyword_result = collect_keyword_query_result(
-                plugins, query or "", current_version, current_platform, installed_records
+                plugins,
+                query or "",
+                current_version,
+                current_platform,
+                installed_records,
+                repo_of=repo_of,
+                skipped=skipped,
             )
             if json_output:
                 print_json(_dump_result(keyword_result))
             else:
-                render_keyword_query_text(keyword_result)
+                render_keyword_query_text(keyword_result, default_repo=default_repo)
             return
 
         try:

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -96,9 +96,10 @@ class KeywordMatchEntry(BaseModel):
 class KeywordQueryResult(BaseModel):
     query: str | None
     results: list[KeywordMatchEntry]
-    # Repositories that could not be consulted for this search, as short
-    # human-readable reasons. Additive: absent means nothing was skipped.
-    skipped: list[str] = []
+    # What to know about the repositories consulted: one unreachable, or one
+    # that served plugins it is not entitled to. Additive: empty means the
+    # results are the whole picture.
+    repository_notes: list[str] = []
 
 
 class AmbiguityErrorResult(BaseModel):
@@ -469,14 +470,14 @@ def collect_keyword_query_result(
     current_platform: str,
     installed_records: list[InstalledPluginRecord],
     repo_of: Callable[[Plugin], str | None] | None = None,
-    skipped: list[str] | None = None,
+    repository_notes: list[str] | None = None,
 ) -> KeywordQueryResult:
     return KeywordQueryResult(
         query=query or None,
         results=collect_keyword_matches(
             plugins, query, current_version, current_platform, installed_records, repo_of=repo_of
         ),
-        skipped=skipped or [],
+        repository_notes=repository_notes or [],
     )
 
 
@@ -497,7 +498,7 @@ def render_keyword_query_text(result: KeywordQueryResult, default_repo: str | No
 
     if not matches:
         console.print("[grey69]No plugins found[/grey69]")
-        _render_skipped(result)
+        _render_repository_notes(result)
         return
 
     table = rich.table.Table(show_header=False, box=None)
@@ -526,18 +527,19 @@ def render_keyword_query_text(result: KeywordQueryResult, default_repo: str | No
         table.add_row(f"[blue]{label}[/blue]", match.version, status, match.repository)
 
     console.print(table)
-    _render_skipped(result)
+    _render_repository_notes(result)
 
 
-def _render_skipped(result: KeywordQueryResult) -> None:
+def _render_repository_notes(result: KeywordQueryResult) -> None:
     """Say which repositories did not contribute, after the results.
 
     Silence would misrepresent an incomplete search as an empty one -- the
     common case being a logged-out user, for whom the private repository simply
     is not there.
     """
-    for reason in result.skipped:
-        console.print(f"[grey69]repository skipped -- {reason}[/grey69]")
+
+    for note in result.repository_notes:
+        console.print(f"[grey69]repository {note}[/grey69]")
 
 
 def _has_exact_name_match(plugins: list[Plugin], name: str) -> bool:
@@ -596,7 +598,7 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
         # failing on them.
         plugins: list[Plugin] = plugin_repo.get_plugins()
         repo_of = aggregate.repo_of if aggregate is not None else None
-        skipped = [f.describe() for f in aggregate.failures()] if aggregate is not None else []
+        repository_notes = aggregate.notes() if aggregate is not None else []
         installed_records = get_installed_plugin_records()
 
         ref = resolve_query_reference(plugins, query)
@@ -609,7 +611,7 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
                 current_platform,
                 installed_records,
                 repo_of=repo_of,
-                skipped=skipped,
+                repository_notes=repository_notes,
             )
             if json_output:
                 print_json(_dump_result(keyword_result))

--- a/src/hcli/commands/plugin/search.py
+++ b/src/hcli/commands/plugin/search.py
@@ -9,7 +9,7 @@ from typing import Any
 import rich.table
 import rich_click as click
 import semantic_version
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from hcli.lib.console import console, print_json
 from hcli.lib.ida import (
@@ -99,7 +99,7 @@ class KeywordQueryResult(BaseModel):
     # What to know about the repositories consulted: one unreachable, or one
     # that served plugins it is not entitled to. Additive: empty means the
     # results are the whole picture.
-    repository_notes: list[str] = []
+    repository_notes: list[str] = Field(default_factory=list)
 
 
 class AmbiguityErrorResult(BaseModel):
@@ -227,7 +227,7 @@ def collect_version_entries(
                 compatible=is_compatible,
                 currently_installed=currently_installed,
                 upgradable=upgradable,
-            )
+            ),
         )
 
     return entries, (installed_record.version if installed_record is not None else None)
@@ -281,7 +281,11 @@ def collect_plugin_name_query_result(
 ) -> PluginNameQueryResult:
     plugin = get_plugin_by_name(plugins, ref.name, host=ref.host)
     entries, installed_version = collect_version_entries(
-        plugin, get_all_versions_newest_first(plugin), current_version, current_platform, installed_records
+        plugin,
+        get_all_versions_newest_first(plugin),
+        current_version,
+        current_platform,
+        installed_records,
     )
     return PluginNameQueryResult(
         plugin=collect_plugin_metadata(get_latest_plugin_metadata(plugin)),
@@ -369,7 +373,11 @@ def collect_plugin_version_range_query_result(
         raise KeyError(f"no versions matching {ref.version_spec!r} found for plugin {plugin.name!r}")
 
     entries, installed_version = collect_version_entries(
-        plugin, matching_versions, current_version, current_platform, installed_records
+        plugin,
+        matching_versions,
+        current_version,
+        current_platform,
+        installed_records,
     )
     return PluginVersionRangeQueryResult(
         plugin=collect_plugin_metadata(plugin.versions[matching_versions[0]][0].metadata),
@@ -436,7 +444,7 @@ def collect_keyword_matches(
                     installed=False,
                     installed_version=None,
                     upgradable=False,
-                )
+                ),
             )
             continue
 
@@ -444,7 +452,7 @@ def collect_keyword_matches(
         installed_record = find_installed_matching(plugin, installed_records)
         installed_version = installed_record.version if installed_record is not None else None
         upgradable = installed_version is not None and parse_plugin_version(
-            latest_compatible_metadata.plugin.version
+            latest_compatible_metadata.plugin.version,
         ) > parse_plugin_version(installed_version)
 
         matches.append(
@@ -457,7 +465,7 @@ def collect_keyword_matches(
                 installed=installed_record is not None,
                 installed_version=installed_version,
                 upgradable=upgradable,
-            )
+            ),
         )
 
     return matches
@@ -475,7 +483,12 @@ def collect_keyword_query_result(
     return KeywordQueryResult(
         query=query or None,
         results=collect_keyword_matches(
-            plugins, query, current_version, current_platform, installed_records, repo_of=repo_of
+            plugins,
+            query,
+            current_version,
+            current_platform,
+            installed_records,
+            repo_of=repo_of,
         ),
         repository_notes=repository_notes or [],
     )
@@ -537,7 +550,6 @@ def _render_repository_notes(result: KeywordQueryResult) -> None:
     common case being a logged-out user, for whom the private repository simply
     is not there.
     """
-
     for note in result.repository_notes:
         console.print(f"[grey69]repository {note}[/grey69]")
 
@@ -622,7 +634,11 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
         try:
             if ref.version_spec:
                 spec_result = collect_plugin_spec_query_result(
-                    plugins, ref, current_version, current_platform, installed_records
+                    plugins,
+                    ref,
+                    current_version,
+                    current_platform,
+                    installed_records,
                 )
                 if json_output:
                     print_json(_dump_result(spec_result))
@@ -630,7 +646,11 @@ def search_plugins(ctx, query: str | None = None, json_output: bool = False) -> 
                     render_plugin_spec_query_text(spec_result)
             else:
                 name_result = collect_plugin_name_query_result(
-                    plugins, ref, current_version, current_platform, installed_records
+                    plugins,
+                    ref,
+                    current_version,
+                    current_platform,
+                    installed_records,
                 )
                 if json_output:
                     print_json(_dump_result(name_result))

--- a/src/hcli/commands/plugin/upgrade.py
+++ b/src/hcli/commands/plugin/upgrade.py
@@ -88,7 +88,16 @@ def upgrade_plugin(ctx, plugin: str, no_build_isolation: bool) -> None:
         # when the repository has a colliding name.
         bare_spec = ref.name + ref.version_spec
         logger.info("finding plugin in repository")
-        plugin_repo: BasePluginRepo = ctx.obj["plugin_repo"]
+        # An upgrade is anchored to the installed name@host, so it may resolve
+        # across every configured repository -- the plugin's identity, not the
+        # default scope, decides which one answers. An explicit prefix narrows
+        # that to one repository, mirroring the @host check above.
+        if ref.repo:
+            from hcli.commands.plugin import repo_for_reference
+
+            plugin_repo: BasePluginRepo = repo_for_reference(ctx, ref)
+        else:
+            plugin_repo = ctx.obj["plugin_repo"]
         try:
             plugin_name, buf = plugin_repo.fetch_compatible_plugin_from_spec(
                 bare_spec, current_ida_platform, current_ida_version, host=installed.host

--- a/src/hcli/commands/plugin/upgrade.py
+++ b/src/hcli/commands/plugin/upgrade.py
@@ -138,6 +138,17 @@ def upgrade_plugin(ctx, plugin: str, no_build_isolation: bool) -> None:
         explain_failed_to_detect_ida_version(console)
         raise click.Abort()
 
+    except KeyError as e:
+        # get_plugins() drops repositories it could not consult, so a miss here
+        # may mean "your session expired", not "no such plugin". Say which.
+        logger.debug("error: %s", e, exc_info=True)
+        console.print(f"[red]Error[/red]: {e}")
+        aggregate = ctx.obj.get("plugin_repos")
+        if aggregate is not None:
+            for note in aggregate.notes():
+                console.print(f"[yellow]Warning:[/yellow] repository {note}")
+        raise click.Abort()
+
     except click.Abort:
         raise
 

--- a/src/hcli/lib/api/common.py
+++ b/src/hcli/lib/api/common.py
@@ -13,11 +13,10 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
-from hcli import __version__
+from hcli import USER_AGENT
 from hcli.env import ENV
-from hcli.lib.auth import get_auth_service
+from hcli.lib.auth import get_auth_service, get_credential_headers
 from hcli.lib.console import console, stderr_console
-from hcli.lib.constants.auth import CredentialType
 from hcli.lib.util.cache import get_cache_directory
 from hcli.lib.util.io import NoSpaceError, check_free_space
 
@@ -54,7 +53,7 @@ class APIClient:
         self.client = httpx.AsyncClient(
             base_url=ENV.HCLI_API_URL,
             timeout=httpx.Timeout(60.0, write=None),  # No timeout for uploads
-            headers={"User-Agent": f"hcli/{__version__}"},
+            headers={"User-Agent": USER_AGENT},
         )
 
     async def __aenter__(self):
@@ -68,19 +67,9 @@ class APIClient:
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
 
         if auth:
-            auth_service = get_auth_service()
-            if auth_service.is_logged_in():
-                auth_type = auth_service.get_auth_type()
-                if auth_type["type"] == CredentialType.INTERACTIVE:
-                    token = auth_service.get_access_token()
-                    if token:
-                        headers["Authorization"] = f"Bearer {token}"
-                else:
-                    api_key = auth_service.get_api_key()
-                    if api_key:
-                        headers["x-api-key"] = api_key
-            else:
+            if not get_auth_service().is_logged_in():
                 raise NotLoggedInError("Authentication required but user is not logged in")
+            headers.update(get_credential_headers())
 
         return headers
 

--- a/src/hcli/lib/auth/__init__.py
+++ b/src/hcli/lib/auth/__init__.py
@@ -652,17 +652,15 @@ class AuthService:
 
 
 # Global auth service instance accessor
-def get_optional_auth_headers() -> dict[str, str]:
-    """Authentication headers for the current credentials, or {} when logged out.
+def get_credential_headers() -> dict[str, str]:
+    """Map the current credentials onto request headers.
 
-    Unlike APIClient._get_headers, being logged out is not an error here:
-    callers use this for endpoints that serve both anonymous and personalized
-    responses, such as a plugin repository document.
+    The one place that knows which header shape each credential type uses.
+    Says nothing about whether being logged out is acceptable -- that is the
+    caller's policy, and it differs: an API call requires credentials, while a
+    plugin repository serves anonymous and personalized responses alike.
     """
     auth_service = get_auth_service()
-    auth_service.ensure_initialized()
-    if not auth_service.is_logged_in():
-        return {}
 
     if auth_service.get_auth_type()["type"] == CredentialType.INTERACTIVE:
         token = auth_service.get_access_token()
@@ -674,6 +672,19 @@ def get_optional_auth_headers() -> dict[str, str]:
             return {"x-api-key": api_key}
 
     return {}
+
+
+def get_optional_auth_headers() -> dict[str, str]:
+    """Credential headers, or {} when logged out.
+
+    For endpoints that answer both anonymously and personally, where being
+    logged out is an ordinary state rather than an error.
+    """
+    auth_service = get_auth_service()
+    auth_service.ensure_initialized()
+    if not auth_service.is_logged_in():
+        return {}
+    return get_credential_headers()
 
 
 def get_auth_service() -> AuthService:

--- a/src/hcli/lib/auth/__init__.py
+++ b/src/hcli/lib/auth/__init__.py
@@ -148,6 +148,17 @@ class AuthService:
         self._load_auth_config()
         self._load_current_credentials()
 
+    def ensure_initialized(self) -> None:
+        """Initialize on first use; no-op once init() has run.
+
+        Lets optional-auth callers -- the plugin repository fetch, which runs
+        outside @require_auth/AuthCommand -- see the stored credentials without
+        every command wiring init() explicitly, while still respecting an
+        earlier init(forced_credentials=...) from an auth-aware command.
+        """
+        if self._auth_config is None:
+            self.init()
+
     def _load_auth_config(self) -> None:
         """Load credentials configuration."""
         config_data = config_store.get_object(CONFIG_CREDENTIALS)
@@ -641,6 +652,30 @@ class AuthService:
 
 
 # Global auth service instance accessor
+def get_optional_auth_headers() -> dict[str, str]:
+    """Authentication headers for the current credentials, or {} when logged out.
+
+    Unlike APIClient._get_headers, being logged out is not an error here:
+    callers use this for endpoints that serve both anonymous and personalized
+    responses, such as a plugin repository document.
+    """
+    auth_service = get_auth_service()
+    auth_service.ensure_initialized()
+    if not auth_service.is_logged_in():
+        return {}
+
+    if auth_service.get_auth_type()["type"] == CredentialType.INTERACTIVE:
+        token = auth_service.get_access_token()
+        if token:
+            return {"Authorization": f"Bearer {token}"}
+    else:
+        api_key = auth_service.get_api_key()
+        if api_key:
+            return {"x-api-key": api_key}
+
+    return {}
+
+
 def get_auth_service() -> AuthService:
     """Get the global AuthService instance."""
     return AuthService.instance()

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -746,8 +746,14 @@ def _copy_dir(src_path: Path, dest_path: Path) -> None:
                 raise
 
 
+# extra="allow" on every model in the ida-config.json tree: the file is IDA's
+# own, so keys hcli does not model must survive a read -> mutate -> write
+# round-trip. pydantic's default extra="ignore" would silently drop them on
+# every writer (plugin config set/delete, ida switch, the repo migration).
+
+
 class PathsConfig(BaseModel):
-    model_config = ConfigDict(serialize_by_alias=True)  # type: ignore
+    model_config = ConfigDict(serialize_by_alias=True, extra="allow")  # type: ignore
 
     # like: "/Applications/IDA Professional 9.1.app" (macOS)
     # Note: IDA itself may write the inner "Contents/MacOS" path here;
@@ -756,7 +762,7 @@ class PathsConfig(BaseModel):
 
 
 class PluginRepositoryConfig(BaseModel):
-    model_config = ConfigDict(serialize_by_alias=True)  # type: ignore
+    model_config = ConfigDict(serialize_by_alias=True, extra="allow")  # type: ignore
 
     url: str = Field(
         default="https://raw.githubusercontent.com/HexRaysSA/plugin-repository/refs/heads/v1/plugin-repository.json",
@@ -764,12 +770,14 @@ class PluginRepositoryConfig(BaseModel):
 
 
 class SettingsConfig(BaseModel):
-    model_config = ConfigDict(serialize_by_alias=True)  # type: ignore
+    model_config = ConfigDict(serialize_by_alias=True, extra="allow")  # type: ignore
 
     plugin_repository: PluginRepositoryConfig = Field(alias="plugin-repository", default_factory=PluginRepositoryConfig)
 
 
 class PluginConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")  # type: ignore
+
     # `ida-plugin.json` `.plugin.settings` describes the schema for these settings.
     settings: dict[str, str | bool] = Field(default_factory=dict)
 
@@ -778,7 +786,7 @@ class PluginConfig(BaseModel):
 class IDAConfigJson(BaseModel):
     """IDA configuration $IDAUSR/ida-config.json"""
 
-    model_config = ConfigDict(serialize_by_alias=True)  # type: ignore
+    model_config = ConfigDict(serialize_by_alias=True, extra="allow")  # type: ignore
 
     version: Literal[1] | None = Field(alias="Version", default=1)
     paths: PathsConfig = Field(alias="Paths", default_factory=PathsConfig)

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -849,7 +849,17 @@ def set_ida_config(config: IDAConfigJson):
         logger.debug("creating $IDAUSR directory")
         ida_config_path.parent.mkdir(parents=True, exist_ok=True)
 
-    _ = ida_config_path.write_text(config.model_dump_json(), encoding="utf-8")
+    doc = config.model_dump(mode="json", by_alias=True)
+
+    # The pre-0.23 single-repository setting is modelled as Optional purely so
+    # the migration can read it. Serializing it back as null would leave a dead
+    # key in IDA's own config file, so drop it once it holds nothing. Every
+    # other None is a real value that must round-trip.
+    settings = doc.get("Settings")
+    if isinstance(settings, dict) and settings.get("plugin-repository") is None:
+        settings.pop("plugin-repository", None)
+
+    _ = ida_config_path.write_text(json.dumps(doc), encoding="utf-8")
 
 
 @dataclass(frozen=True)

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -895,7 +895,15 @@ def _migrate_plugin_repositories(config: IDAConfigJson) -> bool:
         return False
 
     legacy = settings.plugin_repository
-    legacy_url = legacy.url if legacy else ""
+    if legacy is None:
+        # Nothing to migrate: a fresh install with no config file, or a config
+        # that never carried the setting. The reserved repositories are
+        # synthesized on read, so there is no reason to create or rewrite the
+        # file -- a read-only command must not announce a change it had no
+        # cause to make.
+        return False
+
+    legacy_url = legacy.url
     customised = bool(legacy_url) and legacy_url != LEGACY_PLUGIN_REPOSITORY_URL
 
     repos = {name: PluginRepositoryConfig(url=url) for name, url in RESERVED_PLUGIN_REPOSITORIES.items()}
@@ -933,11 +941,15 @@ def get_plugin_repositories(config: IDAConfigJson | None = None) -> dict[str, Pl
             set_ida_config(config)
         except OSError as e:
             # A read-only $IDAUSR must not break every plugin command; the new
-            # layout still applies in memory for this process.
+            # layout still applies in memory for this process. Deliberately
+            # quiet: the migration is retried on the next command, and
+            # announcing a change that did not happen -- every time -- is worse
+            # than saying nothing.
             logger.warning("could not persist plugin repository migration to %s: %s", get_ida_config_path(), e)
-        stderr_console.print(
-            f"[yellow]Note:[/yellow] {get_ida_config_path()} was updated to the new named plugin repository layout."
-        )
+        else:
+            stderr_console.print(
+                f"[yellow]Note:[/yellow] {get_ida_config_path()} was updated to the new named plugin repository layout."
+            )
 
     repos: dict[str, PluginRepository] = {}
     for name, entry in config.settings.plugin_repositories.items():

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -19,7 +19,7 @@ from typing import Any, Literal, NamedTuple
 
 import rich.console
 from packaging.version import InvalidVersion, Version
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_serializer
 from rich.markup import escape
 
 from hcli.env import ENV
@@ -780,8 +780,10 @@ RESERVED_PLUGIN_REPOSITORIES = {
 }
 
 # Repository names appear as a "repo/" prefix on plugin references, so they must
-# not collide with the plugin-name grammar or need quoting.
-PLUGIN_REPOSITORY_NAME_RE = re.compile(r"^[a-z0-9-]+$")
+# not collide with the plugin-name grammar or need quoting. The character class
+# is shared with the reference parser, which peels that prefix.
+PLUGIN_REPOSITORY_NAME_CHARS = "a-z0-9-"
+PLUGIN_REPOSITORY_NAME_RE = re.compile(rf"^[{PLUGIN_REPOSITORY_NAME_CHARS}]+$")
 
 
 class PluginRepositoryConfig(BaseModel):
@@ -803,6 +805,21 @@ class SettingsConfig(BaseModel):
     # A sibling key rather than a member of the map, so a repository may
     # legitimately be called "default".
     default_plugin_repository: str | None = Field(alias="default-plugin-repository", default=None)
+
+    @model_serializer(mode="wrap")
+    def _drop_retired_keys(self, handler):
+        """Omit the retired single-repository key instead of writing it as null.
+
+        plugin_repository is Optional only so the migration can read it. Once
+        it holds nothing it should leave the file entirely, rather than linger
+        as a dead `"plugin-repository": null` in IDA's own config. Keeping this
+        on the model means set_ida_config stays a generic writer that knows
+        nothing about individual settings.
+        """
+        doc = handler(self)
+        if doc.get("plugin-repository") is None:
+            doc.pop("plugin-repository", None)
+        return doc
 
 
 class PluginConfig(BaseModel):
@@ -849,17 +866,7 @@ def set_ida_config(config: IDAConfigJson):
         logger.debug("creating $IDAUSR directory")
         ida_config_path.parent.mkdir(parents=True, exist_ok=True)
 
-    doc = config.model_dump(mode="json", by_alias=True)
-
-    # The pre-0.23 single-repository setting is modelled as Optional purely so
-    # the migration can read it. Serializing it back as null would leave a dead
-    # key in IDA's own config file, so drop it once it holds nothing. Every
-    # other None is a real value that must round-trip.
-    settings = doc.get("Settings")
-    if isinstance(settings, dict) and settings.get("plugin-repository") is None:
-        settings.pop("plugin-repository", None)
-
-    _ = ida_config_path.write_text(json.dumps(doc), encoding="utf-8")
+    _ = ida_config_path.write_text(config.model_dump_json(), encoding="utf-8")
 
 
 @dataclass(frozen=True)
@@ -909,7 +916,7 @@ def _migrate_plugin_repositories(config: IDAConfigJson) -> bool:
     return True
 
 
-def get_plugin_repositories() -> dict[str, PluginRepository]:
+def get_plugin_repositories(config: IDAConfigJson | None = None) -> dict[str, PluginRepository]:
     """The configured plugin repositories, keyed by name.
 
     Migrates a pre-0.23 config on first read. The two reserved repositories are
@@ -917,7 +924,8 @@ def get_plugin_repositories() -> dict[str, PluginRepository]:
     is ignored on that point and told so, since the whole value of a reserved
     name is that it cannot be pointed somewhere else.
     """
-    config = get_ida_config()
+    if config is None:
+        config = get_ida_config()
 
     if _migrate_plugin_repositories(config):
         logger.info("migrating ida-config.json to named plugin repositories")
@@ -960,10 +968,11 @@ def get_plugin_repositories() -> dict[str, PluginRepository]:
     return repos
 
 
-def get_default_plugin_repository_name() -> str:
+def get_default_plugin_repository_name(config: IDAConfigJson | None = None) -> str:
     """The repository resolving references that carry no ``repo/`` prefix."""
-    name = get_ida_config().settings.default_plugin_repository
-    return name or COMMUNITY_REPO_NAME
+    if config is None:
+        config = get_ida_config()
+    return config.settings.default_plugin_repository or COMMUNITY_REPO_NAME
 
 
 class MissingCurrentInstallationDirectory(ValueError):

--- a/src/hcli/lib/ida/__init__.py
+++ b/src/hcli/lib/ida/__init__.py
@@ -20,8 +20,10 @@ from typing import Any, Literal, NamedTuple
 import rich.console
 from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, ConfigDict, Field
+from rich.markup import escape
 
 from hcli.env import ENV
+from hcli.lib.console import stderr_console
 from hcli.lib.ida.version import parse_version_from_ida_binary
 from hcli.lib.util.io import NoSpaceError, check_free_space, get_os
 from hcli.lib.venv import resolve_user_virtual_env
@@ -761,18 +763,46 @@ class PathsConfig(BaseModel):
     installation_directory: Path | None = Field(alias="ida-install-dir", default=None)
 
 
+# The single-repository setting written by hcli <= 0.22, kept only so the
+# migration can recognise and replace it.
+LEGACY_PLUGIN_REPOSITORY_URL = (
+    "https://raw.githubusercontent.com/HexRaysSA/plugin-repository/refs/heads/v1/plugin-repository.json"
+)
+
+# The two repositories hcli ships. Reserved: always present, always these URLs,
+# so a config file cannot repoint "hexrays" at a host of its own choosing and
+# harvest the credentials that name attracts.
+COMMUNITY_REPO_NAME = "community"
+HEXRAYS_REPO_NAME = "hexrays"
+RESERVED_PLUGIN_REPOSITORIES = {
+    COMMUNITY_REPO_NAME: "https://community.plugins.hex-rays.com/plugin-repository.json",
+    HEXRAYS_REPO_NAME: "https://hexrays.plugins.hex-rays.com/plugin-repository.json",
+}
+
+# Repository names appear as a "repo/" prefix on plugin references, so they must
+# not collide with the plugin-name grammar or need quoting.
+PLUGIN_REPOSITORY_NAME_RE = re.compile(r"^[a-z0-9-]+$")
+
+
 class PluginRepositoryConfig(BaseModel):
     model_config = ConfigDict(serialize_by_alias=True, extra="allow")  # type: ignore
 
-    url: str = Field(
-        default="https://raw.githubusercontent.com/HexRaysSA/plugin-repository/refs/heads/v1/plugin-repository.json",
-    )
+    url: str = Field(default="")
 
 
 class SettingsConfig(BaseModel):
     model_config = ConfigDict(serialize_by_alias=True, extra="allow")  # type: ignore
 
-    plugin_repository: PluginRepositoryConfig = Field(alias="plugin-repository", default_factory=PluginRepositoryConfig)
+    # The pre-0.23 single-repository setting. Retained on the model so the
+    # migration can read it; removed from the file once migrated.
+    plugin_repository: PluginRepositoryConfig | None = Field(alias="plugin-repository", default=None)
+
+    plugin_repositories: dict[str, PluginRepositoryConfig] = Field(alias="plugin-repositories", default_factory=dict)
+
+    # Names the repository that resolves references carrying no "repo/" prefix.
+    # A sibling key rather than a member of the map, so a repository may
+    # legitimately be called "default".
+    default_plugin_repository: str | None = Field(alias="default-plugin-repository", default=None)
 
 
 class PluginConfig(BaseModel):
@@ -820,6 +850,110 @@ def set_ida_config(config: IDAConfigJson):
         ida_config_path.parent.mkdir(parents=True, exist_ok=True)
 
     _ = ida_config_path.write_text(config.model_dump_json(), encoding="utf-8")
+
+
+@dataclass(frozen=True)
+class PluginRepository:
+    """A named plugin repository: where to look, and what to call it."""
+
+    name: str
+    url: str
+    reserved: bool
+
+
+def _migrate_plugin_repositories(config: IDAConfigJson) -> bool:
+    """Bring a pre-0.23 single-repository config up to the named-repository map.
+
+    Returns True when the config was changed and should be written back.
+
+    One-shot by construction: the legacy ``plugin-repository`` key is removed by
+    the rewrite, so this cannot re-trigger and needs no marker. A user who had
+    customised that URL keeps it -- as a repository named "custom" that becomes
+    the default -- because it is far more likely to be a repository of their own
+    than a mirror of ours, and pointing the default at it is what preserves
+    their unprefixed installs.
+    """
+    settings = config.settings
+    if settings.plugin_repositories:
+        return False
+
+    legacy = settings.plugin_repository
+    legacy_url = legacy.url if legacy else ""
+    customised = bool(legacy_url) and legacy_url != LEGACY_PLUGIN_REPOSITORY_URL
+
+    repos = {name: PluginRepositoryConfig(url=url) for name, url in RESERVED_PLUGIN_REPOSITORIES.items()}
+    default = COMMUNITY_REPO_NAME
+
+    if customised:
+        name = "custom"
+        suffix = 2
+        while name in repos:
+            name = f"custom-{suffix}"
+            suffix += 1
+        repos[name] = PluginRepositoryConfig(url=legacy_url)
+        default = name
+
+    settings.plugin_repositories = repos
+    settings.default_plugin_repository = default
+    settings.plugin_repository = None
+    return True
+
+
+def get_plugin_repositories() -> dict[str, PluginRepository]:
+    """The configured plugin repositories, keyed by name.
+
+    Migrates a pre-0.23 config on first read. The two reserved repositories are
+    always present with their shipped URLs: a file that tries to redefine them
+    is ignored on that point and told so, since the whole value of a reserved
+    name is that it cannot be pointed somewhere else.
+    """
+    config = get_ida_config()
+
+    if _migrate_plugin_repositories(config):
+        logger.info("migrating ida-config.json to named plugin repositories")
+        try:
+            set_ida_config(config)
+        except OSError as e:
+            # A read-only $IDAUSR must not break every plugin command; the new
+            # layout still applies in memory for this process.
+            logger.warning("could not persist plugin repository migration to %s: %s", get_ida_config_path(), e)
+        stderr_console.print(
+            f"[yellow]Note:[/yellow] {get_ida_config_path()} was updated to the new named plugin repository layout."
+        )
+
+    repos: dict[str, PluginRepository] = {}
+    for name, entry in config.settings.plugin_repositories.items():
+        if name in RESERVED_PLUGIN_REPOSITORIES:
+            continue
+        if not PLUGIN_REPOSITORY_NAME_RE.match(name):
+            # escape(): the pattern contains a character class, which Rich
+            # would otherwise consume as markup and print as "^+$".
+            stderr_console.print(
+                f"[yellow]Warning:[/yellow] ignoring plugin repository {name!r}: "
+                f"names must match {escape(PLUGIN_REPOSITORY_NAME_RE.pattern)}"
+            )
+            continue
+        if not entry.url:
+            stderr_console.print(f"[yellow]Warning:[/yellow] ignoring plugin repository {name!r}: no url")
+            continue
+        repos[name] = PluginRepository(name=name, url=entry.url, reserved=False)
+
+    for name, url in RESERVED_PLUGIN_REPOSITORIES.items():
+        configured = config.settings.plugin_repositories.get(name)
+        if configured is not None and configured.url and configured.url != url:
+            stderr_console.print(
+                f"[yellow]Warning:[/yellow] ignoring the url configured for reserved plugin repository "
+                f"{name!r}; it always resolves to {url}"
+            )
+        repos[name] = PluginRepository(name=name, url=url, reserved=True)
+
+    return repos
+
+
+def get_default_plugin_repository_name() -> str:
+    """The repository resolving references that carry no ``repo/`` prefix."""
+    name = get_ida_config().settings.default_plugin_repository
+    return name or COMMUNITY_REPO_NAME
 
 
 class MissingCurrentInstallationDirectory(ValueError):

--- a/src/hcli/lib/ida/plugin/__init__.py
+++ b/src/hcli/lib/ida/plugin/__init__.py
@@ -203,23 +203,50 @@ class Contact(BaseModel):
     name: str | None = Field(default=None, description="Contact name.")
 
 
+# Together with the plugin name, this URL IS the plugin's identity, so the
+# namespace has to stay closed: a public plugin is identified by its GitHub
+# repository, a private one by its page on the Hex-Rays plugin portal.
+_GITHUB_REPOSITORY_PATTERN = r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/?$"
+
+# The portal's canonical shape is three segments, <org>/<repo>/<name>, which the
+# server enforces. hcli also accepts two because production predates that rule
+# and already contains <org>/<repo> and <org>/<name> identities -- installed on
+# user machines, and still served until those plugins are republished.
+# Rejecting them here would break status and upgrade for exactly the users who
+# already have private plugins.
+_PORTAL_REPOSITORY_PATTERN = r"^https://plugins\.hex-rays\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)?/?$"
+
+
+def is_plugin_repository_url(value: str) -> bool:
+    """Whether this URL may identify a plugin (GitHub repo, or portal page)."""
+    return bool(re.match(_GITHUB_REPOSITORY_PATTERN, value) or re.match(_PORTAL_REPOSITORY_PATTERN, value))
+
+
 class URLs(BaseModel):
     repository: str = Field(
-        description="URL of the GitHub repository containing the source code for the plugin.",
-        examples=["https://github.com/org/project"],
+        description=(
+            "Canonical URL identifying the plugin: the GitHub repository containing its source code, "
+            "or, for plugins distributed through the Hex-Rays portal, its page there."
+        ),
+        examples=[
+            "https://github.com/org/project",
+            "https://plugins.hex-rays.com/org/repo/name",
+        ],
     )
 
     homepage: str | None = Field(
         default=None,
-        description="URL of a website describing the plugin, if different from the GitHub repo.",
+        description="URL of a website describing the plugin, if different from the repository.",
     )
 
     @field_validator("repository", mode="after")
     @classmethod
-    def validate_github_url(cls, v: str) -> str:
-        github_pattern = r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/?$"
-        if not re.match(github_pattern, v):
-            raise ValueError("Repository must be a valid GitHub URL in the format: https://github.com/org/project")
+    def validate_repository_url(cls, v: str) -> str:
+        if not is_plugin_repository_url(v):
+            raise ValueError(
+                "Repository must be a GitHub URL (https://github.com/org/project) "
+                "or a Hex-Rays plugin page (https://plugins.hex-rays.com/org/repo/name)"
+            )
         return v
 
 

--- a/src/hcli/lib/ida/plugin/__init__.py
+++ b/src/hcli/lib/ida/plugin/__init__.py
@@ -206,7 +206,7 @@ class Contact(BaseModel):
 # Together with the plugin name, this URL IS the plugin's identity, so the
 # namespace has to stay closed: a public plugin is identified by its GitHub
 # repository, a private one by its page on the Hex-Rays plugin portal.
-_GITHUB_REPOSITORY_PATTERN = r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/?$"
+GITHUB_REPOSITORY_PATTERN = r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/?$"
 
 # The portal's canonical shape is three segments, <org>/<repo>/<name>, which the
 # server enforces. hcli also accepts two because production predates that rule
@@ -214,12 +214,12 @@ _GITHUB_REPOSITORY_PATTERN = r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._
 # user machines, and still served until those plugins are republished.
 # Rejecting them here would break status and upgrade for exactly the users who
 # already have private plugins.
-_PORTAL_REPOSITORY_PATTERN = r"^https://plugins\.hex-rays\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)?/?$"
+PORTAL_REPOSITORY_PATTERN = r"^https://plugins\.hex-rays\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)?/?$"
 
 
 def is_plugin_repository_url(value: str) -> bool:
     """Whether this URL may identify a plugin (GitHub repo, or portal page)."""
-    return bool(re.match(_GITHUB_REPOSITORY_PATTERN, value) or re.match(_PORTAL_REPOSITORY_PATTERN, value))
+    return bool(re.match(GITHUB_REPOSITORY_PATTERN, value) or re.match(PORTAL_REPOSITORY_PATTERN, value))
 
 
 class URLs(BaseModel):

--- a/src/hcli/lib/ida/plugin/exceptions.py
+++ b/src/hcli/lib/ida/plugin/exceptions.py
@@ -181,3 +181,31 @@ class InstalledPluginNameConflictError(PluginInstallationError):
             f"cannot install plugin '{requested_name}@{requested_host}' because "
             f"'{installed_name}@{installed_host}' is already installed at {installed_path}"
         )
+
+
+class PluginAccessDeniedError(Exception):
+    """A plugin repository refused to serve a resource.
+
+    Raised only for denials by a Hex-Rays plugin repository host, where the
+    status is entitlement-shaped: private plugins are gated on the caller's
+    account. A denial from anywhere else (a deleted GitHub release asset, say)
+    keeps its generic HTTP error, which names the real cause.
+    """
+
+    def __init__(self, url: str, status_code: int, authenticated: bool, repo_name: str | None = None):
+        self.url = url
+        self.status_code = status_code
+        self.authenticated = authenticated
+        self.repo_name = repo_name
+
+        where = f"repository '{repo_name}'" if repo_name else "the plugin repository"
+        msg = f"Access denied (HTTP {status_code}) by {where}. "
+        if not authenticated:
+            msg += f"Run '{ENV.HCLI_BINARY_NAME} login' and try again."
+        elif status_code == 401:
+            # 401 *with* credentials attached means they were rejected -- an
+            # expired session or a revoked key -- not an entitlement problem.
+            msg += f"Your credentials were rejected: run '{ENV.HCLI_BINARY_NAME} login' again, or check HCLI_API_KEY."
+        else:
+            msg += "Your account is not entitled to it."
+        super().__init__(msg)

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -19,9 +19,18 @@ from dataclasses import dataclass
 from urllib.parse import urlparse
 
 # whole-string match for a GitHub repository URL in the shape allowed by
-# ``ida-plugin.json`` (see ``URLs.validate_github_url`` in
+# ``ida-plugin.json`` (see ``URLs.validate_repository_url`` in
 # ``src/hcli/lib/ida/plugin/__init__.py``). Trailing slash optional.
 _GITHUB_REPO_RE = re.compile(r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/?$", re.IGNORECASE)
+
+# ...and the Hex-Rays portal page identifying a privately distributed plugin.
+# Must stay in lockstep with ``_PORTAL_REPOSITORY_PATTERN``: that one validates
+# an identity, this one parses a reference to it, and a reference hcli cannot
+# parse is a plugin the user cannot name.
+_PORTAL_REPO_RE = re.compile(
+    r"^https://plugins\.hex-rays\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)?/?$",
+    re.IGNORECASE,
+)
 
 # broader match that also accepts ``.git`` suffix and ``@tag`` for direct
 # installs (e.g. ``https://github.com/org/repo.git@v1.0``).
@@ -56,6 +65,17 @@ def is_github_repository_url(value: str) -> bool:
     a reference, not a raw URL, so we use a strict whole-string match here.
     """
     return bool(_GITHUB_REPO_RE.match(value))
+
+
+def is_plugin_host_url(value: str) -> bool:
+    """Return True if ``value`` can appear after ``@`` in a plugin reference.
+
+    Accepts every shape that can identify a plugin: a GitHub repository, or a
+    Hex-Rays portal page. Note this is deliberately wider than
+    ``is_github_direct_install_url``, which stays GitHub-only because it guards
+    "this string is a raw URL, not a reference".
+    """
+    return bool(_GITHUB_REPO_RE.match(value) or _PORTAL_REPO_RE.match(value))
 
 
 def is_github_direct_install_url(value: str) -> bool:
@@ -162,9 +182,9 @@ def parse_plugin_reference(value: str) -> PluginReference:
     remaining = value
     if "@" in value:
         left, _, right = value.rpartition("@")
-        if not is_github_repository_url(right):
+        if not is_plugin_host_url(right):
             raise ValueError(
-                f"plugin reference has an '@' but the suffix is not a valid GitHub repository URL: {value!r}"
+                f"plugin reference has an '@' but the suffix is not a valid plugin repository URL: {value!r}"
             )
         host = normalize_plugin_host(right)
         remaining = left

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -53,7 +53,7 @@ class PluginReference:
     Attributes:
         name: bare plugin name.
         version_spec: version specifier with operator (``"==1.2.3"``), or ``""`` when absent.
-        host: normalized repository URL, or ``None`` when unqualified.
+        host: normalized code repository URL, or ``None`` when unqualified.
         repo: configured repository name to search, or ``None`` for the default.
             Lookup scope only: it is dropped once the plugin is resolved and is
             never stored, because where a plugin was found is not part of what

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -20,19 +20,15 @@ import re
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
-# whole-string match for a GitHub repository URL in the shape allowed by
-# ``ida-plugin.json`` (see ``URLs.validate_repository_url`` in
-# ``src/hcli/lib/ida/plugin/__init__.py``). Trailing slash optional.
-_GITHUB_REPO_RE = re.compile(r"^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/?$", re.IGNORECASE)
+from hcli.lib.ida import PLUGIN_REPOSITORY_NAME_CHARS
+from hcli.lib.ida.plugin import GITHUB_REPOSITORY_PATTERN, PORTAL_REPOSITORY_PATTERN
 
-# ...and the Hex-Rays portal page identifying a privately distributed plugin.
-# Must stay in lockstep with ``_PORTAL_REPOSITORY_PATTERN``: that one validates
-# an identity, this one parses a reference to it, and a reference hcli cannot
-# parse is a plugin the user cannot name.
-_PORTAL_REPO_RE = re.compile(
-    r"^https://plugins\.hex-rays\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)?/?$",
-    re.IGNORECASE,
-)
+# The shapes that may identify a plugin, taken from the schema module that
+# validates them: one definition, so a reference hcli parses and an identity
+# hcli accepts can never drift apart. Compiled case-insensitively here because
+# a user typing a reference is not held to the casing a descriptor declares.
+_GITHUB_REPO_RE = re.compile(GITHUB_REPOSITORY_PATTERN, re.IGNORECASE)
+_PORTAL_REPO_RE = re.compile(PORTAL_REPOSITORY_PATTERN, re.IGNORECASE)
 
 # broader match that also accepts ``.git`` suffix and ``@tag`` for direct
 # installs (e.g. ``https://github.com/org/repo.git@v1.0``).
@@ -43,10 +39,11 @@ _GITHUB_DIRECT_INSTALL_RE = re.compile(
 )
 
 
-# A leading "repo/" scopes the lookup. Same grammar as a configured repository
-# name, which is what makes the reference unambiguous: plugin names are
-# ``^[a-zA-Z0-9_-]+$``, so a "/" can only ever be this separator.
-_REPO_PREFIX_RE = re.compile(r"^([a-z0-9-]+)/(.+)$")
+# A leading "repo/" scopes the lookup. The character class comes from the
+# config module that validates repository names, so a name hcli accepts is
+# always a prefix hcli can parse. Plugin names are ``^[a-zA-Z0-9_-]+$``, so a
+# "/" can only ever be this separator.
+_REPO_PREFIX_RE = re.compile(rf"^([{PLUGIN_REPOSITORY_NAME_CHARS}]+)/(.+)$")
 
 
 @dataclass(frozen=True)

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -54,7 +54,7 @@ class PluginReference:
         name: bare plugin name.
         version_spec: version specifier with operator (``"==1.2.3"``), or ``""`` when absent.
         host: normalized code repository URL, or ``None`` when unqualified.
-        repo: configured repository name to search, or ``None`` for the default.
+        repo: configured plugin repository name to search, or ``None`` for the default.
             Lookup scope only: it is dropped once the plugin is resolved and is
             never stored, because where a plugin was found is not part of what
             it is.

--- a/src/hcli/lib/ida/plugin/reference.py
+++ b/src/hcli/lib/ida/plugin/reference.py
@@ -8,6 +8,8 @@ Accepted forms:
     name==1.2.3
     name@https://github.com/org/repo
     name==1.2.3@https://github.com/org/repo
+    repo/name
+    repo/name==1.2.3@https://github.com/org/repo
 
 The module is intentionally free of Click/Rich so it can be unit tested easily.
 """
@@ -41,6 +43,12 @@ _GITHUB_DIRECT_INSTALL_RE = re.compile(
 )
 
 
+# A leading "repo/" scopes the lookup. Same grammar as a configured repository
+# name, which is what makes the reference unambiguous: plugin names are
+# ``^[a-zA-Z0-9_-]+$``, so a "/" can only ever be this separator.
+_REPO_PREFIX_RE = re.compile(r"^([a-z0-9-]+)/(.+)$")
+
+
 @dataclass(frozen=True)
 class PluginReference:
     """A parsed plugin reference.
@@ -49,11 +57,16 @@ class PluginReference:
         name: bare plugin name.
         version_spec: version specifier with operator (``"==1.2.3"``), or ``""`` when absent.
         host: normalized repository URL, or ``None`` when unqualified.
+        repo: configured repository name to search, or ``None`` for the default.
+            Lookup scope only: it is dropped once the plugin is resolved and is
+            never stored, because where a plugin was found is not part of what
+            it is.
     """
 
     name: str
     version_spec: str
     host: str | None
+    repo: str | None = None
 
 
 def is_github_repository_url(value: str) -> bool:
@@ -178,6 +191,15 @@ def parse_plugin_reference(value: str) -> PluginReference:
     if is_github_direct_install_url(value):
         raise ValueError(f"value is a GitHub URL, not a plugin reference: {value!r}")
 
+    # Peel the repository prefix first. No URL can be mistaken for one: the
+    # pattern requires every character before the first "/" to be [a-z0-9-],
+    # which "https://..." (colon) and "name@https://..." (at-sign, colon) both
+    # fail, so a scheme can never parse as a repository name.
+    repo: str | None = None
+    prefix_match = _REPO_PREFIX_RE.match(value)
+    if prefix_match:
+        repo, value = prefix_match.group(1), prefix_match.group(2)
+
     host: str | None = None
     remaining = value
     if "@" in value:
@@ -196,21 +218,23 @@ def parse_plugin_reference(value: str) -> PluginReference:
     if not name:
         raise ValueError(f"plugin reference has empty name: {value!r}")
 
-    return PluginReference(name=name, version_spec=version_spec, host=host)
+    if "/" in name:
+        raise ValueError(f"plugin reference name must not contain '/': {name!r}")
+
+    return PluginReference(name=name, version_spec=version_spec, host=host, repo=repo)
 
 
 def format_qualified_plugin_reference(ref: PluginReference) -> str:
     """Render a plugin reference in its canonical user-facing string form.
 
     Formats:
-        name@repo
-        name==1.2.3@repo
+        name@host
+        name==1.2.3@host
+        repo/name==1.2.3@host
     """
-    if not ref.host:
-        if ref.version_spec:
-            return f"{ref.name}{ref.version_spec}"
-        return ref.name
+    prefix = f"{ref.repo}/" if ref.repo else ""
 
-    if ref.version_spec:
-        return f"{ref.name}{ref.version_spec}@{ref.host}"
-    return f"{ref.name}@{ref.host}"
+    if not ref.host:
+        return f"{prefix}{ref.name}{ref.version_spec}"
+
+    return f"{prefix}{ref.name}{ref.version_spec}@{ref.host}"

--- a/src/hcli/lib/ida/plugin/repo/__init__.py
+++ b/src/hcli/lib/ida/plugin/repo/__init__.py
@@ -53,7 +53,11 @@ def is_plugin_repo_host(url: str) -> bool:
 
 
 def fetch_plugin_repo_bytes(url: str, repo_name: str | None = None) -> bytes:
-    """Fetch plugin repository content (an index document or an archive) over https.
+    """Fetch plugin repository content: an index document or a plugin archive.
+
+    Accepts http and https, because fetch_plugin_archive routes both here; only
+    https can ever carry credentials, and an https request that redirects to
+    http is refused rather than downgraded.
 
     Credentials are attached only on hops that land on a Hex-Rays plugin
     repository host, where they unlock entitled private plugins -- never to

--- a/src/hcli/lib/ida/plugin/repo/__init__.py
+++ b/src/hcli/lib/ida/plugin/repo/__init__.py
@@ -98,12 +98,14 @@ def fetch_plugin_repo_bytes(url: str, repo_name: str | None = None) -> bytes:
                 current_url = next_url
                 continue
 
-            # Only denials by our own hosts are entitlement-shaped. A logged-in
-            # 404 stays generic: it means no such archive, not "log in first".
+            # Only denials by our own hosts are entitlement-shaped, and only
+            # 401/403: these hosts answer 401 for anything they will not serve,
+            # so a 404 means the resource genuinely is not there and keeps its
+            # own error. Mapping 404 to "log in" would tell a user to
+            # authenticate against `community`, which needs no credentials.
             if credentialed:
                 authenticated = bool(auth_headers)
-                denied = (401, 403) if authenticated else (401, 403, 404)
-                if response.status_code in denied:
+                if response.status_code in (401, 403):
                     raise PluginAccessDeniedError(
                         url, response.status_code, authenticated=authenticated, repo_name=repo_name
                     )

--- a/src/hcli/lib/ida/plugin/repo/__init__.py
+++ b/src/hcli/lib/ida/plugin/repo/__init__.py
@@ -10,6 +10,7 @@ import httpx
 import semantic_version
 from pydantic import BaseModel, ConfigDict
 
+from hcli import USER_AGENT
 from hcli.lib.ida.plugin import (
     IDAMetadataDescriptor,
     IdaVersion,
@@ -20,11 +21,97 @@ from hcli.lib.ida.plugin import (
     split_plugin_version_spec,
     validate_metadata_in_plugin_archive,
 )
-from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError
+from hcli.lib.ida.plugin.exceptions import AmbiguousPluginReferenceError, PluginAccessDeniedError
 from hcli.lib.ida.plugin.reference import normalize_plugin_host
 from hcli.lib.util.logging import m
 
 logger = logging.getLogger(__name__)
+
+MAX_REDIRECTS = 10
+
+# Hex-Rays serves plugin repository documents and their archives from
+# subdomains of this host. It is the sole destination hcli credentials may go
+# in the plugin path -- deliberately a constant, and deliberately NOT
+# ENV.HCLI_API_URL, which scopes the API client and answers a different
+# question. Widening either one must not widen the other.
+PLUGIN_REPO_HOST = "plugins.hex-rays.com"
+
+
+def is_plugin_repo_host(url: str) -> bool:
+    """Whether hcli credentials may be attached to a request for this URL.
+
+    True only for HTTPS on PLUGIN_REPO_HOST or a subdomain of it. The leading
+    dot in the suffix test is what keeps "evilplugins.hex-rays.com" and
+    "plugins.hex-rays.com.attacker.tld" out. Never plaintext HTTP, so a
+    downgrade cannot carry a credential.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False
+    host = (parsed.hostname or "").lower()
+    return host == PLUGIN_REPO_HOST or host.endswith("." + PLUGIN_REPO_HOST)
+
+
+def fetch_plugin_repo_bytes(url: str, repo_name: str | None = None) -> bytes:
+    """Fetch plugin repository content (an index document or an archive) over https.
+
+    Credentials are attached only on hops that land on a Hex-Rays plugin
+    repository host, where they unlock entitled private plugins -- never to
+    third parties (GitHub release assets, mirrors, presigned S3 URLs). Because
+    httpx only strips Authorization across origins and would happily forward an
+    x-api-key, redirects are walked by hand so the decision is remade per hop.
+    """
+    scheme = urlparse(url).scheme
+
+    # Resolved lazily on the first credential-eligible hop and reused: deciding
+    # whether we are logged in can cost a network round-trip for interactive
+    # credentials, so it must not repeat per redirect. Per hop we only decide
+    # whether to attach what was already resolved.
+    auth_headers: dict[str, str] | None = None
+
+    with httpx.Client(timeout=30.0, follow_redirects=False) as client:
+        current_url = url
+        # +1 because the initial request consumes an iteration; MAX_REDIRECTS
+        # counts redirects actually followed.
+        for _ in range(MAX_REDIRECTS + 1):
+            credentialed = is_plugin_repo_host(current_url)
+            if credentialed and auth_headers is None:
+                # Deferred import: the auth service is only needed for our own hosts.
+                from hcli.lib.auth import get_optional_auth_headers
+
+                auth_headers = get_optional_auth_headers()
+
+            headers = {"User-Agent": USER_AGENT}
+            if credentialed and auth_headers:
+                headers.update(auth_headers)
+
+            response = client.get(current_url, headers=headers)
+
+            # has_redirect_location, not is_redirect: is_redirect matches any
+            # 3xx, but only those carrying a Location are followable. A 300 or
+            # 304 falls through to raise_for_status, which names the real
+            # status instead of a misleading missing-Location error.
+            if response.has_redirect_location:
+                next_url = str(httpx.URL(current_url).join(response.headers["location"]))
+                if scheme == "https" and urlparse(next_url).scheme != "https":
+                    raise ValueError(f"HTTPS request was redirected to insecure HTTP URL: {next_url}")
+                current_url = next_url
+                continue
+
+            # Only denials by our own hosts are entitlement-shaped. A logged-in
+            # 404 stays generic: it means no such archive, not "log in first".
+            if credentialed:
+                authenticated = bool(auth_headers)
+                denied = (401, 403) if authenticated else (401, 403, 404)
+                if response.status_code in denied:
+                    raise PluginAccessDeniedError(
+                        url, response.status_code, authenticated=authenticated, repo_name=repo_name
+                    )
+
+            response.raise_for_status()
+            return response.content
+
+    raise ValueError(f"too many redirects while fetching: {url}")
 
 
 def fetch_plugin_archive(url: str) -> bytes:
@@ -37,11 +124,7 @@ def fetch_plugin_archive(url: str) -> bytes:
         return file_path.read_bytes()
 
     elif parsed_url.scheme in ("http", "https"):
-        response = httpx.get(url, timeout=30.0, follow_redirects=True)
-        response.raise_for_status()
-        if parsed_url.scheme == "https" and response.url.scheme != "https":
-            raise ValueError(f"HTTPS request was redirected to insecure HTTP URL: {response.url}")
-        return response.content
+        return fetch_plugin_repo_bytes(url)
 
     else:
         raise ValueError(f"Unsupported URL scheme: {parsed_url.scheme}")

--- a/src/hcli/lib/ida/plugin/repo/aggregate.py
+++ b/src/hcli/lib/ida/plugin/repo/aggregate.py
@@ -1,0 +1,147 @@
+"""A plugin repository spanning several named repositories.
+
+Repositories are fetched independently and merged here, in the client, so the
+name a plugin was found under is always known -- unlike a server-side merge,
+which would hand back one anonymous document.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import httpx
+
+from hcli.lib.ida import PluginRepository
+from hcli.lib.ida.plugin.exceptions import PluginAccessDeniedError
+from hcli.lib.ida.plugin.repo import BasePluginRepo, Plugin
+from hcli.lib.ida.plugin.repo.file import JSONFilePluginRepo
+
+logger = logging.getLogger(__name__)
+
+# Identities under this host are Hex-Rays', and only the repository Hex-Rays
+# serves may assert them. Adding a repository must not confer the power to
+# impersonate us: without this, a repository the user added could claim
+# "plugins.hex-rays.com/HexRaysSA/..." and, because `upgrade` resolves an
+# installed plugin by host across every configured repository, take over
+# upgrades of a genuinely installed private plugin.
+PORTAL_IDENTITY_HOST = "plugins.hex-rays.com"
+PORTAL_IDENTITY_REPO = "hexrays"
+
+
+@dataclass(frozen=True)
+class RepoFailure:
+    """Why a repository could not be consulted."""
+
+    name: str
+    error: Exception
+
+    def describe(self) -> str:
+        e = self.error
+        if isinstance(e, PluginAccessDeniedError):
+            if not e.authenticated:
+                return f"{self.name}: not logged in"
+            return f"{self.name}: {'credentials rejected' if e.status_code == 401 else 'not entitled'}"
+        if isinstance(e, (httpx.ConnectError, httpx.TimeoutException)):
+            return f"{self.name}: unreachable"
+        if isinstance(e, httpx.HTTPStatusError):
+            return f"{self.name}: HTTP {e.response.status_code}"
+        return f"{self.name}: {e}"
+
+
+def _identity_host(plugin: Plugin) -> str:
+    return (urlparse(plugin.host).hostname or "").lower()
+
+
+class AggregatePluginRepo(BasePluginRepo):
+    """Several named repositories presented as one.
+
+    Callers pass the scope they want -- one repository, or all of them. This
+    class holds no notion of a default: which repository resolves an unprefixed
+    reference is a configuration question, answered by the caller.
+    """
+
+    def __init__(self, repositories: dict[str, PluginRepository]):
+        super().__init__()
+        self.repositories = repositories
+        self._plugins: dict[str, list[Plugin]] = {}
+        self._failures: dict[str, RepoFailure] = {}
+
+    def _load(self, name: str) -> list[Plugin]:
+        """Fetch one repository, at most once, remembering failure as well as success."""
+        if name in self._plugins:
+            return self._plugins[name]
+        if name in self._failures:
+            raise self._failures[name].error
+
+        repo = self.repositories[name]
+        try:
+            plugins = JSONFilePluginRepo.from_url(repo.url, repo_name=name).get_plugins()
+        except Exception as e:
+            logger.debug("failed to fetch plugin repository %s (%s): %s", name, repo.url, e)
+            self._failures[name] = RepoFailure(name=name, error=e)
+            raise
+
+        self._plugins[name] = self._filter_entitled(name, plugins)
+        return self._plugins[name]
+
+    def _filter_entitled(self, name: str, plugins: list[Plugin]) -> list[Plugin]:
+        """Drop plugins claiming an identity this repository may not assert."""
+        if name == PORTAL_IDENTITY_REPO:
+            return plugins
+
+        kept = [p for p in plugins if _identity_host(p) != PORTAL_IDENTITY_HOST]
+        dropped = len(plugins) - len(kept)
+        if dropped:
+            # Loud enough to debug a misconfigured repository -- by far the
+            # likelier cause than a hostile one -- without narrating details
+            # back to whoever served it.
+            from hcli.lib.console import stderr_console
+
+            stderr_console.print(
+                f"[yellow]Warning:[/yellow] repository {name!r} served {dropped} plugin(s) claiming "
+                f"Hex-Rays identities; ignored"
+            )
+        return kept
+
+    def names(self) -> list[str]:
+        return list(self.repositories)
+
+    def failures(self) -> list[RepoFailure]:
+        """Repositories that could not be consulted during this run."""
+        return [self._failures[n] for n in self.repositories if n in self._failures]
+
+    def get_plugins_in(self, name: str) -> list[Plugin]:
+        """Plugins from one named repository. Propagates that repository's failure."""
+        if name not in self.repositories:
+            raise KeyError(f"unknown plugin repository: {name}")
+        return list(self._load(name))
+
+    def get_plugins_across(self, names: list[str]) -> list[Plugin]:
+        """Plugins from several repositories, skipping those that cannot be fetched.
+
+        Surveying is best-effort by design: one unreachable or unauthorized
+        repository must not hide the results of the others. Callers report the
+        skips via failures().
+        """
+        plugins: list[Plugin] = []
+        for name in names:
+            try:
+                plugins.extend(self._load(name))
+            except Exception as e:
+                # Recorded by _load() and reported by failures(); the point of a
+                # survey is that the reachable repositories still answer.
+                logger.debug("skipping plugin repository %s: %s", name, e)
+        return plugins
+
+    def get_plugins(self) -> list[Plugin]:
+        """Every plugin hcli can see, across every configured repository."""
+        return self.get_plugins_across(self.names())
+
+    def repo_of(self, plugin: Plugin) -> str | None:
+        """Which loaded repository served this plugin."""
+        for name, plugins in self._plugins.items():
+            if any(p is plugin for p in plugins):
+                return name
+        return None

--- a/src/hcli/lib/ida/plugin/repo/aggregate.py
+++ b/src/hcli/lib/ida/plugin/repo/aggregate.py
@@ -8,46 +8,28 @@ which would hand back one anonymous document.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from urllib.parse import urlparse
 
 import httpx
 
-from hcli.lib.ida import PluginRepository
+from hcli.lib.ida import HEXRAYS_REPO_NAME, PluginRepository
 from hcli.lib.ida.plugin.exceptions import PluginAccessDeniedError
-from hcli.lib.ida.plugin.repo import BasePluginRepo, Plugin
+from hcli.lib.ida.plugin.repo import PLUGIN_REPO_HOST, BasePluginRepo, Plugin
 from hcli.lib.ida.plugin.repo.file import JSONFilePluginRepo
 
 logger = logging.getLogger(__name__)
 
-# Identities under this host are Hex-Rays', and only the repository Hex-Rays
-# serves may assert them. Adding a repository must not confer the power to
-# impersonate us: without this, a repository the user added could claim
-# "plugins.hex-rays.com/HexRaysSA/..." and, because `upgrade` resolves an
-# installed plugin by host across every configured repository, take over
-# upgrades of a genuinely installed private plugin.
-PORTAL_IDENTITY_HOST = "plugins.hex-rays.com"
-PORTAL_IDENTITY_REPO = "hexrays"
 
-
-@dataclass(frozen=True)
-class RepoFailure:
-    """Why a repository could not be consulted."""
-
-    name: str
-    error: Exception
-
-    def describe(self) -> str:
-        e = self.error
-        if isinstance(e, PluginAccessDeniedError):
-            if not e.authenticated:
-                return f"{self.name}: not logged in"
-            return f"{self.name}: {'credentials rejected' if e.status_code == 401 else 'not entitled'}"
-        if isinstance(e, (httpx.ConnectError, httpx.TimeoutException)):
-            return f"{self.name}: unreachable"
-        if isinstance(e, httpx.HTTPStatusError):
-            return f"{self.name}: HTTP {e.response.status_code}"
-        return f"{self.name}: {e}"
+def _describe_failure(name: str, error: Exception) -> str:
+    if isinstance(error, PluginAccessDeniedError):
+        if not error.authenticated:
+            return f"{name}: not logged in"
+        return f"{name}: {'credentials rejected' if error.status_code == 401 else 'not entitled'}"
+    if isinstance(error, (httpx.ConnectError, httpx.TimeoutException)):
+        return f"{name}: unreachable"
+    if isinstance(error, httpx.HTTPStatusError):
+        return f"{name}: HTTP {error.response.status_code}"
+    return f"{name}: {error}"
 
 
 def _identity_host(plugin: Plugin) -> str:
@@ -66,51 +48,64 @@ class AggregatePluginRepo(BasePluginRepo):
         super().__init__()
         self.repositories = repositories
         self._plugins: dict[str, list[Plugin]] = {}
-        self._failures: dict[str, RepoFailure] = {}
+        self._failures: dict[str, Exception] = {}
+        self._dropped: dict[str, int] = {}
+        # Which repository served which plugin, remembered at load time rather
+        # than reconstructed later by scanning every loaded list.
+        self._owner: dict[int, str] = {}
 
     def _load(self, name: str) -> list[Plugin]:
         """Fetch one repository, at most once, remembering failure as well as success."""
         if name in self._plugins:
             return self._plugins[name]
         if name in self._failures:
-            raise self._failures[name].error
+            raise self._failures[name]
 
         repo = self.repositories[name]
         try:
             plugins = JSONFilePluginRepo.from_url(repo.url, repo_name=name).get_plugins()
         except Exception as e:
             logger.debug("failed to fetch plugin repository %s (%s): %s", name, repo.url, e)
-            self._failures[name] = RepoFailure(name=name, error=e)
+            self._failures[name] = e
             raise
 
-        self._plugins[name] = self._filter_entitled(name, plugins)
-        return self._plugins[name]
-
-    def _filter_entitled(self, name: str, plugins: list[Plugin]) -> list[Plugin]:
-        """Drop plugins claiming an identity this repository may not assert."""
-        if name == PORTAL_IDENTITY_REPO:
-            return plugins
-
-        kept = [p for p in plugins if _identity_host(p) != PORTAL_IDENTITY_HOST]
-        dropped = len(plugins) - len(kept)
-        if dropped:
-            # Loud enough to debug a misconfigured repository -- by far the
-            # likelier cause than a hostile one -- without narrating details
-            # back to whoever served it.
-            from hcli.lib.console import stderr_console
-
-            stderr_console.print(
-                f"[yellow]Warning:[/yellow] repository {name!r} served {dropped} plugin(s) claiming "
-                f"Hex-Rays identities; ignored"
-            )
+        kept = self._filter_entitled(name, plugins)
+        self._plugins[name] = kept
+        for plugin in kept:
+            self._owner[id(plugin)] = name
         return kept
 
-    def names(self) -> list[str]:
-        return list(self.repositories)
+    def _filter_entitled(self, name: str, plugins: list[Plugin]) -> list[Plugin]:
+        """Drop plugins claiming an identity this repository may not assert.
 
-    def failures(self) -> list[RepoFailure]:
-        """Repositories that could not be consulted during this run."""
-        return [self._failures[n] for n in self.repositories if n in self._failures]
+        Recorded rather than printed: a repository that could not fully answer
+        is reported through notes(), the same way an unreachable one is, so
+        --json callers see it too instead of only text-mode users.
+        """
+        if name == HEXRAYS_REPO_NAME:
+            return plugins
+
+        kept = [p for p in plugins if _identity_host(p) != PLUGIN_REPO_HOST]
+        dropped = len(plugins) - len(kept)
+        if dropped:
+            logger.debug("repository %s served %d plugin(s) claiming Hex-Rays identities", name, dropped)
+            self._dropped[name] = dropped
+        return kept
+
+    def notes(self) -> list[str]:
+        """What the caller should know about repositories consulted so far.
+
+        Covers both a repository that could not be reached and one that was
+        reached but served plugins it is not entitled to. Both mean the answer
+        is not the whole picture, so both belong in the same report.
+        """
+        notes = []
+        for name in self.repositories:
+            if name in self._failures:
+                notes.append(f"skipped -- {_describe_failure(name, self._failures[name])}")
+            if name in self._dropped:
+                notes.append(f"{name}: ignored {self._dropped[name]} plugin(s) claiming Hex-Rays identities")
+        return notes
 
     def get_plugins_in(self, name: str) -> list[Plugin]:
         """Plugins from one named repository. Propagates that repository's failure."""
@@ -118,30 +113,21 @@ class AggregatePluginRepo(BasePluginRepo):
             raise KeyError(f"unknown plugin repository: {name}")
         return list(self._load(name))
 
-    def get_plugins_across(self, names: list[str]) -> list[Plugin]:
-        """Plugins from several repositories, skipping those that cannot be fetched.
+    def get_plugins(self) -> list[Plugin]:
+        """Every plugin hcli can see, across every configured repository.
 
-        Surveying is best-effort by design: one unreachable or unauthorized
-        repository must not hide the results of the others. Callers report the
-        skips via failures().
+        Best-effort by design: one unreachable or unauthorized repository must
+        not hide the results of the others, so failures are recorded and
+        reported through notes() rather than raised.
         """
         plugins: list[Plugin] = []
-        for name in names:
+        for name in self.repositories:
             try:
                 plugins.extend(self._load(name))
             except Exception as e:
-                # Recorded by _load() and reported by failures(); the point of a
-                # survey is that the reachable repositories still answer.
                 logger.debug("skipping plugin repository %s: %s", name, e)
         return plugins
 
-    def get_plugins(self) -> list[Plugin]:
-        """Every plugin hcli can see, across every configured repository."""
-        return self.get_plugins_across(self.names())
-
     def repo_of(self, plugin: Plugin) -> str | None:
         """Which loaded repository served this plugin."""
-        for name, plugins in self._plugins.items():
-            if any(p is plugin for p in plugins):
-                return name
-        return None
+        return self._owner.get(id(plugin))

--- a/src/hcli/lib/ida/plugin/repo/file.py
+++ b/src/hcli/lib/ida/plugin/repo/file.py
@@ -4,10 +4,9 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
-import httpx
 from pydantic import BaseModel
 
-from hcli.lib.ida.plugin.repo import BasePluginRepo, Plugin
+from hcli.lib.ida.plugin.repo import BasePluginRepo, Plugin, fetch_plugin_repo_bytes
 
 
 class StaticPluginRepo(BaseModel):
@@ -46,7 +45,7 @@ class JSONFilePluginRepo(BasePluginRepo):
         return cls.from_bytes(path.read_bytes())
 
     @classmethod
-    def from_url(cls, url: str):
+    def from_url(cls, url: str, repo_name: str | None = None):
         parsed_url = urlparse(url)
 
         if parsed_url.scheme == "file":
@@ -56,11 +55,8 @@ class JSONFilePluginRepo(BasePluginRepo):
             return cls.from_bytes(file_path.read_bytes())
 
         elif parsed_url.scheme == "https":
-            response = httpx.get(url, timeout=30.0, follow_redirects=True)
-            response.raise_for_status()
-            if parsed_url.scheme == "https" and response.url.scheme != "https":
-                raise ValueError(f"HTTPS request was redirected to insecure HTTP URL: {response.url}")
-            return cls.from_bytes(response.content)
+            # host-scoped credentials personalize the document with entitled private plugins
+            return cls.from_bytes(fetch_plugin_repo_bytes(url, repo_name=repo_name))
 
         else:
             raise ValueError(f"Unsupported URL scheme: {parsed_url.scheme}")

--- a/tests/lib/test_plugin_reference.py
+++ b/tests/lib/test_plugin_reference.py
@@ -5,6 +5,7 @@ from hcli.lib.ida.plugin.reference import (
     format_qualified_plugin_reference,
     is_github_direct_install_url,
     is_github_repository_url,
+    is_plugin_host_url,
     normalize_plugin_host,
     parse_plugin_reference,
 )
@@ -197,3 +198,195 @@ def test_parse_github_url(url: str, expected: tuple[str, str, str | None]):
 def test_parse_github_url_rejects(url: str):
     with pytest.raises(ValueError):
         parse_github_url(url)
+
+
+# --- Hex-Rays portal identities ------------------------------------------------
+#
+# A plugin distributed through the portal is built from a private GitHub
+# repository, so its github.com URL cannot be its public identity. The portal
+# page stands in, and hcli must both accept it as an identity and parse a
+# reference to it -- a reference hcli cannot parse is a plugin nobody can name.
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # canonical: <org>/<repo>/<name>
+        "https://plugins.hex-rays.com/org/repo/plugin1",
+        "https://plugins.hex-rays.com/org/repo/plugin1/",
+        # two segments: predates the canonical shape and is still installed on
+        # user machines, so it must keep parsing
+        "https://plugins.hex-rays.com/org/repo",
+        # GitHub keeps working through the same predicate
+        "https://github.com/org/repo",
+    ],
+)
+def test_is_plugin_host_url_accepts_identity_shapes(value: str):
+    assert is_plugin_host_url(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # one segment is not an identity
+        "https://plugins.hex-rays.com/org",
+        # four is past the namespace
+        "https://plugins.hex-rays.com/a/b/c/d",
+        # subdomains are delivery hosts, never identities: allowing them would
+        # let one plugin hold two identities that never collide
+        "https://hexrays.plugins.hex-rays.com/org/repo/plugin1",
+        "https://evil.plugins.hex-rays.com/a/b",
+        # a look-alike host outside the namespace
+        "https://plugins.hex-rays.com.attacker.tld/a/b",
+        "http://plugins.hex-rays.com/a/b",
+        "https://gitlab.com/org/repo",
+    ],
+)
+def test_is_plugin_host_url_rejects_non_identities(value: str):
+    assert not is_plugin_host_url(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://plugins.hex-rays.com/org/repo/plugin1",
+        "https://plugins.hex-rays.com/org/repo",
+    ],
+)
+def test_portal_urls_are_not_direct_install_urls(value: str):
+    # is_github_direct_install_url guards "this string is a raw URL, not a
+    # reference". Widening it to the portal would make `hcli plugin install
+    # <portal-url>` try to install from the page instead of resolving a
+    # reference, so it stays GitHub-only.
+    assert not is_github_direct_install_url(value)
+
+
+def test_parse_plugin_reference_accepts_portal_host():
+    ref = parse_plugin_reference("plugin1@https://plugins.hex-rays.com/org/repo/plugin1")
+    assert ref == PluginReference(
+        name="plugin1",
+        version_spec="",
+        host="https://plugins.hex-rays.com/org/repo/plugin1",
+        repo=None,
+    )
+
+
+def test_parse_plugin_reference_normalizes_portal_host_case():
+    # users type references by hand; a descriptor's casing must not decide
+    # whether the reference resolves
+    ref = parse_plugin_reference("plugin1@https://PLUGINS.hex-rays.com/Org/Repo")
+    assert ref.host == "https://plugins.hex-rays.com/org/repo"
+
+
+# --- repository prefixes -------------------------------------------------------
+#
+# A leading "repo/" selects which repository to search. It is lookup scope only:
+# dropped once the plugin resolves, never stored, because where a plugin was
+# found is not part of what it is.
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("hexrays/foo", PluginReference(name="foo", version_spec="", host=None, repo="hexrays")),
+        ("community/foo", PluginReference(name="foo", version_spec="", host=None, repo="community")),
+        # digits and hyphens are legal in a repository name
+        ("my-repo-2/foo", PluginReference(name="foo", version_spec="", host=None, repo="my-repo-2")),
+        # version specs compose with the prefix
+        ("hexrays/foo>=1.2", PluginReference(name="foo", version_spec=">=1.2", host=None, repo="hexrays")),
+        ("hexrays/foo==1.0.0", PluginReference(name="foo", version_spec="==1.0.0", host=None, repo="hexrays")),
+        # prefix and host together: the prefix scopes the search, the host pins
+        # identity
+        (
+            "hexrays/plugin1@https://plugins.hex-rays.com/org/repo/plugin1",
+            PluginReference(
+                name="plugin1",
+                version_spec="",
+                host="https://plugins.hex-rays.com/org/repo/plugin1",
+                repo="hexrays",
+            ),
+        ),
+        (
+            "hexrays/plugin1>=1.2@https://plugins.hex-rays.com/org/repo/plugin1",
+            PluginReference(
+                name="plugin1",
+                version_spec=">=1.2",
+                host="https://plugins.hex-rays.com/org/repo/plugin1",
+                repo="hexrays",
+            ),
+        ),
+        # a prefix may also scope a GitHub-identified plugin
+        (
+            "community/foo@https://github.com/org/repo",
+            PluginReference(name="foo", version_spec="", host="https://github.com/org/repo", repo="community"),
+        ),
+    ],
+)
+def test_parse_plugin_reference_with_repo_prefix(value: str, expected: PluginReference):
+    assert parse_plugin_reference(value) == expected
+
+
+def test_unprefixed_reference_has_no_repo():
+    assert parse_plugin_reference("foo").repo is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # repository names are lowercase; an uppercase prefix is not a prefix,
+        # so the slash lands in the name and is refused
+        "HEXRAYS/foo",
+        "Hexrays/foo",
+        # underscores are legal in plugin names but not repository names
+        "my_repo/foo",
+        # only one prefix level exists
+        "a/b/c",
+        # empty on either side of the separator
+        "/foo",
+        "foo/",
+    ],
+)
+def test_parse_plugin_reference_rejects_bad_prefixes(value: str):
+    with pytest.raises(ValueError):
+        parse_plugin_reference(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://github.com/org/repo",
+        "https://plugins.hex-rays.com/org/repo/plugin1",
+        "file:///tmp/plugin.zip",
+    ],
+)
+def test_repo_prefix_cannot_swallow_a_url_scheme(value: str):
+    # The prefix pattern requires every character before the first "/" to be
+    # [a-z0-9-], which a scheme's ":" fails. Without that, "https://host/path"
+    # would parse as repository "https:".
+    try:
+        ref = parse_plugin_reference(value)
+    except ValueError:
+        return  # refused outright, which is also correct
+    assert ref.repo is None
+
+
+@pytest.mark.parametrize(
+    ("ref", "expected"),
+    [
+        (PluginReference(name="foo", version_spec="", host=None, repo="hexrays"), "hexrays/foo"),
+        (PluginReference(name="foo", version_spec=">=1.2", host=None, repo="hexrays"), "hexrays/foo>=1.2"),
+        (
+            PluginReference(
+                name="plugin1",
+                version_spec="==1.0.0",
+                host="https://plugins.hex-rays.com/org/repo/plugin1",
+                repo="hexrays",
+            ),
+            "hexrays/plugin1==1.0.0@https://plugins.hex-rays.com/org/repo/plugin1",
+        ),
+    ],
+)
+def test_format_qualified_plugin_reference_round_trips_with_repo(ref: PluginReference, expected: str):
+    assert format_qualified_plugin_reference(ref) == expected
+    # search prints this string as the thing to type; it must parse back
+    assert parse_plugin_reference(expected) == ref


### PR DESCRIPTION
Replaces the single `plugin-repository` URL with named repositories, so hcli can install private, entitlement-gated plugins alongside public ones and always knows which repository served what.

## Configuration

`.Settings.plugin-repositories` is a map of name → url, plus `.Settings.default-plugin-repository`. Two entries are reserved — `community` and `hexrays` — always present, always their Hex-Rays URLs. A config that tries to repoint one is ignored on that point and told so: a reserved name whose URL can be changed is worth nothing, and `hexrays` is exactly the name an attacker would want, because it is the name credentials follow.

Managed with `hcli plugin repo list | add | remove | set-default`.

## Scope depends on the operation

Searching is a survey; installing is a choice.

| operation | searches | on 401 |
|---|---|---|
| `search` | every configured repository | skip, and report it |
| `install xyz` | the default repository only | never happens — no credentials sent |
| `install hexrays/xyz` | that repository alone | fatal |
| `upgrade` | all repositories, anchored by installed host | skip |

A bare `install` never touches an authenticated repository, so a logged-out user never sees a 401 for a plugin they weren't asking for. A `repo/` prefix is an explicit request, so failing it is the honest answer.

Repositories are never overlaid, so cross-repository name collisions do not arise: a bare name resolves in the default repository only, exactly as released hcli resolves it against its single repository, and a private plugin is always named explicitly. Collisions *within* one repository behave as before.

## Credentials

`fetch_plugin_repo_bytes` walks redirects by hand rather than letting httpx follow them. httpx strips `Authorization` across origins but forwards `x-api-key` — which would hand a credential to whatever host a repository 302s to. Each hop re-decides; the logged-in state resolves once per fetch because it can cost a network round-trip.

`is_plugin_repo_host` is the only predicate for where those credentials go: HTTPS on `plugins.hex-rays.com` or a subdomain. Deliberately separate from the API client's `ENV.HCLI_API_URL` scoping — the two answer different questions, and widening one must not widen the other.

## Identity spoofing

The aggregate drops any plugin claiming a `plugins.hex-rays.com` identity from a repository other than `hexrays`. Adding a repository must not confer the power to impersonate us: `upgrade` resolves an installed plugin by host across every configured repository, so without this, a repository the user added could take over upgrades of a genuinely installed private plugin.

## Migration

One-shot, no marker — it removes the key it reads. A customized URL survives as a repository named `custom` that becomes the default, which is what preserves that user's unprefixed installs; it is far more likely to be a repository of their own than a mirror of ours.

Also adds `extra="allow"` across the `ida-config.json` models. Without it every write silently dropped keys IDA owns but hcli doesn't model — a pre-existing bug, and a precondition for a migration that rewrites the file.

## Compatibility

Public flow is unchanged: search, install, upgrade and status for a GitHub-hosted plugin behave exactly as released. `--repo`, bundles, and offline installs are untouched. JSON output gains fields only.

## Verification

Against the live repositories: `community` fetches anonymously (127 plugins), `hexrays` 401s anonymously and returns 3 plugins with an API key, and a private archive downloads with a matching sha256. Install, status and upgrade complete for a private plugin. A local-server test confirms the credential is attached on an eligible hop and dropped across a cross-origin redirect.

## Server dependency

Requires the `hexrays` and `community` documents (already live). The three private plugins have been updated to three-segment identities; hcli accepts two- and three-segment forms so already-installed plugins keep working through the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcAS3eAwMhhtpKr3VxquW7
