### PR TITLE
Detect when IDAPYTHON_VENV_EXECUTABLE points to a missing file

### DIFF
--- a/docs/user-guide/ida-python-environment.md
+++ b/docs/user-guide/ida-python-environment.md
@@ -69,7 +69,7 @@ Warnings (1)
         export IDAPYTHON_VENV_EXECUTABLE="/Users/user/.idapro/venv/bin/python"
 ```
 
-Errors are conditions where installing packages fails, or puts them where IDA cannot see them: no virtual environment, no `pip`, an externally managed system Python (PEP 668), a temporary `uv run` environment, or a version mismatch between the venv and IDA's `libpython`. Warnings are setups that work today but are fragile, such as a venv that `IDAPYTHON_VENV_EXECUTABLE` does not select, or a venv activated from `idapythonrc.py`. `doctor` exits non-zero when there are errors. `--json` prints the same report as JSON.
+Errors are conditions where installing packages fails, or puts them where IDA cannot see them: no virtual environment, no `pip`, an externally managed system Python (PEP 668), a temporary `uv run` environment, a version mismatch between the venv and IDA's `libpython`, or `IDAPYTHON_VENV_EXECUTABLE` pointing to a file that does not exist. Warnings are setups that work today but are fragile, such as a venv that `IDAPYTHON_VENV_EXECUTABLE` does not select, or a venv activated from `idapythonrc.py`. `doctor` exits non-zero when there are errors. `--json` prints the same report as JSON.
 
 `hcli plugin install` runs this check before it installs Python dependencies. Errors stop the install and print the findings. Warnings only print, and the install continues. The `ida python exec`, `run-script`, and `find-script` commands only print warnings, because you use them to repair the environment. To skip the check, pass `--no-python-environment-check` to the `plugin` or `ida python` group, for example `hcli plugin --no-python-environment-check install <name>`.
 

--- a/src/hcli/commands/ida/python/doctor.py
+++ b/src/hcli/commands/ida/python/doctor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+from pathlib import Path
 
 import rich.status
 import rich_click as click
@@ -138,7 +139,25 @@ def build_doctor_report() -> DoctorReport:
         idausr = None
 
     if resolved is None:
-        findings = [
+        findings: list[EnvironmentFinding] = []
+        venv_exe = ENV.IDAPYTHON_VENV_EXECUTABLE
+        if venv_exe and not Path(venv_exe).is_file():
+            findings.append(
+                EnvironmentFinding(
+                    id="venv-exe-not-found",
+                    severity="error",
+                    summary=(f"$IDAPYTHON_VENV_EXECUTABLE points to a file that does not exist: {venv_exe}"),
+                    detail=(
+                        "The variable is set, but the interpreter it names is not on disk. "
+                        "The virtual environment may have been deleted, moved, or not yet created."
+                    ),
+                    fix_hint=(
+                        f"Run `{ENV.HCLI_BINARY_NAME} ida python create-environment` to create a virtual "
+                        "environment and configure $IDAPYTHON_VENV_EXECUTABLE."
+                    ),
+                )
+            )
+        findings.append(
             EnvironmentFinding(
                 id="python-not-found",
                 severity="error",
@@ -150,7 +169,7 @@ def build_doctor_report() -> DoctorReport:
                     "that IDA uses."
                 ),
             )
-        ]
+        )
         return DoctorReport(
             ida_install_dir=selected.install_dir,
             ida_install_dir_source=selected.install_dir_source,

--- a/src/hcli/lib/ida/python/environment.py
+++ b/src/hcli/lib/ida/python/environment.py
@@ -394,7 +394,7 @@ def check_python_environment(state: PythonEnvironmentState) -> list[EnvironmentF
         if state.source == "$HCLI_CURRENT_IDA_PYTHON_EXE":
             return findings
 
-    if state.venv_root is None:
+    if state.venv_root is None and state.python_exe_exists:
         summary = f"IDA's Python is not a virtual environment: {exe}"
         detail = (
             "IDA loads a global Python (system, Homebrew, python.org, or Windows Store). Plugin dependencies "
@@ -431,7 +431,7 @@ def check_python_environment(state: PythonEnvironmentState) -> list[EnvironmentF
             )
         )
 
-    if state.pip_available is False:
+    if state.pip_available is False and state.python_exe_exists:
         venv_hint = ""
         if state.venv_root is not None:
             venv_hint = (
@@ -659,7 +659,7 @@ def identify_setup_pattern(state: PythonEnvironmentState) -> SetupPattern:
             name="Missing interpreter",
             description=(
                 f"The interpreter selected by {state.source} does not exist on disk. "
-                "No checks can run until this is corrected."
+                "HCLI cannot install packages or run scripts until this is corrected."
             ),
         )
 

--- a/src/hcli/lib/ida/python/environment.py
+++ b/src/hcli/lib/ida/python/environment.py
@@ -124,6 +124,8 @@ class PythonEnvironmentState:
     uv_ephemeral: bool
     # $IDAPYTHON_VENV_EXECUTABLE as HCLI sees it
     idapython_venv_executable: Path | None
+    # whether the file at idapython_venv_executable exists on disk
+    idapython_venv_executable_exists: bool
     # $VIRTUAL_ENV as HCLI sees it, excluding HCLI's own venv and uv overlays
     shell_virtual_env: Path | None
     idapythonrc_path: Path | None
@@ -265,6 +267,7 @@ def collect_python_environment_state(
 
     raw_venv_exe = ENV.IDAPYTHON_VENV_EXECUTABLE
     idapython_venv_executable = Path(raw_venv_exe) if raw_venv_exe else None
+    idapython_venv_executable_exists = idapython_venv_executable is not None and idapython_venv_executable.is_file()
 
     shell_virtual_env = resolve_user_virtual_env()
 
@@ -285,6 +288,7 @@ def collect_python_environment_state(
         externally_managed=externally_managed,
         uv_ephemeral=uv_ephemeral,
         idapython_venv_executable=idapython_venv_executable,
+        idapython_venv_executable_exists=idapython_venv_executable_exists,
         shell_virtual_env=shell_virtual_env,
         idapythonrc_path=idapythonrc_path,
         idapythonrc_activates_venv=idapythonrc_activates_venv,
@@ -350,6 +354,24 @@ def check_python_environment(state: PythonEnvironmentState) -> list[EnvironmentF
                     f"Or set $IDAPYTHON_VENV_EXECUTABLE to IDA's real virtualenv.\n"
                     f"{_render_create_environment_hint(state)}"
                 ),
+            )
+        )
+
+    if state.idapython_venv_executable is not None and not state.idapython_venv_executable_exists:
+        findings.append(
+            EnvironmentFinding(
+                id="venv-exe-not-found",
+                severity="error",
+                summary=(
+                    f"$IDAPYTHON_VENV_EXECUTABLE points to a file that does not exist: "
+                    f"{state.idapython_venv_executable}"
+                ),
+                detail=(
+                    "The variable is set, but the interpreter it names is not on disk. HCLI fell back to "
+                    "probing IDA directly, which found a different Python. The virtual environment may have "
+                    "been deleted, moved, or not yet created."
+                ),
+                fix_hint=_render_create_environment_hint(state),
             )
         )
 
@@ -440,7 +462,8 @@ def check_python_environment(state: PythonEnvironmentState) -> list[EnvironmentF
             )
         )
 
-    if state.venv_root is not None and not venv_executable_points_at(state):
+    dangling_var = state.idapython_venv_executable is not None and not state.idapython_venv_executable_exists
+    if state.venv_root is not None and not venv_executable_points_at(state) and not dangling_var:
         venv_python = get_venv_python_path(state.venv_root, state.system)
         set_var = render_set_env_var_command("IDAPYTHON_VENV_EXECUTABLE", str(venv_python), state.system)
         if state.idapython_venv_executable is None:
@@ -608,6 +631,16 @@ def identify_setup_pattern(state: PythonEnvironmentState) -> SetupPattern:
             description=(
                 "HCLI runs under `uv run --with`. The virtualenv it sees is uv's temporary overlay, not IDA's "
                 "environment."
+            ),
+        )
+
+    if state.idapython_venv_executable is not None and not state.idapython_venv_executable_exists:
+        return SetupPattern(
+            id="dangling-venv-exe",
+            name="Missing virtual environment",
+            description=(
+                "$IDAPYTHON_VENV_EXECUTABLE is set, but the interpreter it names does not exist on disk. "
+                "The virtual environment may have been deleted, moved, or not yet created."
             ),
         )
 

--- a/src/hcli/lib/ida/python/environment.py
+++ b/src/hcli/lib/ida/python/environment.py
@@ -386,12 +386,13 @@ def check_python_environment(state: PythonEnvironmentState) -> list[EnvironmentF
                 summary=f"IDA's Python interpreter does not exist: {exe}",
                 detail=(
                     f"The interpreter was selected by {state.source}, but the file is not on disk. "
-                    "All other checks are skipped because nothing can be determined about a missing interpreter."
+                    "HCLI cannot install packages or run scripts with a missing interpreter."
                 ),
                 fix_hint=_render_create_environment_hint(state),
             )
         )
-        return findings
+        if state.source == "$HCLI_CURRENT_IDA_PYTHON_EXE":
+            return findings
 
     if state.venv_root is None:
         summary = f"IDA's Python is not a virtual environment: {exe}"

--- a/src/hcli/lib/ida/python/environment.py
+++ b/src/hcli/lib/ida/python/environment.py
@@ -106,6 +106,8 @@ class PythonEnvironmentState:
 
     # the interpreter HCLI would install plugin dependencies with
     python_exe: Path
+    # whether python_exe exists on disk
+    python_exe_exists: bool
     # what selected it, like "$IDAPYTHON_VENV_EXECUTABLE" (see ResolvedPython.source)
     source: str
     system: System
@@ -278,6 +280,7 @@ def collect_python_environment_state(
 
     return PythonEnvironmentState(
         python_exe=python_exe,
+        python_exe_exists=python_exe.is_file(),
         source=resolved.source,
         system=system,
         idausr=idausr,
@@ -374,6 +377,21 @@ def check_python_environment(state: PythonEnvironmentState) -> list[EnvironmentF
                 fix_hint=_render_create_environment_hint(state),
             )
         )
+
+    if not state.python_exe_exists:
+        findings.append(
+            EnvironmentFinding(
+                id="python-exe-not-found",
+                severity="error",
+                summary=f"IDA's Python interpreter does not exist: {exe}",
+                detail=(
+                    f"The interpreter was selected by {state.source}, but the file is not on disk. "
+                    "All other checks are skipped because nothing can be determined about a missing interpreter."
+                ),
+                fix_hint=_render_create_environment_hint(state),
+            )
+        )
+        return findings
 
     if state.venv_root is None:
         summary = f"IDA's Python is not a virtual environment: {exe}"
@@ -631,6 +649,16 @@ def identify_setup_pattern(state: PythonEnvironmentState) -> SetupPattern:
             description=(
                 "HCLI runs under `uv run --with`. The virtualenv it sees is uv's temporary overlay, not IDA's "
                 "environment."
+            ),
+        )
+
+    if not state.python_exe_exists:
+        return SetupPattern(
+            id="missing-interpreter",
+            name="Missing interpreter",
+            description=(
+                f"The interpreter selected by {state.source} does not exist on disk. "
+                "No checks can run until this is corrected."
             ),
         )
 

--- a/tests/lib/test_python_environment.py
+++ b/tests/lib/test_python_environment.py
@@ -172,6 +172,8 @@ def test_missing_probe_derived_interpreter_still_runs_downstream_checks():
     ids = finding_ids(findings)
     assert "python-exe-not-found" in ids
     assert "externally-managed" in ids
+    assert "no-venv" not in ids
+    assert "no-pip" not in ids
 
 
 def test_venv_exe_var_matches_when_naming_a_different_interpreter_alias():

--- a/tests/lib/test_python_environment.py
+++ b/tests/lib/test_python_environment.py
@@ -31,6 +31,7 @@ VENV_PYTHON = VENV / "bin" / "python"
 
 RECOMMENDED_STATE = PythonEnvironmentState(
     python_exe=VENV_PYTHON,
+    python_exe_exists=True,
     source="$IDAPYTHON_VENV_EXECUTABLE",
     system="linux",
     idausr=IDAUSR,
@@ -134,6 +135,26 @@ def test_dangling_venv_exe_var_suppresses_no_venv_exe_var_warning():
     ids = finding_ids(check_python_environment(state))
     assert "venv-exe-not-found" in ids
     assert "no-venv-exe-var" not in ids
+
+
+def test_missing_interpreter_is_an_error_and_skips_downstream_checks():
+    gone = Path("/opt/gone/bin/python3")
+    state = make_state(
+        python_exe=gone,
+        python_exe_exists=False,
+        source="$HCLI_CURRENT_IDA_PYTHON_EXE",
+        venv_root=None,
+        pip_available=False,
+        python_version=None,
+        idapython_venv_executable=None,
+    )
+    findings = check_python_environment(state)
+    ids = finding_ids(findings)
+    assert ids == ["python-exe-not-found"]
+    assert findings[0].severity == "error"
+    assert str(gone) in findings[0].summary
+    assert "$HCLI_CURRENT_IDA_PYTHON_EXE" in findings[0].detail
+    assert identify_setup_pattern(state).id == "missing-interpreter"
 
 
 def test_venv_exe_var_matches_when_naming_a_different_interpreter_alias():
@@ -327,6 +348,7 @@ def test_collect_state_from_a_real_venv_via_venv_executable_var(real_venv: Path,
     resolved = ResolvedPython(exe, "$IDAPYTHON_VENV_EXECUTABLE")
     state = collect_python_environment_state(resolved, probe_ida=False)
 
+    assert state.python_exe_exists
     assert state.venv_root is not None
     assert state.venv_root.resolve() == real_venv.resolve()
     assert state.pip_available is True

--- a/tests/lib/test_python_environment.py
+++ b/tests/lib/test_python_environment.py
@@ -157,6 +157,23 @@ def test_missing_interpreter_is_an_error_and_skips_downstream_checks():
     assert identify_setup_pattern(state).id == "missing-interpreter"
 
 
+def test_missing_probe_derived_interpreter_still_runs_downstream_checks():
+    gone = Path("/opt/homebrew/bin/python3.12")
+    state = make_state(
+        python_exe=gone,
+        python_exe_exists=False,
+        source="derived from idat probe",
+        venv_root=None,
+        pip_available=None,
+        externally_managed=True,
+        idapython_venv_executable=None,
+    )
+    findings = check_python_environment(state)
+    ids = finding_ids(findings)
+    assert "python-exe-not-found" in ids
+    assert "externally-managed" in ids
+
+
 def test_venv_exe_var_matches_when_naming_a_different_interpreter_alias():
     state = make_state(idapython_venv_executable=VENV / "bin" / "python3.12")
     assert venv_executable_points_at(state)

--- a/tests/lib/test_python_environment.py
+++ b/tests/lib/test_python_environment.py
@@ -41,6 +41,7 @@ RECOMMENDED_STATE = PythonEnvironmentState(
     externally_managed=False,
     uv_ephemeral=False,
     idapython_venv_executable=VENV_PYTHON,
+    idapython_venv_executable_exists=True,
     shell_virtual_env=None,
     idapythonrc_path=None,
     idapythonrc_activates_venv=False,
@@ -102,6 +103,37 @@ def test_venv_exe_var_pointing_at_a_different_venv_warns():
     findings = check_python_environment(state)
     assert finding_ids(findings) == ["no-venv-exe-var"]
     assert str(other) in findings[0].summary
+
+
+def test_dangling_venv_exe_var_is_an_error_when_probe_falls_through():
+    gone = Path("/home/user/.idapro/venv/bin/python")
+    state = make_state(
+        python_exe=Path("/usr/bin/python3"),
+        source="derived from idat probe",
+        venv_root=None,
+        idapython_venv_executable=gone,
+        idapython_venv_executable_exists=False,
+    )
+    findings = check_python_environment(state)
+    ids = finding_ids(findings)
+    assert "venv-exe-not-found" in ids
+    assert "no-venv" in ids
+    assert ids.index("venv-exe-not-found") < ids.index("no-venv")
+    assert findings[0].severity == "error"
+    assert str(gone) in findings[0].summary
+    assert "create-environment" in findings[0].fix_hint
+    assert identify_setup_pattern(state).id == "dangling-venv-exe"
+
+
+def test_dangling_venv_exe_var_suppresses_no_venv_exe_var_warning():
+    gone = Path("/home/user/.idapro/old-venv/bin/python")
+    state = make_state(
+        idapython_venv_executable=gone,
+        idapython_venv_executable_exists=False,
+    )
+    ids = finding_ids(check_python_environment(state))
+    assert "venv-exe-not-found" in ids
+    assert "no-venv-exe-var" not in ids
 
 
 def test_venv_exe_var_matches_when_naming_a_different_interpreter_alias():
@@ -303,6 +335,7 @@ def test_collect_state_from_a_real_venv_via_venv_executable_var(real_venv: Path,
     assert not state.externally_managed
     assert not state.uv_ephemeral
     assert state.idapython_venv_executable == exe
+    assert state.idapython_venv_executable_exists
     assert state.idapythonrc_activates_venv
     assert venv_executable_points_at(state)
 

--- a/tests/lib/test_python_venv_create.py
+++ b/tests/lib/test_python_venv_create.py
@@ -7,6 +7,7 @@ import pytest
 
 from hcli.lib.ida.python import IdatProbe
 from hcli.lib.ida.python.environment import System, get_venv_python_path
+from hcli.lib.venv import get_python_exe_candidates
 from hcli.lib.ida.python.venv_create import (
     VenvCreationError,
     append_to_shell_profile,
@@ -198,8 +199,8 @@ def test_get_registered_python_exe_skips_non_python_executable(tmp_path: Path):
     idat = tmp_path / "idat"
     idat.write_text("", encoding="utf-8")
 
-    python = tmp_path / "bin" / "python3.13"
-    python.parent.mkdir(parents=True)
+    python = get_python_exe_candidates(tmp_path, "3.13")[0]
+    python.parent.mkdir(parents=True, exist_ok=True)
     python.write_text("", encoding="utf-8")
 
     probe = IdatProbe(
@@ -215,8 +216,8 @@ def test_get_registered_python_exe_skips_non_python_executable(tmp_path: Path):
 
 
 def test_get_registered_python_exe_accepts_real_python_executable(tmp_path: Path):
-    python = tmp_path / "bin" / "python3.12"
-    python.parent.mkdir(parents=True)
+    python = get_python_exe_candidates(tmp_path, "3.12")[0]
+    python.parent.mkdir(parents=True, exist_ok=True)
     python.write_text("", encoding="utf-8")
 
     probe = IdatProbe(


### PR DESCRIPTION
## Summary

Two related fixes for when user-configured paths don't exist on disk:

**`IDAPYTHON_VENV_EXECUTABLE` pointing to a missing file:**
- Add `venv-exe-not-found` error finding when the variable is set but the target file does not exist
- Add `dangling-venv-exe` setup pattern ("Missing virtual environment") instead of the misleading "Default (no setup)"
- Suppress the redundant `no-venv-exe-var` warning when the var is dangling
- Handle the dangling var in doctor's early-return path (when both the env var and idat probe fail)

Previously, doctor silently fell back to the idat probe and then diagnosed the probed state without mentioning that the user's configured env var pointed to nothing. The fix hint told users to "set IDAPYTHON_VENV_EXECUTABLE" when they already had.

**`HCLI_CURRENT_IDA_PYTHON_EXE` pointing to a missing interpreter:**
- Add `python-exe-not-found` error finding with an early return that skips downstream noise (no-pip, no-venv, etc.)
- Add `missing-interpreter` setup pattern

Previously, `has_pip()` and `probe_python_version()` failed individually and produced confusing findings like "no-pip" when the real problem was that the interpreter didn't exist.

Both fixes add a `_exists` field to `PythonEnvironmentState` so `check_python_environment` stays pure.

## Test plan

- [ ] `test_dangling_venv_exe_var_is_an_error_when_probe_falls_through` - var set, target missing, probe finds base python
- [ ] `test_dangling_venv_exe_var_suppresses_no_venv_exe_var_warning` - var dangling with venv present via probe
- [ ] `test_missing_interpreter_is_an_error_and_skips_downstream_checks` - HCLI override points to nothing, only python-exe-not-found emitted
- [ ] `test_collect_state_from_a_real_venv_via_venv_executable_var` - verifies both `_exists` fields are True for real venvs
- [ ] Existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)