### PR TITLE
Add --create-python-environment to CI install steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           bash .github/scripts/retry.sh 5 20 \
-            uv run hcli --disable-updates ida install --download-id "ida-pro:latest" --license-id "${IDA_LICENSE_ID}" --install-dir="${{ runner.temp }}/app/ida" --set-default --accept-eula --yes
+            uv run hcli --disable-updates ida install --download-id "ida-pro:latest" --license-id "${IDA_LICENSE_ID}" --install-dir="${{ runner.temp }}/app/ida" --create-python-environment --set-default --accept-eula --yes
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
@@ -379,7 +379,7 @@ jobs:
         shell: bash
         run: |
           bash .github/scripts/retry.sh 5 20 \
-            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${IDA_LICENSE_ID}" --accept-eula --set-default --yes
+            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${IDA_LICENSE_ID}" --create-python-environment --accept-eula --set-default --yes
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
@@ -404,7 +404,7 @@ jobs:
         shell: bash
         run: |
           bash .github/scripts/retry.sh 5 20 \
-            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${IDA_LICENSE_ID}" --install-dir "${{ runner.temp }}/app/ida-${{ matrix.os_ida.ida_version }}/" --accept-eula --set-default --yes
+            uv run hcli --disable-updates ida install --download-id "${{ matrix.os_ida.slug }}" --license-id "${IDA_LICENSE_ID}" --install-dir "${{ runner.temp }}/app/ida-${{ matrix.os_ida.ida_version }}/" --create-python-environment --accept-eula --set-default --yes
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Test IDA installation command (Unix)
         if: runner.os != 'Windows'
         run: |
-          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --accept-eula --set-default
+          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --create-python-environment --accept-eula --set-default
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}
@@ -61,7 +61,7 @@ jobs:
       - name: Test IDA installation command (Windows)
         if: runner.os == 'Windows'
         run: |
-          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --accept-eula --set-default
+          hcli --disable-updates ida install --yes --download-id ${{ matrix.install-id }} --license-id ${{ secrets.IDA_LICENSE_ID }} --install-dir "${{ runner.temp }}/app/ida/" --create-python-environment --accept-eula --set-default
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
           IDA_LICENSE_ID: ${{ secrets.IDA_LICENSE_ID }}

--- a/docs/advanced/ci-cd-integration.md
+++ b/docs/advanced/ci-cd-integration.md
@@ -110,9 +110,12 @@ jobs:
             --yes \
             --accept-eula \
             --set-default \
+            --create-python-environment \
             --license-id ${{ secrets.IDA_LICENSE_ID }} \
             --download-id release/9.2/ida-pro/ida-pro_92_x64linux.run
 ```
+
+`--create-python-environment` creates a virtualenv at `$IDAUSR/venv` and sets `IDAPYTHON_VENV_EXECUTABLE`. Without it, plugins that depend on Python packages will fail to install. See [IDA's Python Environment](../user-guide/ida-python-environment.md).
 
 #### GitHub Actions Secrets
 
@@ -271,6 +274,7 @@ jobs:
             --yes \
             --accept-eula \
             --set-default \
+            --create-python-environment \
             --license-id ${{ secrets.IDA_LICENSE_ID }} \
             --download-id release/${{ matrix.ida-version }}/ida-pro/$INSTALLER
 ```

--- a/docs/advanced/docker/Dockerfile
+++ b/docs/advanced/docker/Dockerfile
@@ -29,12 +29,13 @@ ARG IDA_INSTALL_DIR=/opt/ida
 RUN if [ -z "$HCLI_API_KEY" ]; then echo "Error: HCLI_API_KEY build argument is required" && exit 1; fi
 RUN if [ -z "$IDA_LICENSE_ID" ]; then echo "Error: IDA_LICENSE_ID build argument is required" && exit 1; fi
 
-# Install IDA Pro
+# Install IDA Pro and create the Python environment
 ENV HCLI_API_KEY=${HCLI_API_KEY}
 RUN hcli --disable-updates ida install \
     --download-id ${IDA_DOWNLOAD_ID} \
     --license-id ${IDA_LICENSE_ID} \
     --install-dir ${IDA_INSTALL_DIR} \
+    --create-python-environment \
     --yes && \
     mkdir -p /root/.idapro && \
     find /tmp -name "*.hexlic" -exec cp {} /root/.idapro/ \; && \
@@ -51,10 +52,11 @@ COPY --from=ida-installer /root/.idapro /root/.idapro
 # Set environment variables for IDA
 ENV PATH="${IDA_INSTALL_DIR}:${PATH}"
 ENV IDADIR="${IDA_INSTALL_DIR}"
+ENV IDAPYTHON_VENV_EXECUTABLE="/root/.idapro/venv/bin/python"
 ENV TVHEADLESS=1
 
-# Install Python dependencies
-RUN pip install --no-cache-dir \
+# Install Python dependencies into the IDA venv
+RUN /root/.idapro/venv/bin/python -m pip install --no-cache-dir \
     idapro \
     ida-domain
 
@@ -66,7 +68,7 @@ COPY entrypoint.py /usr/local/bin/entrypoint.py
 RUN chmod +x /usr/local/bin/entrypoint.py
 
 # Set entrypoint
-ENTRYPOINT ["python", "/usr/local/bin/entrypoint.py"]
+ENTRYPOINT ["/root/.idapro/venv/bin/python", "/usr/local/bin/entrypoint.py"]
 
 # Default: show help if no arguments provided
 CMD ["--help"]

--- a/docs/advanced/docker/README.md
+++ b/docs/advanced/docker/README.md
@@ -94,20 +94,21 @@ Analysis complete!
 ### Installed Components
 - IDA Pro 9.2 Professional (x64 Linux) - installed to `/opt/ida`
 - IDA Pro license (`.hexlic` file) - copied to `/root/.idapro/`
-- Python packages:
+- Python virtualenv at `/root/.idapro/venv` with:
   - `idapro`: IDA Pro Python bindings
   - `ida-domain`: High-level IDA analysis API
 
 ### Environment Variables
 - `IDADIR=/opt/ida`: IDA installation directory
+- `IDAPYTHON_VENV_EXECUTABLE=/root/.idapro/venv/bin/python`: Python interpreter for IDA's virtualenv
 - `PATH`: Includes `/opt/ida` for IDA binaries
 
 ### Build Process
 The Dockerfile uses a multi-stage build:
 1. **base**: Python 3.13-slim with curl and ca-certificates
 2. **hcli-installer**: Downloads and installs hcli standalone binary
-3. **ida-installer**: Uses hcli to download and install IDA Pro, configures license
-4. **final**: Copies IDA installation and license, installs Python packages, adds entrypoint
+3. **ida-installer**: Uses hcli to download and install IDA Pro with `--create-python-environment`, configures license
+4. **final**: Copies IDA installation with its license and venv, installs Python packages into the venv, adds entrypoint
 
 ## Security Considerations
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -140,14 +140,16 @@ $ hcli ida install --help
  Installs IDA unattended.
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────╮
-│ --yes          -y        Auto-accept confirmation prompts                          │
-│ --dry-run                Show what would be done without actually installing       │
-│ --set-default            Mark this IDA installation as the default                 │
-│ --accept-eula  -a        Accept EULA                                               │
-│ --install-dir  -i  TEXT  Install dir                                               │
-│ --license-id   -l  TEXT  License ID (e.g., 96-0000-0000-01)                        │
-│ --download-id  -d  TEXT  Installer slug                                            │
-│ --help                   Show this message and exit.                               │
+│ --create-python-environment  After installing IDA, create a virtual environment   │
+│                              for its Python at $IDAUSR/venv                        │
+│ --yes          -y            Auto-accept confirmation prompts                      │
+│ --dry-run                    Show what would be done without actually installing   │
+│ --set-default                Mark this IDA installation as the default             │
+│ --accept-eula  -a            Accept EULA                                           │
+│ --install-dir  -i  TEXT      Install dir                                           │
+│ --license-id   -l  TEXT      License ID (e.g., 96-0000-0000-01)                    │
+│ --download-id  -d  TEXT      Installer slug                                        │
+│ --help                       Show this message and exit.                           │
 ╰────────────────────────────────────────────────────────────────────────────────────╯
 ```
    
@@ -156,12 +158,13 @@ Now lets run the automated installer, which doesn't show any dialog or popups - 
 Note:
 
   - we're setting this as the "default" IDA installation, so this is what idalib and the plugin manager will use
+  - `--create-python-environment` sets up a virtualenv for IDAPython at `$IDAUSR/venv` and configures `IDAPYTHON_VENV_EXECUTABLE`; plugins that need Python packages are installed here
   - in this example we set `--dry-run`, but you should remove this in real-life
   - HCLI also fetches and installs the associated license key file so everything's ready to go
    
 
 ```bash
-$ hcli ida install --set-default --accept-eula --license-id 96-0000-0000-01 ida-pro_92_armmac.app.zip --dry-run
+$ hcli ida install --set-default --create-python-environment --accept-eula --license-id 96-0000-0000-01 ida-pro_92_armmac.app.zip --dry-run
 
 Installation details:
   Installer: /Users/user/code/hex-rays/ida-hcli/ida-pro_92_armmac.app.zip
@@ -183,7 +186,7 @@ Note the use of `--download-id release/9.2/ida-pro/ida-pro_92_armmac.app.zip`, t
   
 
 ```bash
-$ hcli ida install --set-default --license-id 96-0000-0000-01 --download-id release/9.2/ida-pro/ida-pro_92_armmac.app.zip --dry-run
+$ hcli ida install --set-default --create-python-environment --license-id 96-0000-0000-01 --download-id release/9.2/ida-pro/ida-pro_92_armmac.app.zip --dry-run
 
 Getting download URL for: release/9.2/ida-pro/ida-pro_92_armmac.app.zip
 Starting download of release/9.2/ida-pro/ida-pro_92_armmac.app.zip...
@@ -344,5 +347,6 @@ They aren't managed by hcli. Try finding an updated version in the plugin reposi
 
 ## Next Steps
 
+- [IDA's Python Environment](../user-guide/ida-python-environment.md) - Check and manage the Python environment that IDA and plugins use
 - [License Management](../user-guide/licenses.md) - Managing your IDA licenses
 - [File Sharing](../user-guide/file-sharing.md) - Share and collaborate on files

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,9 @@ This will automatically install the **HCLI** standalone executable
 ## Key Features
 
 - **[Install IDA](user-guide/installing-ida.md)** - Download and install IDA, interactively or headlessly
+- **[Python Environment](user-guide/ida-python-environment.md)** - Set up and manage the Python environment for IDA and its plugins
 - **[License Management](user-guide/licenses.md)** - Install and manage your IDA Pro licenses
-- **[Plugin Manager](user-guide/plugin-manager.md)** - discover, install, and configure IDA Pro plugins.
+- **[Plugin Manager](user-guide/plugin-manager.md)** - Discover and manage IDA Pro plugins
 - **[File Sharing](user-guide/file-sharing.md)** - Securely share analysis files with Hex-Rays for support tickets
 
 ## What's New

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -32,7 +32,7 @@ Furthermore, HCLI reads the following IDA Pro-related environment variables:
 |-------------------------------|------------------------------------------------------------------|
 | IDAUSR                        | Standard IDA Pro user directory (checked if HCLI_IDAUSR not set) |
 | IDADIR                        | Set by HCLI during IDA Pro execution contexts                    |
-| IDAPYTHON_VENV_EXECUTABLE     | Python interpreter for IDA's virtualenv; used for plugin dependency management when the file exists (lower priority than `HCLI_CURRENT_IDA_PYTHON_EXE`) |
+| IDAPYTHON_VENV_EXECUTABLE     | Python interpreter for IDA's virtualenv. This is the recommended way to tell both IDA and HCLI which Python environment to use. `hcli ida python create-environment` sets it for you. See [IDA's Python Environment](../user-guide/ida-python-environment.md). Lower priority than `HCLI_CURRENT_IDA_PYTHON_EXE`. |
 
 ## Network & API Endpoints
 

--- a/docs/user-guide/ida-python-environment.md
+++ b/docs/user-guide/ida-python-environment.md
@@ -40,6 +40,8 @@ HCLI never deletes or modifies an existing directory. If `$IDAUSR/venv` is alrea
 
 On macOS, shell profiles do not apply to IDA started from Finder or the Dock. For that, run `launchctl setenv IDAPYTHON_VENV_EXECUTABLE <path>`, or start IDA from a terminal.
 
+In Docker containers, the system Python is not writable (PEP 668 externally-managed), so you still need a venv. Use `--create-python-environment` when installing IDA and set `IDAPYTHON_VENV_EXECUTABLE` in the Dockerfile. See [Docker](../advanced/docker/README.md) for a working example.
+
 ## Checking the setup
 
 `hcli ida python doctor` reports which IDA and which interpreter HCLI resolved. It names the setup it recognizes and lists each difference from the recommended setup, with a fix:

--- a/docs/user-guide/installing-ida.md
+++ b/docs/user-guide/installing-ida.md
@@ -59,14 +59,16 @@ $ hcli ida install --help
  Installs IDA unattended.
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────╮
-│ --yes          -y        Auto-accept confirmation prompts                          │
-│ --dry-run                Show what would be done without actually installing       │
-│ --set-default            Mark this IDA installation as the default                 │
-│ --accept-eula  -a        Accept EULA                                               │
-│ --install-dir  -i  TEXT  Install dir                                               │
-│ --license-id   -l  TEXT  License ID (e.g., 96-0000-0000-01)                        │
-│ --download-id  -d  TEXT  Installer slug                                            │
-│ --help                   Show this message and exit.                               │
+│ --create-python-environment  After installing IDA, create a virtual environment   │
+│                              for its Python at $IDAUSR/venv                        │
+│ --yes          -y            Auto-accept confirmation prompts                      │
+│ --dry-run                    Show what would be done without actually installing   │
+│ --set-default                Mark this IDA installation as the default             │
+│ --accept-eula  -a            Accept EULA                                           │
+│ --install-dir  -i  TEXT      Install dir                                           │
+│ --license-id   -l  TEXT      License ID (e.g., 96-0000-0000-01)                    │
+│ --download-id  -d  TEXT      Installer slug                                        │
+│ --help                       Show this message and exit.                           │
 ╰────────────────────────────────────────────────────────────────────────────────────╯
 ```
    
@@ -75,12 +77,13 @@ Now lets run the automated installer, which doesn't show any dialog or popups - 
 Note:
 
   - we're setting this as the "default" IDA installation, so this is what idalib and the plugin manager will use
+  - `--create-python-environment` sets up a virtualenv for IDAPython at `$IDAUSR/venv` and configures `IDAPYTHON_VENV_EXECUTABLE`; plugins that need Python packages are installed here (see [IDA's Python Environment](ida-python-environment.md))
   - in this example we set `--dry-run`, but you should remove this in real-life
   - HCLI also fetches and installs the associated license key file so everything's ready to go
    
 
 ```bash
-$ hcli ida install --set-default --accept-eula --license-id 96-0000-0000-01 ida-pro_92_armmac.app.zip --dry-run
+$ hcli ida install --set-default --create-python-environment --accept-eula --license-id 96-0000-0000-01 ida-pro_92_armmac.app.zip --dry-run
 
 Installation details:
   Installer: /Users/user/code/hex-rays/ida-hcli/ida-pro_92_armmac.app.zip
@@ -102,7 +105,7 @@ Note the use of `--download-id release/9.2/ida-pro/ida-pro_92_armmac.app.zip`, t
   
 
 ```bash
-$ hcli ida install --set-default --license-id 96-0000-0000-01 --download-id release/9.2/ida-pro/ida-pro_92_armmac.app.zip --dry-run
+$ hcli ida install --set-default --create-python-environment --license-id 96-0000-0000-01 --download-id release/9.2/ida-pro/ida-pro_92_armmac.app.zip --dry-run
 
 Getting download URL for: release/9.2/ida-pro/ida-pro_92_armmac.app.zip
 Starting download of release/9.2/ida-pro/ida-pro_92_armmac.app.zip...

--- a/docs/user-guide/plugin-manager.md
+++ b/docs/user-guide/plugin-manager.md
@@ -48,6 +48,10 @@ They aren't managed by HCLI. Try finding an updated version in the plugin reposi
 
 
 
+## Python environment
+
+Plugins that declare Python dependencies need a working Python environment. HCLI checks this before installing dependencies. If something is wrong, the install stops and points you to `hcli ida python doctor` for details. See [IDA's Python Environment](ida-python-environment.md) for setup.
+
 ## As a user of IDA...
 
 You'll want to know the HCLI commands:


### PR DESCRIPTION
## Summary
- Add `--create-python-environment` flag to all `hcli ida install` invocations in CI workflows (`test.yml`, `test_install.yml`)

## Test plan
- [ ] Verify CI workflows pass with the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)