### PR TITLE
AI-assisted: add --allowed-editions alongside --allowed-segments in asset put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 ### Added
+- Add `--allowed-editions` to `hcli asset put` to gate an asset by licence edition, addon code, or `any_edition`
 - Warn when IDA's Python version (registered by idapyswitch) doesn't match the active virtualenv, in `explain-environment` and before installing plugin dependencies
 - Honor `$IDAPYTHON_VENV_EXECUTABLE` for plugin dependency management
 - Add GitHub Copilot CLI support to `hcli mcp install`

--- a/src/hcli/commands/asset/put.py
+++ b/src/hcli/commands/asset/put.py
@@ -33,6 +33,12 @@ from hcli.lib.console import console
     help="Comma-separated list of allowed email addresses",
 )
 @click.option(
+    "--allowed-editions",
+    required=False,
+    default=None,
+    help="Comma-separated list of allowed editions (edition ids such as ida-pro, addon codes such as HEXX64, or any_edition)",
+)
+@click.option(
     "-f",
     "--force",
     is_flag=True,
@@ -45,6 +51,7 @@ async def put(
     metadata: tuple[str, ...],
     allowed_segments: str | None,
     allowed_emails: str | None,
+    allowed_editions: str | None,
     force: bool = False,
 ) -> None:
     """Upload an asset to a bucket."""
@@ -84,11 +91,13 @@ async def put(
 
     segments = allowed_segments.split(",") if allowed_segments else None
     emails = allowed_emails.split(",") if allowed_emails else None
+    editions = allowed_editions.split(",") if allowed_editions else None
     result = await asset.upload_asset(
         bucket=bucket,
         file_path=str(path),
         allowed_segments=segments,
         allowed_emails=emails,
+        allowed_editions=editions,
         metadata=metadata_dict,
         force=force,
     )


### PR DESCRIPTION
Adds `--allowed-editions` to `hcli asset put`, comma-separated like `--allowed-segments`. The API client already accepted the field; the command never exposed it.

Values are licence edition ids (`ida-pro`), addon codes (`HEXX64`), or `any_edition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ehAcBobySex5dtdYZbVXt